### PR TITLE
refactor: one component for the ❤️/⭐ vote tally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The emoji, label and display order of a vote live only in `app/(site)/votes.ts`, and `VotesContext` exposes
   `proposalVoteLabel` beside `proposalVoteEmoji`. The choice→label mapping had been copied into three components, each
   free to drift from the emoji next to it
+- The ❤️/⭐ tally against a proposal is one `VoteTally` component instead of three hand-written copies, and the vote
+  breakdown lists its rows from `VOTE_CHOICES`. Both had the emoji spelled out inline, so a change in `votes.ts` would
+  have left them behind
 
 ## [3.4.2] - 2026-08-24
 

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -27,6 +27,7 @@ import { useLocalZone } from "@/utils/hooks";
 import { formatDuration, durationMinusBreak } from "@/utils/utils";
 
 import { VotingButtons } from "./voting-buttons";
+import { VoteTally } from "./vote-tally";
 import { voteChoiceRank } from "@/app/(site)/votes";
 import { viewProposalLinkFromOwner } from "../modal-nav";
 import { stripMarkdown } from "@/utils/markdown";
@@ -602,20 +603,7 @@ export function ProposalTable({
                         </span>
                       </td>
                       <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                        <div className="flex items-center gap-2">
-                          <span
-                            title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                            className="flex items-center gap-1 text-sm text-fg-subtle"
-                          >
-                            ❤️&nbsp;{proposal.interestedVotesCount}
-                          </span>
-                          <span
-                            title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                            className="flex items-center gap-1 text-sm text-fg-subtle"
-                          >
-                            ⭐&nbsp;{proposal.maybeVotesCount}
-                          </span>
-                        </div>
+                        <VoteTally proposal={proposal} />
                       </td>
                     </>
                   )}
@@ -757,18 +745,7 @@ export function ProposalTable({
                       )}
                       <div className="flex items-center gap-2">
                         Total votes:
-                        <span
-                          title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                          className="flex items-center gap-1 text-sm text-fg-subtle"
-                        >
-                          ❤️&nbsp;{proposal.interestedVotesCount}
-                        </span>
-                        <span
-                          title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                          className="flex items-center gap-1 text-sm text-fg-subtle"
-                        >
-                          ⭐&nbsp;{proposal.maybeVotesCount}
-                        </span>
+                        <VoteTally proposal={proposal} />
                       </div>
                     </>
                   )}

--- a/app/(site)/[eventSlug]/proposals/view-proposal.tsx
+++ b/app/(site)/[eventSlug]/proposals/view-proposal.tsx
@@ -22,6 +22,7 @@ import type {
 import { ProposalComments } from "./proposal-comments";
 import { VotingButtons } from "@/app/(site)/[eventSlug]/proposals/voting-buttons";
 import { VoteBreakdown } from "./vote-breakdown";
+import { VoteTally } from "./vote-tally";
 import type { EventInterestSummary } from "@/utils/proposal-vote-stats";
 import { DateTime } from "luxon";
 import { useLocalZone } from "@/utils/hooks";
@@ -156,20 +157,7 @@ export function ViewProposal(props: {
           ) : (
             <div className="text-sm text-fg-muted">
               Total votes:
-              <span className="ml-2 inline-flex items-center gap-3">
-                <span
-                  title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                  className="inline-flex items-center gap-1 text-sm text-fg-subtle"
-                >
-                  ❤️&nbsp;{proposal.interestedVotesCount}
-                </span>
-                <span
-                  title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                  className="inline-flex items-center gap-1 text-sm text-fg-subtle"
-                >
-                  ⭐&nbsp;{proposal.maybeVotesCount}
-                </span>
-              </span>
+              <VoteTally proposal={proposal} className="ml-2" />
             </div>
           )}
         </div>

--- a/app/(site)/[eventSlug]/proposals/vote-breakdown.tsx
+++ b/app/(site)/[eventSlug]/proposals/vote-breakdown.tsx
@@ -3,6 +3,12 @@
 import { useContext, useId } from "react";
 
 import { EventContext } from "@/app/(site)/context";
+import {
+  VOTE_CHOICES,
+  VoteChoice,
+  voteChoiceToEmoji,
+  voteChoiceToLabel,
+} from "@/app/(site)/votes";
 import type { SessionProposal } from "@/db/repositories/interfaces";
 import {
   MIN_TURNOUT_PCT_FOR_ESTIMATE,
@@ -58,6 +64,24 @@ export function VoteBreakdown({
     skip: proposal.skipVotesCount,
   });
 
+  const perChoice: Record<
+    VoteChoice,
+    { count: number; pctOfVotes: number | null }
+  > = {
+    [VoteChoice.interested]: {
+      count: stats.interested,
+      pctOfVotes: stats.interestedPctOfVotes,
+    },
+    [VoteChoice.maybe]: {
+      count: stats.maybe,
+      pctOfVotes: stats.maybePctOfVotes,
+    },
+    [VoteChoice.skip]: {
+      count: stats.skip,
+      pctOfVotes: stats.skipPctOfVotes,
+    },
+  };
+
   return (
     <section
       aria-labelledby={headingId}
@@ -75,18 +99,13 @@ export function VoteBreakdown({
           Did not vote: {stats.nonVoters} attendees
           {pct(stats.nonVotersPctOfAttendees)}
         </li>
-        <li>
-          ❤️ Interested: {stats.interested}
-          {pctOfVotes(stats.interestedPctOfVotes)}
-        </li>
-        <li>
-          ⭐ Maybe: {stats.maybe}
-          {pctOfVotes(stats.maybePctOfVotes)}
-        </li>
-        <li>
-          👋🏽 Skip: {stats.skip}
-          {pctOfVotes(stats.skipPctOfVotes)}
-        </li>
+        {VOTE_CHOICES.map((choice) => (
+          <li key={choice}>
+            {voteChoiceToEmoji(choice)} {voteChoiceToLabel(choice)}:{" "}
+            {perChoice[choice].count}
+            {pctOfVotes(perChoice[choice].pctOfVotes)}
+          </li>
+        ))}
       </ul>
       {stats.estimatedAttendance && (
         <Estimate range={stats.estimatedAttendance} />
@@ -100,14 +119,16 @@ export function VoteBreakdown({
       )}
       {stats.noEstimateReason === "no-interest" && (
         <p className="mt-2 text-fg-subtle">
-          Nobody voted ❤️ Interested, and that is the only signal there is to
-          guess attendance from.
+          Nobody voted {voteChoiceToEmoji(VoteChoice.interested)}{" "}
+          {voteChoiceToLabel(VoteChoice.interested)}, and that is the only
+          signal there is to guess attendance from.
         </p>
       )}
       {stats.noEstimateReason === "unknown-event" && (
         <p className="mt-2 text-fg-subtle">
           There is nothing to measure this against yet — guessing at attendance
-          needs the event&apos;s attendee list and ❤️ votes on its other
+          needs the event&apos;s attendee list and{" "}
+          {voteChoiceToEmoji(VoteChoice.interested)} votes on its other
           proposals.
         </p>
       )}

--- a/app/(site)/[eventSlug]/proposals/vote-tally.tsx
+++ b/app/(site)/[eventSlug]/proposals/vote-tally.tsx
@@ -1,0 +1,40 @@
+import clsx from "clsx";
+
+import {
+  VoteChoice,
+  voteChoiceToEmoji,
+  voteChoiceToLabel,
+  voteCount,
+  type ProposalVoteCounts,
+} from "@/app/(site)/votes";
+
+// Skip votes are left out on purpose: this is the public tally, and it reads as
+// interest in a proposal rather than as a scoreboard for it. The full split is
+// the host's to see, in the vote breakdown.
+const TALLIED = [VoteChoice.interested, VoteChoice.maybe] as const;
+
+export function VoteTally({
+  proposal,
+  className,
+}: {
+  proposal: ProposalVoteCounts;
+  className?: string;
+}) {
+  return (
+    <span className={clsx("inline-flex items-center gap-2", className)}>
+      {TALLIED.map((choice) => {
+        const count = voteCount(proposal, choice);
+        const label = voteChoiceToLabel(choice).toLowerCase();
+        return (
+          <span
+            key={choice}
+            title={`${count} ${label} vote${count !== 1 ? "s" : ""}`}
+            className="inline-flex items-center gap-1 text-sm text-fg-subtle"
+          >
+            {voteChoiceToEmoji(choice)}&nbsp;{count}
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/app/(site)/votes.ts
+++ b/app/(site)/votes.ts
@@ -2,6 +2,7 @@ export { VoteChoice } from "@/db/repositories/interfaces";
 export type { Vote } from "@/db/repositories/interfaces";
 
 import { VoteChoice } from "@/db/repositories/interfaces";
+import type { SessionProposal } from "@/db/repositories/interfaces";
 
 // Strongest interest first: this is both the order the vote buttons appear in
 // and the order the proposal list sorts by "Your vote".
@@ -39,4 +40,22 @@ export function voteChoiceToLabel(choice: VoteChoice): string {
 export function voteChoiceRank(choice: VoteChoice | undefined): number {
   const index = choice ? VOTE_CHOICES.indexOf(choice) : -1;
   return index < 0 ? VOTE_CHOICES.length : index;
+}
+
+export type ProposalVoteCounts = Pick<
+  SessionProposal,
+  "interestedVotesCount" | "maybeVotesCount" | "skipVotesCount"
+>;
+
+const COUNT_FIELD: Record<VoteChoice, keyof ProposalVoteCounts> = {
+  [VoteChoice.interested]: "interestedVotesCount",
+  [VoteChoice.maybe]: "maybeVotesCount",
+  [VoteChoice.skip]: "skipVotesCount",
+};
+
+export function voteCount(
+  counts: ProposalVoteCounts,
+  choice: VoteChoice
+): number {
+  return counts[COUNT_FIELD[choice]];
 }

--- a/tests/unit/votes.test.ts
+++ b/tests/unit/votes.test.ts
@@ -3,6 +3,7 @@ import {
   voteChoiceToEmoji,
   voteChoiceToLabel,
   voteChoiceRank,
+  voteCount,
   VOTE_CHOICES,
   VoteChoice,
 } from "@/app/(site)/votes";
@@ -33,6 +34,21 @@ describe("VOTE_CHOICES", () => {
   // the "Your vote" sort order.
   it("covers every VoteChoice", () =>
     expect([...VOTE_CHOICES].sort()).toEqual(Object.values(VoteChoice).sort()));
+});
+
+describe("voteCount", () => {
+  const counts = {
+    interestedVotesCount: 3,
+    maybeVotesCount: 2,
+    skipVotesCount: 1,
+  };
+
+  // Reading the wrong field would show a plausible number, so nothing else
+  // would notice.
+  it("reads each choice's own count", () =>
+    expect(VOTE_CHOICES.map((choice) => voteCount(counts, choice))).toEqual([
+      3, 2, 1,
+    ]));
 });
 
 describe("voteChoiceRank", () => {


### PR DESCRIPTION
The tally was hand-written three times — twice in the proposal table, once
in the proposal modal — each copy spelling out the emoji and its own
pluralised tooltip, so nothing in votes.ts reached them. The vote breakdown
listed its rows the same way. Both now derive emoji, label and order from
VOTE_CHOICES.

The modal tally spaced its two counts a little wider than the table did;
they now share the table spacing.

<!-- jip:pushed-commit=f3a6304a25bf45051ab33845f64aa788c5b9ad16 -->