### PR TITLE
refactor: give vote emoji, label and order a single home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the other way turns the card around smoothly from wherever it is, and catching a sliding card with a finger picks it
   up where it is instead of teleporting it
 
+### Internal
+
+- The emoji, label and display order of a vote live only in `app/(site)/votes.ts`, and `VotesContext` exposes
+  `proposalVoteLabel` beside `proposalVoteEmoji`. The choice→label mapping had been copied into three components, each
+  free to drift from the emoji next to it
+
 ## [3.4.2] - 2026-08-24
 
 ### Fixed

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -27,7 +27,7 @@ import { useLocalZone } from "@/utils/hooks";
 import { formatDuration, durationMinusBreak } from "@/utils/utils";
 
 import { VotingButtons } from "./voting-buttons";
-import { VoteChoice } from "@/app/(site)/votes";
+import { voteChoiceRank } from "@/app/(site)/votes";
 import { viewProposalLinkFromOwner } from "../modal-nav";
 import { stripMarkdown } from "@/utils/markdown";
 
@@ -80,7 +80,8 @@ export function ProposalTable({
         }
   );
   const { user: currentUserId } = useContext(UserContext);
-  const { votes, proposalVoteEmoji } = useContext(VotesContext);
+  const { votes, proposalVoteEmoji, proposalVoteLabel } =
+    useContext(VotesContext);
   const localZone = useLocalZone();
   const router = useRouter();
   // Derived: filter only applies when a user is selected. Hidden from data
@@ -201,24 +202,15 @@ export function ProposalTable({
       } else if (key === "votesCount") {
         cmp = (a[key] || 0) - (b[key] || 0);
       } else if (key === "userVote") {
-        const getVoteOrder = (proposalId: string) => {
-          if (!currentUserId) return 3;
-          const userVote = votes.find(
-            (v) => v.proposalId === proposalId && v.guestId === currentUserId
+        // Not VotesContext.getVote: that closes over the provider's state and
+        // would be an unstable dependency of this memo.
+        const rank = (proposalId: string) =>
+          voteChoiceRank(
+            votes.find(
+              (v) => v.proposalId === proposalId && v.guestId === currentUserId
+            )?.choice
           );
-          if (!userVote) return 3; // no vote
-          switch (userVote.choice) {
-            case VoteChoice.interested:
-              return 0;
-            case VoteChoice.maybe:
-              return 1;
-            case VoteChoice.skip:
-              return 2;
-            default:
-              return 3; // no vote
-          }
-        };
-        cmp = getVoteOrder(a.id) - getVoteOrder(b.id);
+        cmp = rank(a.id) - rank(b.id);
       } else if (key === "votes") {
         const voteNum = (p: SessionProposal) =>
           p.interestedVotesCount * 4 + p.maybeVotesCount;
@@ -605,26 +597,7 @@ export function ProposalTable({
                   {schedEnabled && (
                     <>
                       <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                        <span
-                          title={(() => {
-                            const vote = votes.find(
-                              (v) =>
-                                v.proposalId === proposal.id &&
-                                v.guestId === currentUserId
-                            );
-                            if (!vote) return "No vote";
-                            switch (vote.choice) {
-                              case VoteChoice.interested:
-                                return "Interested";
-                              case VoteChoice.maybe:
-                                return "Maybe";
-                              case VoteChoice.skip:
-                                return "Skip";
-                              default:
-                                return "No vote";
-                            }
-                          })()}
-                        >
+                        <span title={proposalVoteLabel(proposal.id)}>
                           {proposalVoteEmoji(proposal.id)}
                         </span>
                       </td>
@@ -775,24 +748,7 @@ export function ProposalTable({
                         <div>
                           Your vote:
                           <span
-                            title={(() => {
-                              const vote = votes.find(
-                                (v) =>
-                                  v.proposalId === proposal.id &&
-                                  v.guestId === currentUserId
-                              );
-                              if (!vote) return "No vote";
-                              switch (vote.choice) {
-                                case VoteChoice.interested:
-                                  return "Interested";
-                                case VoteChoice.maybe:
-                                  return "Maybe";
-                                case VoteChoice.skip:
-                                  return "Skip";
-                                default:
-                                  return "No vote";
-                              }
-                            })()}
+                            title={proposalVoteLabel(proposal.id)}
                             className="ml-1"
                           >
                             {proposalVoteEmoji(proposal.id)}

--- a/app/(site)/[eventSlug]/proposals/view-proposal.tsx
+++ b/app/(site)/[eventSlug]/proposals/view-proposal.tsx
@@ -21,7 +21,6 @@ import type {
 } from "@/db/repositories/interfaces";
 import { ProposalComments } from "./proposal-comments";
 import { VotingButtons } from "@/app/(site)/[eventSlug]/proposals/voting-buttons";
-import { VoteChoice } from "@/app/(site)/votes";
 import { VoteBreakdown } from "./vote-breakdown";
 import type { EventInterestSummary } from "@/utils/proposal-vote-stats";
 import { DateTime } from "luxon";
@@ -48,7 +47,7 @@ export function ViewProposal(props: {
     isInModal = false,
   } = props;
   const { user: currentUserId } = useContext(UserContext);
-  const { proposalVoteEmoji, votes } = useContext(VotesContext);
+  const { proposalVoteEmoji, proposalVoteLabel } = useContext(VotesContext);
   const { now } = useContext(EventContext);
   const localZone = useLocalZone();
   const router = useRouter();
@@ -147,27 +146,7 @@ export function ViewProposal(props: {
           {!isHost() && (
             <div className="text-sm text-fg-muted">
               Your vote:
-              <span
-                title={(() => {
-                  const vote = votes.find(
-                    (v) =>
-                      v.proposalId === proposal.id &&
-                      v.guestId === currentUserId
-                  );
-                  if (!vote) return "No vote";
-                  switch (vote.choice) {
-                    case VoteChoice.interested:
-                      return "Interested";
-                    case VoteChoice.maybe:
-                      return "Maybe";
-                    case VoteChoice.skip:
-                      return "Skip";
-                    default:
-                      return "No vote";
-                  }
-                })()}
-                className="ml-1"
-              >
+              <span title={proposalVoteLabel(proposal.id)} className="ml-1">
                 {proposalVoteEmoji(proposal.id)}
               </span>
             </div>

--- a/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
+++ b/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
@@ -1,6 +1,12 @@
 import { useContext } from "react";
 import clsx from "clsx";
-import { VoteChoice, type Vote } from "@/app/(site)/votes";
+import {
+  VoteChoice,
+  VOTE_CHOICES,
+  voteChoiceToEmoji,
+  voteChoiceToLabel,
+  type Vote,
+} from "@/app/(site)/votes";
 import HoverTooltip from "@/app/(site)/hover-tooltip";
 import { UserContext, VotesContext } from "@/app/(site)/context";
 
@@ -155,11 +161,11 @@ export function VotingButtons({
   );
 }
 
-const VOTE_OPTIONS = [
-  { choice: VoteChoice.interested, emoji: "❤️", label: "Interested" },
-  { choice: VoteChoice.maybe, emoji: "⭐", label: "Maybe" },
-  { choice: VoteChoice.skip, emoji: "👋🏽", label: "Skip" },
-] as const;
+const VOTE_OPTIONS = VOTE_CHOICES.map((choice) => ({
+  choice,
+  emoji: voteChoiceToEmoji(choice),
+  label: voteChoiceToLabel(choice),
+}));
 
 // The chosen vote must stay recognisable without perceiving hue: a light tint
 // against white collapsed into "no visible difference" under the Dark Reader

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -14,7 +14,12 @@ import type {
   Guest,
   Rsvp,
 } from "@/db/repositories/interfaces";
-import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
+import {
+  Vote,
+  voteChoiceToEmoji,
+  voteChoiceToLabel,
+  NO_VOTE_LABEL,
+} from "@/app/(site)/votes";
 import {
   selectUserAction,
   type SelectUserResult,
@@ -112,6 +117,7 @@ export interface VotesContextType {
   hasVoted: (proposalId: string) => boolean;
   getVote: (proposalId: string) => Vote | undefined;
   proposalVoteEmoji: (proposalId: string) => string;
+  proposalVoteLabel: (proposalId: string) => string;
   isLoading: boolean;
 }
 
@@ -124,6 +130,7 @@ export const VotesContext = createContext<VotesContextType>({
   hasVoted: () => false,
   getVote: () => undefined,
   proposalVoteEmoji: () => "",
+  proposalVoteLabel: () => NO_VOTE_LABEL,
   isLoading: false,
 });
 
@@ -449,6 +456,11 @@ export function VotesProvider({
     return choice ? voteChoiceToEmoji(choice) : "-";
   };
 
+  const proposalVoteLabel = (proposalId: string) => {
+    const choice = getVote(proposalId)?.choice;
+    return choice ? voteChoiceToLabel(choice) : NO_VOTE_LABEL;
+  };
+
   const contextValue: VotesContextType = {
     votes,
     setVotes,
@@ -458,6 +470,7 @@ export function VotesProvider({
     hasVoted,
     getVote,
     proposalVoteEmoji,
+    proposalVoteLabel,
     isLoading,
   };
 

--- a/app/(site)/votes.ts
+++ b/app/(site)/votes.ts
@@ -3,6 +3,16 @@ export type { Vote } from "@/db/repositories/interfaces";
 
 import { VoteChoice } from "@/db/repositories/interfaces";
 
+// Strongest interest first: this is both the order the vote buttons appear in
+// and the order the proposal list sorts by "Your vote".
+export const VOTE_CHOICES = [
+  VoteChoice.interested,
+  VoteChoice.maybe,
+  VoteChoice.skip,
+] as const;
+
+export const NO_VOTE_LABEL = "No vote";
+
 export function voteChoiceToEmoji(choice: VoteChoice): string {
   switch (choice) {
     case VoteChoice.interested:
@@ -12,4 +22,21 @@ export function voteChoiceToEmoji(choice: VoteChoice): string {
     case VoteChoice.skip:
       return "👋🏽";
   }
+}
+
+export function voteChoiceToLabel(choice: VoteChoice): string {
+  switch (choice) {
+    case VoteChoice.interested:
+      return "Interested";
+    case VoteChoice.maybe:
+      return "Maybe";
+    case VoteChoice.skip:
+      return "Skip";
+  }
+}
+
+/** Sort rank following VOTE_CHOICES, with "no vote" ranked after every vote. */
+export function voteChoiceRank(choice: VoteChoice | undefined): number {
+  const index = choice ? VOTE_CHOICES.indexOf(choice) : -1;
+  return index < 0 ? VOTE_CHOICES.length : index;
 }

--- a/tests/unit/votes.test.ts
+++ b/tests/unit/votes.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { voteChoiceToEmoji, VoteChoice } from "@/app/(site)/votes";
+import {
+  voteChoiceToEmoji,
+  voteChoiceToLabel,
+  voteChoiceRank,
+  VOTE_CHOICES,
+  VoteChoice,
+} from "@/app/(site)/votes";
 
 describe("voteChoiceToEmoji", () => {
   it("interested → ❤️", () =>
@@ -9,4 +15,30 @@ describe("voteChoiceToEmoji", () => {
     expect(voteChoiceToEmoji(VoteChoice.maybe)).toBe("⭐"));
 
   it("skip → 👋🏽", () => expect(voteChoiceToEmoji(VoteChoice.skip)).toBe("👋🏽"));
+});
+
+describe("voteChoiceToLabel", () => {
+  it("interested → Interested", () =>
+    expect(voteChoiceToLabel(VoteChoice.interested)).toBe("Interested"));
+
+  it("maybe → Maybe", () =>
+    expect(voteChoiceToLabel(VoteChoice.maybe)).toBe("Maybe"));
+
+  it("skip → Skip", () =>
+    expect(voteChoiceToLabel(VoteChoice.skip)).toBe("Skip"));
+});
+
+describe("VOTE_CHOICES", () => {
+  // A choice missing here would silently lose its vote button and its place in
+  // the "Your vote" sort order.
+  it("covers every VoteChoice", () =>
+    expect([...VOTE_CHOICES].sort()).toEqual(Object.values(VoteChoice).sort()));
+});
+
+describe("voteChoiceRank", () => {
+  it("ranks the choices in VOTE_CHOICES order", () =>
+    expect(VOTE_CHOICES.map(voteChoiceRank)).toEqual([0, 1, 2]));
+
+  it("ranks no vote after every choice", () =>
+    expect(voteChoiceRank(undefined)).toBe(VOTE_CHOICES.length));
 });


### PR DESCRIPTION
The choice->label switch was copied into three components, each able to
drift from the emoji it sits next to.

<!-- jip:pushed-commit=50b8fa1c0ab82aaf5f63744b487caf53fa949e3c -->