### PR TITLE
refactor: one home for the admin cookie check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   copied five, three and two times. Copies had already drifted: the "Host(s)" header was the only one not left-aligned,
   only "My proposals" announced itself as pressed to a screen reader, and the "No proposals found" row stopped one
   column short of the table during the scheduling phase
+- The admin cookie check for server actions and server components is one `isAdminRequest` in
+  `utils/acting-admin.ts`, the counterpart to `utils/acting-guest.ts`, instead of the same private
+  helper copied into all eleven admin action modules, the admin layout and `require-admin.ts`
 
 ## [3.4.2] - 2026-08-24
 

--- a/app/actions/admin-days.ts
+++ b/app/actions/admin-days.ts
@@ -1,20 +1,14 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import {
   dayAlignmentError,
   daysOverlap,
   sessionContainedInWindow,
 } from "@/utils/day-window";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 export type DayInput = {
   eventId: string;

--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -1,14 +1,13 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import {
   eventNameToSlug,
   normalizeWebsiteUrl,
   RESERVED_EVENT_SLUGS,
 } from "@/utils/utils";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import type { Event } from "@/db/repositories/interfaces";
 import type { AdminActionResult } from "./admin-guests";
 import { isEventIconName } from "@/app/event-icons";
@@ -18,11 +17,6 @@ import {
   isSlotAligned,
 } from "@/utils/slots";
 import { sessionOverlapsWindow } from "@/utils/day-window";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 export type EventInput = {
   name: string;

--- a/app/actions/admin-guest-events.ts
+++ b/app/actions/admin-guest-events.ts
@@ -1,15 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 function revalidateEventPaths(eventId: string) {
   revalidatePath("/admin");

--- a/app/actions/admin-guest-import.ts
+++ b/app/actions/admin-guest-import.ts
@@ -1,19 +1,13 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import { parseUserImportCsv } from "@/utils/user-import";
 
 export type ImportGuestsResult =
   | { ok: true; created: number; existing: number }
   | { ok: false; error: string; lineErrors?: string[] };
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 /**
  * Imports users from CSV (header: name,email) and assigns them to the given

--- a/app/actions/admin-guests.ts
+++ b/app/actions/admin-guests.ts
@@ -1,9 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import { sendMail } from "@/utils/mailer";
 import { testEmail } from "@/emails/test-email";
 import { z } from "zod";
@@ -12,11 +11,6 @@ import { createGuestSchema, updateGuestSchema } from "@/model/guest";
 export type AdminFormActionResult =
   { ok: true } | { ok: false; error: string | z.core.$ZodIssue[] };
 export type AdminActionResult = { ok: true } | { ok: false; error: string };
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 const EMAIL_UNIQUENESS_ERROR: z.core.$ZodIssue = {
   code: "custom",

--- a/app/actions/admin-location-events.ts
+++ b/app/actions/admin-location-events.ts
@@ -1,15 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 function revalidateEventPaths(eventId: string) {
   revalidatePath("/admin");

--- a/app/actions/admin-locations.ts
+++ b/app/actions/admin-locations.ts
@@ -1,19 +1,13 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import { getImageRepositories } from "@/utils/images";
 import type { Location } from "@/db/repositories/interfaces";
 import type { AdminActionResult, AdminFormActionResult } from "./admin-guests";
 import { locationSchema, updateLocationSchema } from "@/model/location";
 import { z } from "zod";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 async function validateEventIds(eventIds: string[]): Promise<boolean> {
   const events = await getRepositories().events.list();

--- a/app/actions/admin-proposals.ts
+++ b/app/actions/admin-proposals.ts
@@ -1,15 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 export type AdminProposalInput = {
   id: string;

--- a/app/actions/admin-rsvps.ts
+++ b/app/actions/admin-rsvps.ts
@@ -1,15 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 export async function adminRemoveRsvpAction(input: {
   sessionId: string;

--- a/app/actions/admin-sessions.ts
+++ b/app/actions/admin-sessions.ts
@@ -1,9 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import { sessionSlotAlignmentError } from "@/utils/day-window";
 import {
   notifyCohostsAdded,
@@ -12,11 +11,6 @@ import {
   rsvpGuestIdsToNotify,
 } from "@/utils/notifications";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 export type AdminSessionInput = {
   id: string;

--- a/app/actions/admin-settings.ts
+++ b/app/actions/admin-settings.ts
@@ -1,20 +1,14 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import {
   deleteMapImage,
   saveMapImage,
   validateMapImage,
 } from "@/utils/map-image";
 import type { AdminActionResult } from "./admin-guests";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 function formString(formData: FormData, key: string): string {
   const value = formData.get(key);

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,7 +1,6 @@
-import { cookies } from "next/headers";
 import Footer from "../footer";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 import { AdminHeader } from "./admin-header";
 
 export default async function AdminLayout({
@@ -9,10 +8,7 @@ export default async function AdminLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookieStore = await cookies();
-  const isAdmin = await isAdminCookieValid(
-    cookieStore.get(ADMIN_COOKIE_NAME)?.value
-  );
+  const isAdmin = await isAdminRequest();
   const { title } = await getRepositories().settings.get();
 
   return (

--- a/app/admin/require-admin.ts
+++ b/app/admin/require-admin.ts
@@ -1,17 +1,12 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { isAdminRequest } from "@/utils/acting-admin";
 
 /**
  * Defense in depth: the proxy already guards /admin, but every admin server
  * component re-checks the cookie and redirects to the login on failure.
  */
 export async function requireAdminPage(): Promise<void> {
-  const cookieStore = await cookies();
-  const isAdmin = await isAdminCookieValid(
-    cookieStore.get(ADMIN_COOKIE_NAME)?.value
-  );
-  if (!isAdmin) {
+  if (!(await isAdminRequest())) {
     redirect("/admin/login");
   }
 }

--- a/utils/acting-admin.ts
+++ b/utils/acting-admin.ts
@@ -1,0 +1,12 @@
+import { cookies } from "next/headers";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "./auth";
+
+// The admin gate for server actions and server components — the counterpart to
+// utils/acting-guest.ts. Kept out of utils/auth.ts because the proxy imports
+// that module, and next/headers isn't available there; the proxy's own
+// equivalent is isAdminAuthenticated(request).
+
+export async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}


### PR DESCRIPTION
The same private isAdminRequest was copied into all eleven admin action
modules, and the admin layout and require-admin.ts each spelled the check
out again. It now lives in utils/acting-admin.ts, next to the guest
equivalent — not in utils/auth.ts, which the proxy imports and so cannot
reach for next/headers.

<!-- jip:pushed-commit=9da0e77153bd52256a8f29c7e6cf8d038a4f69e2 -->