### PR TITLE
fix: Check validity of verified guest on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   little more with every press. Repeated presses in the same direction now let the first slide simply finish, a press
   the other way turns the card around smoothly from wherever it is, and catching a sliding card with a finger picks it
   up where it is instead of teleporting it
+- **Setting a password no longer leaves your name stuck in the header**: after protecting your name from the same browser
+  you had already picked it in, the header kept showing your name while the site had stopped recognising it — so "Edit
+  profile" and "Settings" both answered that no name was selected, and the chip for picking one again was nowhere to be
+  found. Setting a password now signs that browser out on the spot, so the header offers "Select your name" straight
+  away and you pick your name again with the password you just set. A password reset signs you out the same way
+- **A protected name is asked to log in, not to pick a name it already picked**: if you protected your name from your
+  phone while your laptop still had that name selected, Settings and Edit profile on the laptop told you to select who
+  you are — advice that could not help, since your name was selected. Both pages now say the name is protected and point
+  you at the header chip to switch to it with your password or emailed code
 
 ## [3.4.2] - 2026-08-24
 

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -4,7 +4,7 @@ import { getRepositories } from "@/db/container";
 import { SessionProposalForm } from "@/app/(site)/[eventSlug]/session-proposal-form";
 import {
   verifiedCurrentUser,
-  currentGuestSelection,
+  unverifiedUserMessage,
 } from "@/utils/acting-guest";
 import { notFound } from "next/navigation";
 
@@ -49,15 +49,9 @@ export default async function EditProposalPage({
     const cookieStore = await cookies();
     const currentUser = await verifiedCurrentUser(cookieStore);
     if (!currentUser) {
-      // verifiedCurrentUser is null both when no name is selected and when the
-      // selected name is protected but unverified — distinguish so a protected
-      // host is told to authenticate, not to pick a name they already picked.
-      const nameSelected = Boolean(await currentGuestSelection(cookieStore));
       return (
         <CantEdit eventSlug={eventSlug}>
-          {nameSelected
-            ? "This name is protected. Switch to it with your password or emailed code — via the name chip in the header — before editing this proposal."
-            : "You need to select who you are before editing this proposal. Pick your name via the “Select your name” chip in the header at the top of the page."}
+          {await unverifiedUserMessage(cookieStore, "editing this proposal")}
         </CantEdit>
       );
     }

--- a/app/(site)/auth/reset/reset-password-form.tsx
+++ b/app/(site)/auth/reset/reset-password-form.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import Link from "next/link";
 import { setPasswordWithTokenAction } from "@/app/actions/user-auth";
+import { UserContext } from "@/app/(site)/context";
 import { PasswordManagerHint } from "@/app/password-manager-hint";
 
 // Sets a new password from a reset link. Grants no session, so on success it
@@ -19,6 +20,7 @@ export function ResetPasswordForm({
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [busy, setBusy] = useState(false);
+  const { user, applyUser } = useContext(UserContext);
 
   const submit = async () => {
     setBusy(true);
@@ -30,6 +32,10 @@ export function ResetPasswordForm({
         newPassword
       );
       if (result.ok) {
+        // The action logged this browser out (the name is protected now, and
+        // the cookie it held isn't a proof), so the header must stop offering
+        // the name straight away rather than at the next navigation.
+        if (user === guestId) applyUser?.(null);
         setDone(true);
       } else {
         setError(result.error);

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -1,29 +1,30 @@
 "use client";
 import {
   createContext,
+  useState,
+  useEffect,
+  useRef,
   ReactNode,
   useContext,
-  useEffect,
-  useState,
 } from "react";
+import { usePathname } from "next/navigation";
 import type {
-  Day,
   Event,
-  Guest,
-  Location,
-  Rsvp,
+  Day,
   Session,
+  Location,
+  Guest,
+  Rsvp,
 } from "@/db/repositories/interfaces";
 import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
 import {
+  currentVerifiedUserAction,
   selectUserAction,
   type SelectUserResult,
-  verifyGuestAction,
 } from "@/app/actions/user-auth";
 import { DEFAULT_BREAK_MINUTES, votesApiUrl } from "@/utils/utils";
 import { DEFAULT_SLOT_INCREMENT_MINUTES } from "@/utils/slots";
-import { NOW_REFRESH_INTERVAL_MS, startNowTicker } from "@/utils/now-ticker";
-import { usePathname } from "next/navigation";
+import { startNowTicker, NOW_REFRESH_INTERVAL_MS } from "@/utils/now-ticker";
 
 export type DayWithSessions = Day & { sessions: Session[] };
 
@@ -149,12 +150,38 @@ export function UserProvider({
     return result;
   };
 
-  // Check if auth cookie is valid every time the user navigates
+  // `initialUser` is read once, when the (site) layout mounts, and that layout
+  // then survives every client-side navigation — so a selection the server has
+  // meanwhile stopped honouring (protection enabled from this browser or from
+  // another device, #805) would go on rendering as if it still held, offering
+  // a menu whose pages all insist no name is selected. Re-ask the server on
+  // each navigation instead. The first run is skipped: the render that mounted
+  // this provider already carries the server's answer, and this provider sits
+  // above every Suspense boundary, where an update landing during hydration
+  // can be built and never committed (see the VotesProvider comment in
+  // app/(site)/[eventSlug]/layout.tsx).
+  const checkedOnce = useRef(false);
   useEffect(() => {
-    async function checkValidity() {
+    if (!checkedOnce.current) {
+      checkedOnce.current = true;
+      return;
+    }
+    if (!user) return;
+    let superseded = false;
+    async function check() {
       try {
-        if (!(await verifyGuestAction())) {
+        const verified = await currentVerifiedUserAction();
+        // A reply overtaken by a later switch must not undo it.
+        if (superseded || verified === user) return;
+        if (verified === null) {
+          // Clear the cookie too, not just the client state: this browser is
+          // logged out, and a selection the server won't act as would go on
+          // telling the pages that read it raw (settings, edit profile) that a
+          // name is picked.
           await switchUser(null);
+        } else {
+          // Another tab switched names; the cookie is shared, so it wins.
+          setUser(verified);
         }
       } catch {
         // Session check failed — leave the current state as-is;
@@ -162,9 +189,10 @@ export function UserProvider({
       }
     }
 
-    if (user) {
-      void checkValidity();
-    }
+    void check();
+    return () => {
+      superseded = true;
+    };
   }, [user, path]);
 
   return (

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -1,27 +1,29 @@
 "use client";
 import {
   createContext,
-  useState,
-  useEffect,
   ReactNode,
   useContext,
+  useEffect,
+  useState,
 } from "react";
 import type {
-  Event,
   Day,
-  Session,
-  Location,
+  Event,
   Guest,
+  Location,
   Rsvp,
+  Session,
 } from "@/db/repositories/interfaces";
 import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
 import {
   selectUserAction,
   type SelectUserResult,
+  verifyGuestAction,
 } from "@/app/actions/user-auth";
 import { DEFAULT_BREAK_MINUTES, votesApiUrl } from "@/utils/utils";
 import { DEFAULT_SLOT_INCREMENT_MINUTES } from "@/utils/slots";
-import { startNowTicker, NOW_REFRESH_INTERVAL_MS } from "@/utils/now-ticker";
+import { NOW_REFRESH_INTERVAL_MS, startNowTicker } from "@/utils/now-ticker";
+import { usePathname } from "next/navigation";
 
 export type DayWithSessions = Day & { sessions: Session[] };
 
@@ -135,6 +137,7 @@ export function UserProvider({
   initialUser: string | null;
 }) {
   const [user, setUser] = useState<string | null>(initialUser);
+  const path = usePathname();
 
   const switchUser = async (
     guestId: string | null
@@ -145,6 +148,24 @@ export function UserProvider({
     }
     return result;
   };
+
+  // Check if auth cookie is valid every time the user navigates
+  useEffect(() => {
+    async function checkValidity() {
+      try {
+        if (!(await verifyGuestAction())) {
+          await switchUser(null);
+        }
+      } catch {
+        // Session check failed — leave the current state as-is;
+        // the next navigation will retry.
+      }
+    }
+
+    if (user) {
+      void checkValidity();
+    }
+  }, [user, path]);
 
   return (
     <UserContext.Provider value={{ user, switchUser, applyUser: setUser }}>

--- a/app/(site)/guests/edit/page.tsx
+++ b/app/(site)/guests/edit/page.tsx
@@ -2,7 +2,10 @@ import { cookies } from "next/headers";
 import { BackLink } from "@/app/components/back-link";
 import { getRepositories } from "@/db/container";
 import { sanitizeGuest } from "@/utils/guests";
-import { verifiedCurrentUser } from "@/utils/acting-guest";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
 import { ProfileForm } from "./profile-form";
 
 export default async function EditProfilePage() {
@@ -14,9 +17,7 @@ export default async function EditProfilePage() {
       <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
         <BackLink href="/guests">Attendees</BackLink>
         <p className="text-fg-muted">
-          You need to select who you are before editing your profile. Pick your
-          name via the &ldquo;Select your name&rdquo; chip in the header at the
-          top of the page.
+          {await unverifiedUserMessage(cookieStore, "editing your profile")}
         </p>
       </div>
     );

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -1,7 +1,10 @@
 import { cookies } from "next/headers";
 import { BackLink } from "@/app/components/back-link";
 import { getRepositories } from "@/db/container";
-import { verifiedCurrentUser } from "@/utils/acting-guest";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
 import { SettingsForm } from "./settings-form";
 import { AccountSecurity } from "./account-security";
 import { AppearanceSettings } from "./appearance";
@@ -20,9 +23,7 @@ export default async function SettingsPage() {
         <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
           <BackLink href="/guests">Attendees</BackLink>
           <p className="text-fg-muted">
-            You need to select who you are before changing your settings. Pick
-            your name via the &ldquo;Select your name&rdquo; chip in the header
-            at the top of the page.
+            {await unverifiedUserMessage(cookieStore, "changing your settings")}
           </p>
         </div>
         <AppearanceSettings />

--- a/app/actions/user-auth.ts
+++ b/app/actions/user-auth.ts
@@ -7,27 +7,27 @@ import type { AuthCode, AuthCodePurpose } from "@/db/repositories/interfaces";
 import {
   createGuestCookie,
   createGuestLogoutCookie,
-  GUEST_COOKIE_NAME,
   readGuestCookie,
+  GUEST_COOKIE_NAME,
 } from "@/utils/auth";
 import {
   AUTH_CODE_VALID_MINUTES,
+  MAX_CODE_ATTEMPTS,
+  RESET_TOKEN_VALID_MINUTES,
   generateAuthCode,
   generateAuthCodeSalt,
   generateResetToken,
   hashAuthCode,
-  hashUserPassword,
   isAuthCodeShaped,
-  MAX_CODE_ATTEMPTS,
   normalizeAuthCode,
-  RESET_TOKEN_VALID_MINUTES,
+  hashUserPassword,
   verifyUserPassword,
 } from "@/utils/user-credentials";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import {
+  TOO_MANY_ATTEMPTS_ERROR,
   isLoginBlocked,
   recordLoginFailure,
-  TOO_MANY_ATTEMPTS_ERROR,
 } from "@/utils/login-rate-limit";
 import { isMailerConfigured, sendMail } from "@/utils/mailer";
 import { siteUrl } from "@/utils/site-url";
@@ -323,6 +323,11 @@ export async function loginAsGuestAction(
  * session: the guest logs in with the new password afterwards. Consumes the
  * token so the link works once. If the guest was already protected this is a
  * password reset, which sends a best-effort heads-up to the address on file.
+ *
+ * A browser that had this guest selected is logged out (#805): its cookie —
+ * an open selection, or a session proof that predates the new password —
+ * stops being honoured the moment protection is on, and leaving it in place
+ * leaves a name selected that every page then refuses to act as.
  */
 export async function setPasswordWithTokenAction(
   guestId: string,
@@ -345,6 +350,13 @@ export async function setPasswordWithTokenAction(
     passwordHash: await hashUserPassword(parsed.data),
   });
   await authCodes.consume(matched.id);
+  const cookieStore = await cookies();
+  const selected = await readGuestCookie(
+    cookieStore.get(GUEST_COOKIE_NAME)?.value
+  );
+  if (selected?.guestId === guestId) {
+    cookieStore.set(createGuestLogoutCookie());
+  }
   if (wasProtected) {
     await notifySecurityChange(guestId, "password-changed");
   }
@@ -430,12 +442,13 @@ export async function disableProtectionAction(
 }
 
 /**
- * Returns the ID of the current authenticated user, or null if no user is
- * selected or the session is not verified. Used by client components to check
- * whether a protected guest is currently logged in with valid credentials.
+ * The guest the server currently acts as, or null if no name is selected or
+ * the selected one is protected without a verified session. Read-only: it
+ * exists so long-lived client state can re-check an identity the server may
+ * have stopped honouring since the page was rendered (see UserProvider).
  */
-export async function verifyGuestAction() {
-  return await verifiedCurrentUser(await cookies());
+export async function currentVerifiedUserAction(): Promise<string | null> {
+  return verifiedCurrentUser(await cookies());
 }
 
 /**

--- a/app/actions/user-auth.ts
+++ b/app/actions/user-auth.ts
@@ -7,27 +7,27 @@ import type { AuthCode, AuthCodePurpose } from "@/db/repositories/interfaces";
 import {
   createGuestCookie,
   createGuestLogoutCookie,
-  readGuestCookie,
   GUEST_COOKIE_NAME,
+  readGuestCookie,
 } from "@/utils/auth";
 import {
   AUTH_CODE_VALID_MINUTES,
-  MAX_CODE_ATTEMPTS,
-  RESET_TOKEN_VALID_MINUTES,
   generateAuthCode,
   generateAuthCodeSalt,
   generateResetToken,
   hashAuthCode,
-  isAuthCodeShaped,
-  normalizeAuthCode,
   hashUserPassword,
+  isAuthCodeShaped,
+  MAX_CODE_ATTEMPTS,
+  normalizeAuthCode,
+  RESET_TOKEN_VALID_MINUTES,
   verifyUserPassword,
 } from "@/utils/user-credentials";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import {
-  TOO_MANY_ATTEMPTS_ERROR,
   isLoginBlocked,
   recordLoginFailure,
+  TOO_MANY_ATTEMPTS_ERROR,
 } from "@/utils/login-rate-limit";
 import { isMailerConfigured, sendMail } from "@/utils/mailer";
 import { siteUrl } from "@/utils/site-url";
@@ -427,6 +427,15 @@ export async function disableProtectionAction(
   cookieStore.set(await createGuestCookie(guestId, "open"));
   await notifySecurityChange(guestId, "disabled");
   return { ok: true };
+}
+
+/**
+ * Returns the ID of the current authenticated user, or null if no user is
+ * selected or the session is not verified. Used by client components to check
+ * whether a protected guest is currently logged in with valid credentials.
+ */
+export async function verifyGuestAction() {
+  return await verifiedCurrentUser(await cookies());
 }
 
 /**

--- a/tests/e2e/user-auth.spec.ts
+++ b/tests/e2e/user-auth.spec.ts
@@ -19,6 +19,14 @@ const AHMAD_EMAIL = "ahmad.karimi@example.com";
 const AHMAD_PASSWORD = "ahmad-e2e-password";
 const AHMAD_NEW_PASSWORD = "ahmad-e2e-password-2";
 
+// Thabo Ndlovu is used by no other spec, likewise, and is seeded unprotected.
+const THABO_EMAIL = "thabo.ndlovu@example.com";
+const THABO_PASSWORD = "thabo-e2e-password";
+
+// Nadia Haddad, likewise: protected from a second browser, never from hers.
+const NADIA_EMAIL = "nadia.haddad@example.com";
+const NADIA_PASSWORD = "nadia-e2e-password";
+
 const LOGIN_SUBJECT = "Your temporary login code";
 const RESET_SUBJECT = "Set your password";
 
@@ -264,4 +272,104 @@ test("forgot password: reset it via an emailed link", async ({ page }) => {
   await ahmadOption.click();
   await logInAs(page, AHMAD_NEW_PASSWORD);
   await expect(headerChip(page, "Ahmad Karimi")).toBeVisible();
+});
+
+// Regression test for #805. The header chip is client state, seeded once when
+// the layout mounts and kept across client-side navigations — so the browser
+// that enables protection on its own selected name (its "open" cookie stops
+// being honoured the moment the password is set) used to go on showing that
+// name, offering a menu whose "Edit profile" and "Settings" then insisted no
+// name was selected, with no picker in sight to fix it.
+test("setting a password drops the selection the same browser was holding", async ({
+  page,
+}) => {
+  test.skip(
+    skipWithoutMailpit(),
+    "mail env vars unset — start Mailpit (make mailpit) and set them in .env.test.local to run this test (see docs/dev/testing.md § Running tests)"
+  );
+  test.slow();
+
+  await login(page);
+  await page.goto("/");
+  await pickName(page, "Thabo Ndlovu");
+  await expect(headerChip(page, "Thabo Ndlovu")).toBeVisible();
+
+  await page.getByRole("button", { name: /your name/i }).click();
+  await page.getByRole("menuitem", { name: /settings/i }).click();
+  const resetBefore = await emailCount(RESET_SUBJECT, THABO_EMAIL);
+  await page.getByRole("button", { name: "Enable protection" }).click();
+  await expect(page.getByText(/check your email/i)).toBeVisible();
+  const resetLink = await newestResetLink(THABO_EMAIL, resetBefore + 1);
+
+  // Unlike the test above, the link is opened in the browser that still holds
+  // the selection — the case the bug was reported for.
+  await page.goto(resetLink);
+  await page.getByLabel(/new password/i).fill(THABO_PASSWORD);
+  await page.getByRole("button", { name: "Set password" }).click();
+  await expect(page.getByText(/password set/i)).toBeVisible();
+
+  // Setting the password logs this browser out, and the header says so right
+  // away — no navigation and no reload in between.
+  await expect(
+    page.getByRole("button", { name: "Your name", exact: true })
+  ).toBeVisible();
+
+  await page.getByRole("link", { name: /go to sign in/i }).click();
+  await expect(
+    page.getByRole("button", { name: "Your name", exact: true })
+  ).toBeVisible();
+
+  // And the name is reachable again, now behind the password just set.
+  await openFilteredNameSwitcher(page, "Thabo");
+  await page.getByRole("option", { name: /Thabo Ndlovu/i }).click();
+  await logInAs(page, THABO_PASSWORD);
+  await expect(headerChip(page, "Thabo Ndlovu")).toBeVisible();
+});
+
+// The cross-device sibling of #805: this browser's own selection is dropped
+// when it sets the password, but a browser that was holding the name while
+// another device protected it keeps an "open" cookie the server has stopped
+// honouring. Nothing links to Settings without a selected name, so the page
+// is reached the way a real attendee reaches it — a bookmark or the back
+// button — and must then say what is actually wrong.
+test("a name protected from another device asks this browser to log in, not to pick a name", async ({
+  page,
+  browser,
+}) => {
+  test.skip(
+    skipWithoutMailpit(),
+    "mail env vars unset — start Mailpit (make mailpit) and set them in .env.test.local to run this test (see docs/dev/testing.md § Running tests)"
+  );
+  test.slow();
+
+  await login(page);
+  await page.goto("/");
+  await pickName(page, "Nadia Haddad");
+  await expect(headerChip(page, "Nadia Haddad")).toBeVisible();
+
+  // Her phone protects the name. A second context, not a second page: pages
+  // share the identity cookie.
+  const phoneContext = await browser.newContext();
+  const phone = await phoneContext.newPage();
+  await login(phone);
+  await phone.goto("/");
+  await pickName(phone, "Nadia Haddad");
+  await phone.getByRole("button", { name: /your name/i }).click();
+  await phone.getByRole("menuitem", { name: /settings/i }).click();
+  const resetBefore = await emailCount(RESET_SUBJECT, NADIA_EMAIL);
+  await phone.getByRole("button", { name: "Enable protection" }).click();
+  await expect(phone.getByText(/check your email/i)).toBeVisible();
+  await phone.goto(await newestResetLink(NADIA_EMAIL, resetBefore + 1));
+  await phone.getByLabel(/new password/i).fill(NADIA_PASSWORD);
+  await phone.getByRole("button", { name: "Set password" }).click();
+  await expect(phone.getByText(/password set/i)).toBeVisible();
+  await phoneContext.close();
+
+  await page.goto("/settings");
+  await expect(page.getByText(/this name is protected/i)).toBeVisible();
+  await expect(page.getByText(/select who you are/i)).toHaveCount(0);
+
+  await page.goto("/guests/edit");
+  await expect(page.getByText(/this name is protected/i)).toBeVisible();
+  await expect(page.getByText(/select who you are/i)).toHaveCount(0);
 });

--- a/tests/integration/user-auth-actions.test.ts
+++ b/tests/integration/user-auth-actions.test.ts
@@ -484,6 +484,42 @@ describe("user auth actions", () => {
       ).toBe(true);
     });
 
+    it("logs out the browser that was holding this name", async () => {
+      // #805: the open cookie stops being honoured the moment protection is
+      // turned on, so leaving it in place keeps a selection the server no
+      // longer accepts — every page then insists no name is selected.
+      const { guest, token } = await guestWithResetToken();
+      await selectUserAction(guest.id);
+      expect(await currentUserId()).toBe(guest.id);
+      expect(
+        (await setPasswordWithTokenAction(guest.id, token, "correct horse")).ok
+      ).toBe(true);
+      expect(await currentUserId()).toBeNull();
+    });
+
+    it("ends the verified session of a guest resetting their password", async () => {
+      const { guest, token } = await guestWithResetToken();
+      await setPasswordWithTokenAction(guest.id, token, "correct horse");
+      await loginAsGuestAction(guest.id, "correct horse");
+      expect(await userAuthCookieValidFor(guest.id)).toBe(true);
+
+      await requestPasswordLinkAction(guest.id);
+      await setPasswordWithTokenAction(
+        guest.id,
+        await lastResetToken(),
+        "battery staple horse"
+      );
+      expect(await currentUserId()).toBeNull();
+    });
+
+    it("leaves another guest's selection alone", async () => {
+      const { guest, token } = await guestWithResetToken();
+      const other = await createGuest();
+      await selectUserAction(other.id);
+      await setPasswordWithTokenAction(guest.id, token, "correct horse");
+      expect(await currentUserId()).toBe(other.id);
+    });
+
     it("is single-use: the same token cannot set a password twice", async () => {
       const { guest, token } = await guestWithResetToken();
       expect(

--- a/tests/integration/verified-guest-reads.test.ts
+++ b/tests/integration/verified-guest-reads.test.ts
@@ -77,7 +77,9 @@ describe("server components read the verified guest, not the raw cookie", () => 
       cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
 
       const html = renderToStaticMarkup(await EditProfilePage());
-      expect(html).toMatch(/select who you are/i);
+      expect(html).not.toMatch(/PROFILE_FORM_STUB/);
+      // Told to log in, not to pick a name they have already picked.
+      expect(html).toMatch(/this name is protected/i);
     });
 
     it("renders the edit form for a verified protected guest", async () => {
@@ -88,7 +90,7 @@ describe("server components read the verified guest, not the raw cookie", () => 
       cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guest.id));
 
       const html = renderToStaticMarkup(await EditProfilePage());
-      expect(html).not.toMatch(/select who you are/i);
+      expect(html).toMatch(/PROFILE_FORM_STUB/);
     });
   });
 

--- a/utils/acting-guest.ts
+++ b/utils/acting-guest.ts
@@ -97,6 +97,25 @@ export async function currentGuestSelection(
 }
 
 /**
+ * What to tell a visitor that {@link verifiedCurrentUser} refused. It returns
+ * null both when no name is selected and when the selected name is protected
+ * without a verified session (protection enabled from another device), and the
+ * two need different advice: being told to pick a name you have already picked
+ * helps nobody. Kept here, like NAME_PROTECTED_ERROR, so the copy can't drift
+ * across the pages that make this check. `task` completes "before …", e.g.
+ * "changing your settings".
+ */
+export async function unverifiedUserMessage(
+  cookieStore: ReadonlyCookies,
+  task: string
+): Promise<string> {
+  if (await currentGuestSelection(cookieStore)) {
+    return `This name is protected. Switch to it with your password or emailed code — via the name chip in the header — before ${task}.`;
+  }
+  return `You need to select who you are before ${task}. Pick your name via the “Select your name” chip in the header at the top of the page.`;
+}
+
+/**
  * True unless the guest cookie claims a protected guest without a verified
  * proof. Unlike verifiedCurrentUser, an absent cookie doesn't fail this
  * check — there's no protected identity being claimed, so there's nothing to


### PR DESCRIPTION
This pull request adds a check for the auth cookie's validity every time the user navigates in the application. This synchronises the state of the UI with the backend's auth, preventing the guest selection button from remaining in a stale state.

**To discuss:** is the overhead acceptable?

issue schellingboard/schellingboard#805