### PR TITLE
feat: add profile comments with threaded replies, likes, and editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Split the comments repository into a scope-agnostic core plus separate proposal-comment and session-comment
   repositories
-- Session comments now have integration and end-to-end test coverage mirroring the proposal comment suites
+- Session and profile comments now have integration and end-to-end test coverage mirroring the proposal comment suites
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **Comments on sessions**: a session's details now have the same comment section proposals already had — threaded
-  replies, likes, editing and deleting your own comments. Open any session in the schedule to discuss times, rooms or
-  last-minute changes
 - **Moving between attendee profiles slides instead of jumping**: Prev, Next and the arrow keys now slide one profile
   out as the next slides in, the way a swipe already moves between them
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Comments on attendee profiles**: a profile now ends with the same comment section sessions and proposals already
+  have — threaded replies, likes, editing and deleting your own comments. Open anyone in the directory to say hi or
+  arrange to meet up
+- **Comments on sessions**: a session's details now have the same comment section proposals already had — threaded
+  replies, likes, editing and deleting your own comments. Open any session in the schedule to discuss times, rooms or
+  last-minute changes
 - **Moving between attendee profiles slides instead of jumping**: Prev, Next and the arrow keys now slide one profile
   out as the next slides in, the way a swipe already moves between them
 

--- a/app/(site)/[eventSlug]/comment-actions.ts
+++ b/app/(site)/[eventSlug]/comment-actions.ts
@@ -10,6 +10,7 @@ import {
   commentDeleteSchema,
   commentLikeSchema,
   commentUpdateSchema,
+  profileCommentSchema,
   proposalCommentSchema,
   sessionCommentSchema,
 } from "@/model/comment";
@@ -43,6 +44,15 @@ function toResult(
   }
   console.error(failure, error);
   return { error: failure };
+}
+
+// Only surfaces that server-render their comments need cache invalidation;
+// client-fetched ones (sessions, profiles) reload through their endpoint.
+// Profiles are also not event-scoped, so they have no slug to revalidate.
+function revalidateEvent(eventSlug: string | undefined): void {
+  if (eventSlug) {
+    revalidatePath(`/${eventSlug}`, "layout");
+  }
 }
 
 async function requireGuest(): Promise<string> {
@@ -108,7 +118,7 @@ export async function createProposalComment(
       body,
       createdTime: await serverNow(),
     });
-    revalidatePath(`/${eventSlug}`, "layout");
+    revalidateEvent(eventSlug);
     after(() => notifyProposalCommented({ proposalId, comment }));
     return { success: true };
   } catch (error) {
@@ -154,6 +164,45 @@ export async function createSessionComment(
   }
 }
 
+export async function createProfileComment(
+  comment: z.input<typeof profileCommentSchema>
+): Promise<CommentActionResult>;
+export async function createProfileComment(
+  input: unknown
+): Promise<CommentActionResult> {
+  try {
+    const guest = await requireGuest();
+    const { profileId, parentId, body } = await requireParsed(
+      profileCommentSchema,
+      input
+    );
+
+    // validation
+    if (!(await getRepositories().guests.findById(profileId))) {
+      return { error: "Profile not found" };
+    }
+    if (parentId) {
+      const parentOf =
+        await getRepositories().profileComments.findProfileId(parentId);
+      if (!parentOf || parentOf !== profileId) {
+        return { error: "The comment being replied to is invalid" };
+      }
+    }
+
+    await getRepositories().profileComments.createForProfile({
+      profileId,
+      authorId: guest,
+      parentId,
+      body,
+      createdTime: await serverNow(),
+    });
+
+    return { success: true };
+  } catch (error) {
+    return toResult(error, "Failed to post comment");
+  }
+}
+
 export async function updateComment(
   comment: z.input<typeof commentUpdateSchema>
 ): Promise<CommentActionResult>;
@@ -172,9 +221,7 @@ export async function updateComment(
       body,
       editedTime: await serverNow(),
     });
-    if (eventSlug) {
-      revalidatePath(`/${eventSlug}`, "layout");
-    }
+    revalidateEvent(eventSlug);
     return { success: true };
   } catch (error) {
     return toResult(error, "Failed to update comment");
@@ -204,9 +251,7 @@ export async function toggleCommentLike(
       guestId: guest,
       createdTime: await serverNow(),
     });
-    if (eventSlug) {
-      revalidatePath(`/${eventSlug}`, "layout");
-    }
+    revalidateEvent(eventSlug);
     return { success: true, liked };
   } catch (error) {
     return toResult(error, "Failed to like comment");
@@ -228,9 +273,7 @@ export async function deleteComment(
     await requireOwnComment(commentId, guest);
 
     await getRepositories().comments.delete(commentId);
-    if (eventSlug) {
-      revalidatePath(`/${eventSlug}`, "layout");
-    }
+    revalidateEvent(eventSlug);
     return { success: true };
   } catch (error) {
     return toResult(error, "Failed to delete comment");

--- a/app/(site)/[eventSlug]/comment-likes.tsx
+++ b/app/(site)/[eventSlug]/comment-likes.tsx
@@ -19,6 +19,8 @@ export function CommentLikes({
   onChanged,
 }: {
   comment: Pick<Comment, "id" | "likes">;
+  // Only the cache invalidation target for pages that server-render their
+  // comments; client-fetched ones (sessions, profiles) omit it.
   eventSlug?: string;
   // Session comments are fetched client-side rather than arriving as server
   // props, so their section hands in its own reload instead of the default.

--- a/app/(site)/[eventSlug]/comments-section.tsx
+++ b/app/(site)/[eventSlug]/comments-section.tsx
@@ -59,11 +59,14 @@ export function CommentsSection({
   permalinkFor,
   changed,
 }: {
+  // Only the cache invalidation target for pages that server-render their
+  // comments; client-fetched ones (sessions, profiles) omit it.
   eventSlug?: string;
   timezone: string;
   comments?: Comment[] | null;
-  // Scope-specific: proposals and sessions differ in the action called and in
-  // where a permalink points. Everything else about commenting is shared.
+  // Scope-specific: proposals, sessions and profiles differ in the action
+  // called and in where a permalink points. Everything else about commenting
+  // is shared.
   create: (input: CommentCreateInput) => Promise<CommentActionResult>;
   permalinkFor: (commentId: string) => string;
   changed: () => void;

--- a/app/(site)/guests/profile-body.tsx
+++ b/app/(site)/guests/profile-body.tsx
@@ -28,6 +28,7 @@ import {
   ProposalLink,
   SessionLink,
 } from "@/app/(site)/guests/profile-link";
+import { ProfileComments } from "@/app/(site)/guests/profile-comments";
 import type { ProfileActivity } from "@/app/(site)/guests/profile-activity";
 
 /**
@@ -38,12 +39,17 @@ import type { ProfileActivity } from "@/app/(site)/guests/profile-activity";
 export function ProfileBody({
   guest,
   isOwnProfile,
+  isActive,
   activity,
   zoomed,
   onToggleZoom,
 }: {
   guest: Attendee;
   isOwnProfile: boolean;
+  // Only the profile being read carries comments: a swipe mounts its
+  // neighbours for a moment, and their sections must not fire requests of
+  // their own.
+  isActive: boolean;
   activity: ProfileActivity | null;
   zoomed: boolean;
   onToggleZoom: () => void;
@@ -187,6 +193,8 @@ export function ProfileBody({
             />
           </>
         )}
+
+        {isActive && <ProfileComments profileId={guest.id} />}
       </div>
     </div>
   );

--- a/app/(site)/guests/profile-comments.tsx
+++ b/app/(site)/guests/profile-comments.tsx
@@ -22,33 +22,48 @@ function withDates(comment: SerializedComment): Comment {
   };
 }
 
+const ERROR = Symbol("loading error");
+
 // The profile modal opens by pushing the URL locally, without an RSC
 // roundtrip, so its comments can't arrive as server props: they load through
 // /api/profile/[profileId]/comments instead, and every mutation reloads them.
 export function ProfileComments({ profileId }: { profileId: string }) {
   // Tagged with the profile it came from, so a previous profile's comments
   // never show through while the next ones load.
-  const [loaded, setLoaded] = useState<{
-    profileId: string;
-    comments: Comment[];
-  } | null>(null);
+  const [loaded, setLoaded] = useState<
+    | {
+        profileId: string;
+        comments: Comment[];
+      }
+    | null
+    | typeof ERROR
+  >(null);
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     void fetch(`/api/profile/${profileId}/comments?reload=${reloadKey}`)
-      .then((res) =>
-        res.ok ? (res.json() as Promise<SerializedComment[]>) : []
-      )
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`comments request failed: ${res.status}`);
+        }
+        return res.json() as Promise<SerializedComment[]>;
+      })
       .then((data) => {
         if (!cancelled) {
           setLoaded({ profileId, comments: data.map(withDates) });
         }
       })
       .catch(() => {
-        // A failed reload keeps what is already shown rather than wiping the
-        // thread; the next mutation or open retries. With nothing loaded yet,
-        // the section stays hidden instead of claiming "0 comments".
+        // A failed reload keeps the thread already on screen; only a load
+        // with nothing to fall back on turns into the message below.
+        if (!cancelled) {
+          setLoaded((prev) =>
+            prev && prev !== ERROR && prev.profileId === profileId
+              ? prev
+              : ERROR
+          );
+        }
       });
     return () => {
       cancelled = true;
@@ -66,6 +81,19 @@ export function ProfileComments({ profileId }: { profileId: string }) {
     (commentId: string) => `/guests/${profileId}#comment-${commentId}`,
     [profileId]
   );
+
+  if (loaded === ERROR) {
+    return (
+      <section className="mt-8 border-t border-line-subtle pt-6">
+        <p
+          role="alert"
+          className="bg-danger-tint border border-danger-border text-danger-fg px-4 py-3 rounded-md"
+        >
+          Couldn&apos;t load comments.
+        </p>
+      </section>
+    );
+  }
 
   const comments =
     loaded && loaded.profileId === profileId ? loaded.comments : null;

--- a/app/(site)/guests/profile-comments.tsx
+++ b/app/(site)/guests/profile-comments.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { Comment } from "@/db/repositories/interfaces";
+import { createProfileComment } from "@/app/(site)/[eventSlug]/comment-actions";
+import {
+  type CommentCreateInput,
+  CommentsSection,
+} from "@/app/(site)/[eventSlug]/comments-section";
+
+type SerializedComment = Omit<Comment, "createdTime" | "editedTime"> & {
+  createdTime: string;
+  editedTime: string | null;
+};
+
+function withDates(comment: SerializedComment): Comment {
+  return {
+    ...comment,
+    createdTime: new Date(comment.createdTime),
+    editedTime: comment.editedTime ? new Date(comment.editedTime) : null,
+  };
+}
+
+// The profile modal opens by pushing the URL locally, without an RSC
+// roundtrip, so its comments can't arrive as server props: they load through
+// /api/profile/[profileId]/comments instead, and every mutation reloads them.
+export function ProfileComments({ profileId }: { profileId: string }) {
+  // Tagged with the profile it came from, so a previous profile's comments
+  // never show through while the next ones load.
+  const [loaded, setLoaded] = useState<{
+    profileId: string;
+    comments: Comment[];
+  } | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch(`/api/profile/${profileId}/comments?reload=${reloadKey}`)
+      .then((res) =>
+        res.ok ? (res.json() as Promise<SerializedComment[]>) : []
+      )
+      .then((data) => {
+        if (!cancelled) {
+          setLoaded({ profileId, comments: data.map(withDates) });
+        }
+      })
+      .catch(() => {
+        // A failed reload keeps what is already shown rather than wiping the
+        // thread; the next mutation or open retries. With nothing loaded yet,
+        // the section stays hidden instead of claiming "0 comments".
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profileId, reloadKey]);
+
+  const changed = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  const create = useCallback(
+    (input: CommentCreateInput) =>
+      createProfileComment({ profileId, ...input }),
+    [profileId]
+  );
+  const permalinkFor = useCallback(
+    (commentId: string) => `/guests/${profileId}#comment-${commentId}`,
+    [profileId]
+  );
+
+  const comments =
+    loaded && loaded.profileId === profileId ? loaded.comments : null;
+
+  return (
+    <CommentsSection
+      // A profile spans every event, so there is no event zone to anchor the
+      // timestamps to: they fall back to UTC and carry each reader's own zone
+      // once that is known.
+      timezone="UTC"
+      comments={comments}
+      create={create}
+      permalinkFor={permalinkFor}
+      changed={changed}
+    />
+  );
+}

--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -393,6 +393,7 @@ export function ProfileModal({
                       <ProfileBody
                         guest={attendee}
                         isOwnProfile={currentUserId === attendee.id}
+                        isActive={current}
                         activity={current ? activity : null}
                         zoomed={current && zoomed}
                         onToggleZoom={() =>

--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRepositories } from "@/db/container";
+
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response
+// and show stale comments after a reload.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
+// Comments are displayed to everyone in the session details, so like
+// per-session RSVPs they stay openly readable.
+export async function GET(request: NextRequest) {
+  const sessionId = request.nextUrl.searchParams.get("session");
+
+  if (!sessionId) {
+    return NextResponse.json(
+      { error: "session parameter is required" },
+      { ...NO_STORE, status: 400 }
+    );
+  }
+
+  try {
+    const comments =
+      await getRepositories().sessionComments.listBySession(sessionId);
+    return NextResponse.json(comments, NO_STORE);
+  } catch (error) {
+    console.error("Error fetching comments:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch comments" },
+      { ...NO_STORE, status: 500 }
+    );
+  }
+}

--- a/app/api/profile/[profileId]/comments/route.ts
+++ b/app/api/profile/[profileId]/comments/route.ts
@@ -7,21 +7,17 @@ export const dynamic = "force-dynamic";
 // and show stale comments after a reload.
 const NO_STORE = { headers: { "cache-control": "no-store" } };
 
-// Comments are displayed to everyone in the session details, so like
-// per-session RSVPs they stay openly readable.
-export async function GET(request: NextRequest) {
-  const sessionId = request.nextUrl.searchParams.get("session");
-
-  if (!sessionId) {
-    return NextResponse.json(
-      { error: "session parameter is required" },
-      { ...NO_STORE, status: 400 }
-    );
-  }
+// Comments are displayed to everyone in the profile details,
+// similarly to sessions
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ profileId: string }> }
+) {
+  const { profileId } = await params;
 
   try {
     const comments =
-      await getRepositories().sessionComments.listBySession(sessionId);
+      await getRepositories().profileComments.listByProfile(profileId);
     return NextResponse.json(comments, NO_STORE);
   } catch (error) {
     console.error("Error fetching comments:", error);

--- a/db/container.ts
+++ b/db/container.ts
@@ -6,6 +6,7 @@ import { resolveDbPath, runMigrations } from "./migrate";
 import { SqliteAuthCodesRepository } from "./repositories/sqlite/auth-codes";
 import {
   SqliteCommentsRepository,
+  SqliteProfileCommentsRepository,
   SqliteProposalCommentsRepository,
   SqliteSessionCommentsRepository,
 } from "./repositories/sqlite/comments";
@@ -25,6 +26,7 @@ import type {
   EventsRepository,
   GuestsRepository,
   LocationsRepository,
+  ProfileCommentsRepository,
   ProposalCommentsRepository,
   RsvpsRepository,
   SessionCommentsRepository,
@@ -40,6 +42,7 @@ export type Repositories = {
   comments: CommentsRepository;
   proposalComments: ProposalCommentsRepository;
   sessionComments: SessionCommentsRepository;
+  profileComments: ProfileCommentsRepository;
   days: DaysRepository;
   events: EventsRepository;
   guests: GuestsRepository;
@@ -61,6 +64,7 @@ function buildRepositories(sqlite: Database.Database): Repositories {
     comments: new SqliteCommentsRepository(db),
     proposalComments: new SqliteProposalCommentsRepository(db),
     sessionComments: new SqliteSessionCommentsRepository(db),
+    profileComments: new SqliteProfileCommentsRepository(db),
     days: new SqliteDaysRepository(db),
     events: new SqliteEventsRepository(db),
     guests: new SqliteGuestsRepository(db),

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -677,10 +677,11 @@ export type Comment = {
 
 /**
  * Scope-agnostic comment operations. A comment is attached to exactly one
- * subject — a session proposal or a scheduled session — but finding,
- * editing, liking and deleting work identically for both, so they live here.
- * Attaching comments to a subject is that subject's own repository:
- * ProposalCommentsRepository and SessionCommentsRepository.
+ * subject — a session proposal, a scheduled session or a guest's profile —
+ * but finding, editing, liking and deleting work identically for all, so they
+ * live here. Attaching comments to a subject is that subject's own repository:
+ * ProposalCommentsRepository, SessionCommentsRepository and
+ * ProfileCommentsRepository.
  */
 export interface CommentsRepository {
   findById(commentId: string): Promise<Comment | undefined>;
@@ -727,6 +728,24 @@ export interface SessionCommentsRepository {
   findSessionId(commentId: string): Promise<string | undefined>;
   createForSession(data: {
     sessionId: string;
+    authorId: string;
+    parentId?: string;
+    body: string;
+    createdTime: Date;
+  }): Promise<Comment>;
+}
+
+/** Comments attached to a guest's profile. */
+export interface ProfileCommentsRepository {
+  /** All comments on the profile, oldest first, likes included. */
+  listByProfile(profileId: string): Promise<Comment[]>;
+  /**
+   * The profile a comment is attached to, or undefined when the comment
+   * doesn't exist or belongs to another subject.
+   */
+  findProfileId(commentId: string): Promise<string | undefined>;
+  createForProfile(data: {
+    profileId: string;
     authorId: string;
     parentId?: string;
     body: string;

--- a/db/repositories/sqlite/comments.ts
+++ b/db/repositories/sqlite/comments.ts
@@ -7,6 +7,7 @@ import type {
   Comment,
   CommentLiker,
   CommentsRepository,
+  ProfileCommentsRepository,
   ProposalCommentsRepository,
   SessionCommentsRepository,
 } from "../interfaces";
@@ -330,6 +331,53 @@ export class SqliteSessionCommentsRepository implements SessionCommentsRepositor
       insertComment(tx, id, data);
       tx.insert(schema.sessionComments)
         .values({ commentId: id, sessionId: data.sessionId })
+        .run();
+    });
+    return createdComment(this.db, id, data);
+  }
+}
+
+export class SqliteProfileCommentsRepository implements ProfileCommentsRepository {
+  constructor(private readonly db: DB) {}
+
+  async listByProfile(profileId: string): Promise<Comment[]> {
+    const rows = this.db
+      .select(commentColumns)
+      .from(schema.profileComments)
+      .innerJoin(
+        schema.comments,
+        eq(schema.profileComments.commentId, schema.comments.id)
+      )
+      .leftJoin(schema.guests, eq(schema.comments.authorId, schema.guests.id))
+      .where(eq(schema.profileComments.profileId, profileId))
+      .orderBy(
+        asc(schema.comments.createdTime),
+        asc(insertionOrder(schema.comments))
+      )
+      .all();
+    return listComments(rows, this.db);
+  }
+
+  async findProfileId(commentId: string): Promise<string | undefined> {
+    return this.db
+      .select({ profileId: schema.profileComments.profileId })
+      .from(schema.profileComments)
+      .where(eq(schema.profileComments.commentId, commentId))
+      .get()?.profileId;
+  }
+
+  async createForProfile(data: {
+    profileId: string;
+    authorId: string;
+    parentId?: string;
+    body: string;
+    createdTime: Date;
+  }): Promise<Comment> {
+    const id = nanoid();
+    this.db.transaction((tx) => {
+      insertComment(tx, id, data);
+      tx.insert(schema.profileComments)
+        .values({ commentId: id, profileId: data.profileId })
         .run();
     });
     return createdComment(this.db, id, data);

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -337,6 +337,22 @@ export const sessionComments = sqliteTable(
   ]
 );
 
+export const profileComments = sqliteTable(
+  "profile_comments",
+  {
+    commentId: text("comment_id")
+      .notNull()
+      .references(() => comments.id, { onDelete: "cascade" }),
+    profileId: text("profile_id")
+      .notNull()
+      .references(() => guests.id, { onDelete: "cascade" }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.commentId] }),
+    index("profile_comments_session_idx").on(t.profileId),
+  ]
+);
+
 export const votes = sqliteTable(
   "votes",
   {

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -216,6 +216,10 @@ search and filters intact.
   for larger still. On a wide window it stays beside you as you scroll,
   together with name, pronouns, location and languages.
 
+A profile ends with the same comment section proposals and sessions have — a good place to say hi, find someone to share
+a ride with, or ask something before the event. Everything works as described under
+[Discuss a proposal](#discuss-a-proposal): threaded replies, likes, editing and deleting your own comments.
+
 ## Your profile
 
 After picking your name, open **"Edit profile"** to set your About me,

--- a/drizzle/0027_fixed_nitro.sql
+++ b/drizzle/0027_fixed_nitro.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `profile_comments`
+(
+  `comment_id` text PRIMARY KEY NOT NULL,
+  `profile_id` text             NOT NULL,
+  FOREIGN KEY (`comment_id`) REFERENCES `comments` (`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`profile_id`) REFERENCES `guests` (`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `profile_comments_session_idx` ON `profile_comments` (`profile_id`);

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1417 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "41c8af3c-6971-4c05-8a3f-d89159e824e1",
+  "prevId": "0e054d3e-ab25-408b-9733-1e57e74cd1cf",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_comments": {
+      "name": "profile_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_comments_session_idx": {
+          "name": "profile_comments_session_idx",
+          "columns": ["profile_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_comments_comment_id_comments_id_fk": {
+          "name": "profile_comments_comment_id_comments_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_comments_profile_id_guests_id_fk": {
+          "name": "profile_comments_profile_id_guests_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "guests",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1787430579703,
       "tag": "0026_session_comments",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1787509687748,
+      "tag": "0027_fixed_nitro",
+      "breakpoints": true
     }
   ]
 }

--- a/model/comment.ts
+++ b/model/comment.ts
@@ -23,6 +23,15 @@ export const sessionCommentSchema = z.object({
   body,
 });
 
+export const profileCommentSchema = z.object({
+  profileId: z.string().min(1),
+  parentId: z.string().min(1).optional(),
+  body,
+});
+
+// eventSlug is only the cache invalidation target for pages that
+// server-render their comments; client-fetched ones (sessions, profiles)
+// omit it.
 export const commentUpdateSchema = z.object({
   commentId: z.string().min(1),
   eventSlug: z.string().min(1).optional(),

--- a/tests/e2e/profile-comments.spec.ts
+++ b/tests/e2e/profile-comments.spec.ts
@@ -7,6 +7,7 @@ import { selectUser } from "./helpers/user";
 // parallel against one shared database, so two tests on the same profile
 // would see each other's comments.
 async function openProfile(page: Page, name: string) {
+  await page.goto("/guests");
   await page.getByRole("link", { name }).click();
   const profile = page.getByRole("dialog", { name });
   await expect(profile).toBeVisible();
@@ -20,21 +21,51 @@ async function actAs(page: Page, name: RegExp) {
   await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
 }
 
+// A click landing while a mutation swaps the DOM is lost, so retry until the
+// UI reflects it. Re-checking first keeps the retry from toggling back.
+async function toggleUntil(button: Locator, settled: () => Promise<boolean>) {
+  await expect(async () => {
+    if (!(await settled())) {
+      await button.click();
+    }
+    expect(await settled()).toBe(true);
+  }).toPass();
+}
+
+async function openReplyForm(profile: Locator) {
+  const form = profile.getByPlaceholder("Write a reply");
+  await toggleUntil(
+    profile.getByRole("button", { name: "Reply" }).first(),
+    () => form.isVisible()
+  );
+}
+
 // Scoped to the open form: once a reply exists, its own "Reply" action button
 // also matches, and it sits after the form in the DOM.
 async function submitReply(profile: Locator, text: string) {
-  const form = profile.locator("form", {
-    has: profile.page().getByPlaceholder("Write a reply"),
-  });
+  const form = profile
+    .locator("form", { has: profile.page().getByPlaceholder("Write a reply") })
+    .first();
   await form.getByPlaceholder("Write a reply").fill(text);
-  await form.getByRole("button", { name: "Reply", exact: true }).click();
+  // Posting unmounts the form, so a click landing mid-swap is lost; retry
+  // until it's gone. The draft survives, so fill before retrying.
+  await toggleUntil(
+    form.getByRole("button", { name: "Reply", exact: true }),
+    () => form.isHidden()
+  );
+}
+
+// getByText also matches a filled-in textarea's value, so a just-submitted
+// reply would "be visible" inside its own form. Waiting for the paragraph the
+// markdown renderer produces means waiting for the comment to actually show.
+function postedComment(profile: Locator, text: string) {
+  return profile.locator("section p", { hasText: text });
 }
 
 test("posts a comment on a profile and shows it when the profile reopens", async ({
   page,
 }) => {
   await login(page);
-  await page.goto("/guests");
   await actAs(page, /Bob Test/i);
 
   const profile = await openProfile(page, "Alice Test");
@@ -61,52 +92,227 @@ test("posts a comment on a profile and shows it when the profile reopens", async
   await expect(reopened.getByText("see you at the venue")).toBeVisible();
 });
 
-test("replies to a profile comment and permalinks to the reply", async ({
+test("edits a comment, showing when it was edited, then deletes it", async ({
   page,
 }) => {
   await login(page);
-  await page.goto("/guests");
   await actAs(page, /Alice Test/i);
 
-  const profile = await openProfile(page, "Bob Test");
+  const profile = await openProfile(page, "Yuki Tanaka");
+  await profile.getByPlaceholder("Add a comment").fill("first thoughts");
+  await profile.getByRole("button", { name: "Comment" }).click();
+  await expect(postedComment(profile, "first thoughts").first()).toBeVisible();
+  await expect(profile.getByText("(edited)")).toHaveCount(0);
+
+  await profile.getByRole("button", { name: "Edit" }).click();
+  await profile.getByPlaceholder("Edit your comment").fill("second thoughts");
+  await profile.getByRole("button", { name: "Save" }).click();
+
+  await expect(profile.getByText("second thoughts")).toBeVisible();
+  await expect(profile.getByText("first thoughts")).toHaveCount(0);
+  const editedMarker = profile.getByText("(edited)");
+  await expect(editedMarker).toBeVisible();
+  await expect(editedMarker).toHaveAttribute("title", /^Edited /);
+
+  await profile.getByRole("button", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Yes" }).click();
+
+  await expect(profile.getByText("second thoughts")).toHaveCount(0);
+  await expect(
+    profile.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+});
+
+test("replies to a profile comment, collapses the thread, and permalinks to the reply", async ({
+  page,
+}) => {
+  await login(page);
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Amara Okafor");
   await profile.getByPlaceholder("Add a comment").fill("which airport?");
   await profile.getByRole("button", { name: "Comment" }).click();
-  await expect(profile.getByText("which airport?")).toBeVisible();
+  const parent = postedComment(profile, "which airport?").first();
+  await expect(parent).toBeVisible();
 
-  await profile.getByRole("button", { name: "Reply" }).click();
-  await submitReply(profile, "whatever is closest to the venue");
+  await openReplyForm(profile);
+  await submitReply(profile, "closest to the venue");
+  const reply = postedComment(profile, "closest to the venue").first();
+  await expect(reply).toBeVisible();
+
+  await toggleUntil(
+    profile.getByRole("button", { name: "Collapse comment" }).first(),
+    () => parent.isHidden()
+  );
+  await expect(reply).toBeHidden();
   await expect(
-    profile.locator("section p", { hasText: "closest to the venue" })
+    profile.getByRole("link", { name: "Alice Test" }).first()
   ).toBeVisible();
+
+  await toggleUntil(
+    profile.getByRole("button", { name: "Expand comment" }).first(),
+    () => parent.isVisible()
+  );
 
   // Each comment's timestamp links to that comment alone, parent and reply
   // getting distinct targets. Both have to be on the page before comparing:
   // with only the parent rendered, first and last are the same link.
   const timestamps = profile.getByRole("link", { name: /^\d/ });
   await expect(timestamps).toHaveCount(2);
+  const parentPermalink = await timestamps.first().getAttribute("href");
   const permalink = await timestamps.last().getAttribute("href");
   expect(permalink).toMatch(/^\/guests\/[^/?]+#comment-/);
+  expect(permalink).not.toBe(parentPermalink);
 
   // The permalink is a real profile URL: opening it cold lands on this
   // profile with the reply shown (and highlighted).
   await page.goto(permalink!);
-  const opened = page.getByRole("dialog", { name: "Bob Test" });
+  const opened = page.getByRole("dialog", { name: "Amara Okafor" });
   await expect(opened).toBeVisible();
   await expect(
     opened.locator("section p", { hasText: "closest to the venue" })
   ).toBeVisible();
 });
 
+test("keeps replies readable when their parent is deleted", async ({
+  page,
+  browser,
+}) => {
+  await login(page);
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Priya Sharma");
+  await profile.getByPlaceholder("Add a comment").fill("a doomed parent");
+  await profile.getByRole("button", { name: "Comment" }).click();
+  await expect(postedComment(profile, "a doomed parent").first()).toBeVisible();
+
+  // Someone else replies, so deleting the parent can't simply remove it. A
+  // second context, not a second page: pages share the identity cookie.
+  const bobContext = await browser.newContext();
+  const bob = await bobContext.newPage();
+  await login(bob);
+  await actAs(bob, /Bob Test/i);
+  const bobProfile = await openProfile(bob, "Priya Sharma");
+  await openReplyForm(bobProfile);
+  await submitReply(bobProfile, "a surviving reply");
+  await expect(
+    postedComment(bobProfile, "a surviving reply").first()
+  ).toBeVisible();
+  await bobContext.close();
+
+  // Her open modal fetched its comments before Bob replied; reloading shows
+  // his reply arrived through the endpoint before she deletes the parent.
+  await page.reload();
+  const reopened = page.getByRole("dialog", { name: "Priya Sharma" });
+  await expect(reopened.getByText("a doomed parent").first()).toBeVisible();
+  await expect(reopened.getByText("a surviving reply").first()).toBeVisible();
+
+  await reopened.getByRole("button", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Yes" }).click();
+
+  await expect(reopened.getByText("a doomed parent")).toHaveCount(0);
+  await expect(reopened.getByText("Comment deleted")).toBeVisible();
+  await expect(reopened.getByText("a surviving reply")).toBeVisible();
+});
+
+test("likes a comment and shows who liked it", async ({ page, browser }) => {
+  await login(page);
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Jean-Pierre Dubois");
+  await profile.getByPlaceholder("Add a comment").fill("a likeable comment");
+  await profile.getByRole("button", { name: "Comment" }).click();
+  await expect(
+    postedComment(profile, "a likeable comment").first()
+  ).toBeVisible();
+
+  const like = profile.getByRole("button", { name: "Like", exact: true });
+  const liked = profile.getByRole("button", { name: "Liked", exact: true });
+  await like.click();
+  await expect(liked).toBeVisible();
+  await expect(profile.getByRole("button", { name: "1 like" })).toBeVisible();
+
+  // A second context, not a second page: pages share the identity cookie.
+  const bobContext = await browser.newContext();
+  const bob = await bobContext.newPage();
+  await login(bob);
+  await actAs(bob, /Bob Test/i);
+  const bobProfile = await openProfile(bob, "Jean-Pierre Dubois");
+  await bobProfile.getByRole("button", { name: "Like", exact: true }).click();
+  await expect(
+    bobProfile.getByRole("button", { name: "2 likes" })
+  ).toBeVisible();
+  await bobContext.close();
+
+  await page.reload();
+  const reopened = page.getByRole("dialog", { name: "Jean-Pierre Dubois" });
+  // Hovering previews the likers, newest first, without opening anything.
+  const count = reopened.getByRole("button", { name: "2 likes" });
+  const tooltip = page.getByRole("tooltip");
+  await expect(tooltip).toHaveCSS("opacity", "0");
+  await count.hover();
+  await expect(tooltip).toHaveCSS("opacity", "1");
+  await expect(tooltip).toHaveText(/^Bob TestAlice Test$/);
+
+  await count.click();
+  const likers = page.getByRole("dialog", { name: "Liked by" });
+  await expect(likers.getByRole("link", { name: "Alice Test" })).toBeVisible();
+  await expect(likers.getByRole("link", { name: "Bob Test" })).toBeVisible();
+  // One avatar per liker — an uploaded image or the initials fallback, both
+  // decorative and so hidden from the accessibility tree.
+  await expect(likers.locator("li [aria-hidden='true']")).toHaveCount(2);
+  await likers.getByRole("button", { name: "Close" }).click();
+  // The pointer never left the count, but the click dismissed its preview.
+  await expect(tooltip).toHaveCSS("opacity", "0");
+
+  await reopened.getByRole("button", { name: "Liked", exact: true }).click();
+  await expect(
+    reopened.getByRole("button", { name: "Like", exact: true })
+  ).toBeVisible();
+  await expect(reopened.getByRole("button", { name: "1 like" })).toBeVisible();
+});
+
 test("asks visitors without a name to select one before commenting", async ({
   page,
 }) => {
   await login(page);
-  await page.goto("/guests");
-
   const profile = await openProfile(page, "Charlie Test");
 
   await expect(
     profile.getByText("Select your name to leave a comment.")
   ).toBeVisible();
   await expect(profile.getByPlaceholder("Add a comment")).toHaveCount(0);
+});
+
+test("nests sibling replies under the comment they answer", async ({
+  page,
+}) => {
+  await login(page);
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Thabo Ndlovu");
+  await profile.getByPlaceholder("Add a comment").fill("Who else is coming?");
+  await profile.getByRole("button", { name: "Comment" }).click();
+  await expect(
+    postedComment(profile, "Who else is coming?").first()
+  ).toBeVisible();
+
+  // Posting closes the reply form (onDone), so each reply waits for the
+  // previous one to actually render before reopening the form.
+  await openReplyForm(profile);
+  await submitReply(profile, "I'd like to join.");
+  await expect(
+    postedComment(profile, "I'd like to join.").first()
+  ).toBeVisible();
+  await openReplyForm(profile);
+  await submitReply(profile, "So would I.");
+  await expect(postedComment(profile, "So would I.").first()).toBeVisible();
+
+  // Both hang off the same parent, so collapsing it takes them together.
+  await toggleUntil(
+    profile.getByRole("button", { name: "Collapse comment" }).first(),
+    () => postedComment(profile, "Who else is coming?").isHidden()
+  );
+  await expect(postedComment(profile, "I'd like to join.")).toBeHidden();
+  await expect(postedComment(profile, "So would I.")).toBeHidden();
 });

--- a/tests/e2e/profile-comments.spec.ts
+++ b/tests/e2e/profile-comments.spec.ts
@@ -92,6 +92,52 @@ test("posts a comment on a profile and shows it when the profile reopens", async
   await expect(reopened.getByText("see you at the venue")).toBeVisible();
 });
 
+test("shows an error instead of a permanent skeleton when comments fail to load", async ({
+  page,
+}) => {
+  await login(page);
+
+  // Fail the comments request outright: the section must own up to it rather
+  // than leave its "Loading comments…" skeleton up forever.
+  await page.route(/\/api\/profile\/[^/]+\/comments/, (route) => route.abort());
+
+  const profile = await openProfile(page, "Alice Test");
+
+  await expect(profile.getByRole("alert")).toHaveText(
+    "Couldn't load comments."
+  );
+  await expect(
+    profile.getByRole("heading", { name: "Loading comments..." })
+  ).toHaveCount(0);
+});
+
+test("keeps the thread already shown when a reload fails", async ({ page }) => {
+  await login(page);
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Mateo Quispe");
+  await expect(
+    profile.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+
+  // Fail every comments request from here on, so the reload that posting
+  // triggers dies. The thread already on screen has to survive it intact.
+  await page.route(/\/api\/profile\/[^/]+\/comments/, (route) => route.abort());
+
+  await profile
+    .getByPlaceholder("Add a comment")
+    .fill("posted with its reload cut off");
+  await profile.getByRole("button", { name: "Comment" }).click();
+
+  await expect(
+    profile.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+  await expect(profile.getByRole("alert")).toHaveCount(0);
+  await expect(
+    profile.getByRole("heading", { name: "Loading comments..." })
+  ).toHaveCount(0);
+});
+
 test("edits a comment, showing when it was edited, then deletes it", async ({
   page,
 }) => {

--- a/tests/e2e/profile-comments.spec.ts
+++ b/tests/e2e/profile-comments.spec.ts
@@ -1,0 +1,112 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+
+// Each test comments on a different seeded guest's profile: the suite runs in
+// parallel against one shared database, so two tests on the same profile
+// would see each other's comments.
+async function openProfile(page: Page, name: string) {
+  await page.getByRole("link", { name }).click();
+  const profile = page.getByRole("dialog", { name });
+  await expect(profile).toBeVisible();
+  return profile;
+}
+
+// selectUser logs out and back in; navigating before that settles aborts the
+// request and drops the selection.
+async function actAs(page: Page, name: RegExp) {
+  await selectUser(page, name);
+  await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
+}
+
+// Scoped to the open form: once a reply exists, its own "Reply" action button
+// also matches, and it sits after the form in the DOM.
+async function submitReply(profile: Locator, text: string) {
+  const form = profile.locator("form", {
+    has: profile.page().getByPlaceholder("Write a reply"),
+  });
+  await form.getByPlaceholder("Write a reply").fill(text);
+  await form.getByRole("button", { name: "Reply", exact: true }).click();
+}
+
+test("posts a comment on a profile and shows it when the profile reopens", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await actAs(page, /Bob Test/i);
+
+  const profile = await openProfile(page, "Alice Test");
+  await expect(
+    profile.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+
+  await profile.getByPlaceholder("Add a comment").fill("see you at the venue");
+  await profile.getByRole("button", { name: "Comment" }).click();
+
+  await expect(
+    profile.getByRole("heading", { name: "1 comment" })
+  ).toBeVisible();
+  await expect(profile.getByText("see you at the venue")).toBeVisible();
+
+  // Comments load through their own endpoint when the profile opens, so
+  // reopening must show them without any refresh.
+  await page.keyboard.press("Escape");
+  await expect(profile).toBeHidden();
+  const reopened = await openProfile(page, "Alice Test");
+  await expect(
+    reopened.getByRole("heading", { name: "1 comment" })
+  ).toBeVisible();
+  await expect(reopened.getByText("see you at the venue")).toBeVisible();
+});
+
+test("replies to a profile comment and permalinks to the reply", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Bob Test");
+  await profile.getByPlaceholder("Add a comment").fill("which airport?");
+  await profile.getByRole("button", { name: "Comment" }).click();
+  await expect(profile.getByText("which airport?")).toBeVisible();
+
+  await profile.getByRole("button", { name: "Reply" }).click();
+  await submitReply(profile, "whatever is closest to the venue");
+  await expect(
+    profile.locator("section p", { hasText: "closest to the venue" })
+  ).toBeVisible();
+
+  // Each comment's timestamp links to that comment alone, parent and reply
+  // getting distinct targets. Both have to be on the page before comparing:
+  // with only the parent rendered, first and last are the same link.
+  const timestamps = profile.getByRole("link", { name: /^\d/ });
+  await expect(timestamps).toHaveCount(2);
+  const permalink = await timestamps.last().getAttribute("href");
+  expect(permalink).toMatch(/^\/guests\/[^/?]+#comment-/);
+
+  // The permalink is a real profile URL: opening it cold lands on this
+  // profile with the reply shown (and highlighted).
+  await page.goto(permalink!);
+  const opened = page.getByRole("dialog", { name: "Bob Test" });
+  await expect(opened).toBeVisible();
+  await expect(
+    opened.locator("section p", { hasText: "closest to the venue" })
+  ).toBeVisible();
+});
+
+test("asks visitors without a name to select one before commenting", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+
+  const profile = await openProfile(page, "Charlie Test");
+
+  await expect(
+    profile.getByText("Select your name to leave a comment.")
+  ).toBeVisible();
+  await expect(profile.getByPlaceholder("Add a comment")).toHaveCount(0);
+});

--- a/tests/integration/comment-likes.test.ts
+++ b/tests/integration/comment-likes.test.ts
@@ -25,16 +25,6 @@ vi.mock("next/headers", () => ({
     }),
 }));
 
-import { resetTestDb, setupTestDb } from "../helpers/db";
-import { createEvent, createGuest, createProposal } from "../helpers/factories";
-import { getRepositories } from "@/db/container";
-import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
-import {
-  createProposalComment as createComment,
-  deleteComment,
-  toggleCommentLike,
-} from "@/app/(site)/[eventSlug]/comment-actions";
-
 const VALID_SECRET = "0123456789abcdef0123456789abcdef";
 
 function act(guestId: string): void {

--- a/tests/integration/comment-likes.test.ts
+++ b/tests/integration/comment-likes.test.ts
@@ -1,4 +1,13 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetTestDb, setupTestDb } from "../helpers/db";
+import { createEvent, createGuest, createProposal } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
+import {
+  createProposalComment as createComment,
+  deleteComment,
+  toggleCommentLike,
+} from "@/app/(site)/[eventSlug]/comment-actions";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -86,7 +86,12 @@ const OUT_OF_SCOPE_PREFIXES = ["admin/", "auth/"];
 const OUT_OF_SCOPE_EXACT = new Set(["health"]);
 
 // Read-only surfaces are exempt from the invariant per CONTRIBUTING.md.
-const READ_ONLY = new Set(["rsvps", "votes", "session/[sessionId]/comments"]);
+const READ_ONLY = new Set([
+  "rsvps",
+  "votes",
+  "session/[sessionId]/comments",
+  "profile/[profileId]/comments",
+]);
 
 type Verifier = () => Promise<void>;
 

--- a/tests/integration/profile-comments.test.ts
+++ b/tests/integration/profile-comments.test.ts
@@ -1,0 +1,488 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetTestDb, setupTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import {
+  GUEST_COOKIE_NAME,
+  openGuestValue,
+  verifiedGuestValue,
+} from "../helpers/guest-cookie";
+import {
+  createProfileComment as createComment,
+  deleteComment,
+  updateComment,
+} from "@/app/(site)/[eventSlug]/comment-actions";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function setup() {
+  const event = await createEvent({ phase: "scheduling" });
+  const owner = await createGuest({ eventId: event.id });
+  const commenter = await createGuest({ eventId: event.id });
+  return { event, owner, commenter };
+}
+
+function act(guestId: string): void {
+  cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guestId));
+}
+
+describe("profile comments", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("stores a comment and reads it back with its author and time", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    const before = new Date();
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "Loved your talk",
+    });
+
+    expect(result).toEqual({ success: true });
+    const comments = await getRepositories().profileComments.listByProfile(
+      owner.id
+    );
+    expect(comments).toHaveLength(1);
+    expect(comments[0].body).toBe("Loved your talk");
+    expect(comments[0].author).toEqual({
+      id: commenter.id,
+      name: commenter.name,
+    });
+    expect(comments[0].createdTime.getTime()).toBeGreaterThanOrEqual(
+      before.getTime() - 1000
+    );
+  });
+
+  it("lists comments oldest first", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+
+    await createComment({ profileId: owner.id, body: "first" });
+    await createComment({ profileId: owner.id, body: "second" });
+
+    const comments = await getRepositories().profileComments.listByProfile(
+      owner.id
+    );
+    expect(comments.map((c) => c.body)).toEqual(["first", "second"]);
+  });
+
+  it("lists comments posted in the same millisecond in the order they were posted", async () => {
+    const { owner } = await setup();
+    const commenter = await createGuest();
+    const { profileComments } = getRepositories();
+    const sameMillisecond = new Date();
+    const bodies = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th"];
+
+    for (const body of bodies) {
+      await profileComments.createForProfile({
+        profileId: owner.id,
+        authorId: commenter.id,
+        body,
+        createdTime: sameMillisecond,
+      });
+    }
+
+    // Comment ids are random, so a tiebreak on the id would shuffle these.
+    expect(
+      (await profileComments.listByProfile(owner.id)).map((c) => c.body)
+    ).toEqual(bodies);
+  });
+
+  it("keeps each profile's comments separate", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+
+    await createComment({ profileId: owner.id, body: "on the first" });
+
+    expect(
+      await getRepositories().profileComments.listByProfile(other.id)
+    ).toHaveLength(0);
+  });
+
+  it("keeps profiles' and sessions' comments separate", async () => {
+    const { event, commenter, owner } = await setup();
+    const session = await createSession(event.id);
+    act(commenter.id);
+
+    await createComment({ profileId: owner.id, body: "on the profile" });
+    await getRepositories().sessionComments.createForSession({
+      sessionId: session.id,
+      authorId: commenter.id,
+      body: "on the session",
+      createdTime: new Date(),
+    });
+
+    expect(
+      (await getRepositories().profileComments.listByProfile(owner.id)).map(
+        (c) => c.body
+      )
+    ).toEqual(["on the profile"]);
+    expect(
+      (await getRepositories().sessionComments.listBySession(session.id)).map(
+        (c) => c.body
+      )
+    ).toEqual(["on the session"]);
+  });
+
+  it("refuses to comment without a selected name", async () => {
+    const { owner } = await setup();
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "anonymous",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toHaveLength(0);
+  });
+
+  it("refuses to comment as a protected guest without a verified session", async () => {
+    const { commenter, owner } = await setup();
+    await getRepositories().guests.setAuthProtection(commenter.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    act(commenter.id);
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "impersonated",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toHaveLength(0);
+  });
+
+  it("allows a verified protected guest to comment", async () => {
+    const { commenter, owner } = await setup();
+    await getRepositories().guests.setAuthProtection(commenter.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(commenter.id));
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "verified",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toHaveLength(1);
+  });
+
+  it("rejects an empty comment", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "   ",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toHaveLength(0);
+  });
+
+  it("rejects a comment on an unknown profile", async () => {
+    const { commenter } = await setup();
+    act(commenter.id);
+
+    const result = await createComment({
+      profileId: "does-not-exist",
+      body: "hello",
+    });
+
+    expect(result).toHaveProperty("error");
+  });
+
+  it("removes a profile's comments when the guest is deleted", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "doomed" });
+
+    await getRepositories().guests.delete(owner.id);
+
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toEqual([]);
+  });
+});
+
+async function onlyComment(profileId: string) {
+  const comments =
+    await getRepositories().profileComments.listByProfile(profileId);
+  expect(comments).toHaveLength(1);
+  return comments[0];
+}
+
+describe("editing a profile comment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("replaces the body and records when it was edited", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "original" });
+    const before = await onlyComment(owner.id);
+    expect(before.editedTime).toBeNull();
+
+    const result = await updateComment({
+      commentId: before.id,
+      body: "revised",
+    });
+
+    expect(result).toEqual({ success: true });
+    const after = await onlyComment(owner.id);
+    expect(after.body).toBe("revised");
+    expect(after.editedTime).toBeInstanceOf(Date);
+    expect(after.createdTime).toEqual(before.createdTime);
+  });
+
+  it("refuses to edit someone else's comment", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "mine" });
+    const comment = await onlyComment(owner.id);
+
+    act(other.id);
+    const result = await updateComment({
+      commentId: comment.id,
+      body: "hijacked",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(owner.id)).body).toBe("mine");
+  });
+
+  it("rejects an empty edit", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "mine" });
+    const comment = await onlyComment(owner.id);
+
+    const result = await updateComment({
+      commentId: comment.id,
+      body: "  ",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(owner.id)).body).toBe("mine");
+  });
+});
+
+describe("deleting a profile comment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("removes a childless comment outright", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "never mind" });
+    const comment = await onlyComment(owner.id);
+
+    const result = await deleteComment({ commentId: comment.id });
+
+    expect(result).toEqual({ success: true });
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toEqual([]);
+  });
+
+  it("leaves a tombstone when the comment has replies", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "the question" });
+    const parent = await onlyComment(owner.id);
+    act(other.id);
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "the answer",
+    });
+
+    act(commenter.id);
+    await deleteComment({ commentId: parent.id });
+
+    const comments = await getRepositories().profileComments.listByProfile(
+      owner.id
+    );
+    expect(comments).toHaveLength(2);
+    const tombstone = comments.find((c) => c.id === parent.id)!;
+    expect(tombstone.deleted).toBe(true);
+    expect(tombstone.body).toBe("");
+    expect(tombstone.author).toBeNull();
+    const reply = comments.find((c) => c.id !== parent.id)!;
+    expect(reply.body).toBe("the answer");
+    expect(reply.parentId).toBe(parent.id);
+  });
+
+  it("clears a tombstone once its last reply goes", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "parent" });
+    const parent = await onlyComment(owner.id);
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "child",
+    });
+    const child = (
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).find((c) => c.id !== parent.id)!;
+
+    await deleteComment({ commentId: parent.id });
+    await deleteComment({ commentId: child.id });
+
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toEqual([]);
+  });
+
+  it("refuses to delete someone else's comment", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "mine" });
+    const comment = await onlyComment(owner.id);
+
+    act(other.id);
+    const result = await deleteComment({ commentId: comment.id });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(owner.id)).body).toBe("mine");
+  });
+});
+
+describe("threaded profile replies", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("records the parent of a reply", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "top level" });
+    const parent = await onlyComment(owner.id);
+
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "a reply",
+    });
+
+    const comments = await getRepositories().profileComments.listByProfile(
+      owner.id
+    );
+    expect(comments.map((c) => c.parentId)).toEqual([null, parent.id]);
+  });
+
+  it("rejects a reply to a comment on another profile", async () => {
+    const { commenter, owner } = await setup();
+    const elsewhere = await createGuest();
+    act(commenter.id);
+    await createComment({
+      profileId: elsewhere.id,
+      body: "top level elsewhere",
+    });
+    const parent = await onlyComment(elsewhere.id);
+
+    const result = await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "misfiled reply",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toEqual([]);
+  });
+
+  it("rejects a reply to a comment left on a session", async () => {
+    const { event, commenter, owner } = await setup();
+    const session = await createSession(event.id);
+    act(commenter.id);
+    await getRepositories().sessionComments.createForSession({
+      sessionId: session.id,
+      authorId: commenter.id,
+      body: "top level on a session",
+      createdTime: new Date(),
+    });
+    const parent = (
+      await getRepositories().sessionComments.listBySession(session.id)
+    )[0];
+
+    const result = await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "misfiled reply",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toEqual([]);
+  });
+
+  it("deletes a whole thread with its profile", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "top level" });
+    const parent = await onlyComment(owner.id);
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "a reply",
+    });
+
+    await getRepositories().guests.delete(owner.id);
+
+    expect(
+      await getRepositories().profileComments.listByProfile(owner.id)
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
- Profiles now feature the same commenting functionality as sessions and proposals.
- Added dedicated repository for profile comments and integrated it into the application.
- Updated schemas, APIs, and UI to support profile-specific comments.
- Extended documentation and user guide to reflect new functionality.