### PR TITLE
fix: schedule sessions after midnight on the right date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Sessions after midnight are scheduled on the right date**: on a day that runs past midnight (say Friday 09:00 to
+  Saturday 03:00), booking a session at 01:00 saved it on the Friday morning instead — almost a day early — where it
+  vanished from the schedule entirely. Late-night times now land on the following calendar date, including on the last
+  night of an event
 - **Interrupting a profile slide no longer restarts it**: pressing Next or Prev (or swiping again) while a profile was
   still sliding into place used to snap the card back to the start and replay the whole slide, putting off the arrival a
   little more with every press. Repeated presses in the same direction now let the first slide simply finish, a press

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -77,11 +77,7 @@ export function SessionForm(props: {
   const initDay = initDateTime
     ? days.find((d) => dateOnDay(initDateTime, d))
     : undefined;
-  let initMinutes: number | undefined;
-  if (initDateTime) {
-    const dt = DateTime.fromJSDate(initDateTime).setZone(timezone);
-    initMinutes = dt.hour * 60 + dt.minute;
-  }
+  const initSlot = initDateTime?.getTime();
 
   // Compute default hosts for new sessions (no initial proposal, no sessionID).
   // Also used as the "reset" target when the user un-selects a proposal.
@@ -129,23 +125,21 @@ export function SessionForm(props: {
     timezone,
     locationId
   );
-  const initTimeValid = startTimes.some(
-    (st) => st.minutesFromMidnight === initMinutes
-  );
+  const initTimeValid = startTimes.some((st) => st.time === initSlot);
   const [startTime, setStartTime] = useState<number | undefined>(
-    initTimeValid ? initMinutes : undefined
+    initTimeValid ? initSlot : undefined
   );
   // Derived: the currently-selected startTime if it is still available under
   // the current location/day, otherwise undefined. Avoids a setState-in-effect
   // reset by not storing invalid values downstream.
   const effectiveStartTime = startTimes.some(
-    (st) => st.minutesFromMidnight === startTime && st.available
+    (st) => st.time === startTime && st.available
   )
     ? startTime
     : undefined;
   const maxDuration =
-    startTimes.find((st) => st.minutesFromMidnight === effectiveStartTime)
-      ?.maxDuration ?? maxSessionDuration;
+    startTimes.find((st) => st.time === effectiveStartTime)?.maxDuration ??
+    maxSessionDuration;
   // Proposal durations are free-form, so they get snapped to the nearest
   // selectable slot multiple; an existing session's duration already sits on
   // the grid and passes through unchanged.
@@ -190,10 +184,8 @@ export function SessionForm(props: {
   let dummySession = newEmptySession(event.id);
   if (effectiveStartTime !== undefined && day) {
     const { start, end } = buildSessionInterval(
-      day,
-      effectiveStartTime,
-      effectiveDuration,
-      timezone
+      new Date(effectiveStartTime),
+      effectiveDuration
     );
     dummySession = {
       ...newEmptySession(event.id),
@@ -276,11 +268,10 @@ export function SessionForm(props: {
         closed,
         day,
         location,
-        startTimeMinutes: effectiveStartTime,
+        startTime: new Date(effectiveStartTime).toISOString(),
         duration: effectiveDuration,
         hosts,
         proposal: proposal?.id ?? session.proposalId,
-        timezone,
       }),
     });
     if (res.ok) {
@@ -477,7 +468,7 @@ export function SessionForm(props: {
           }
           setCurrValue={(v) => setStartTime(parseInt(v, 10))}
           options={startTimes.map((st) => ({
-            value: String(st.minutesFromMidnight),
+            value: String(st.time),
             display: st.formattedTime,
             available: st.available,
           }))}
@@ -557,7 +548,7 @@ const RequiredStar = () => <span className="text-brand-fg mx-1">*</span>;
 
 type StartTime = {
   formattedTime: string;
-  minutesFromMidnight: number;
+  /** The slot's absolute start, as epoch milliseconds. */
   time: number;
   maxDuration: number;
   available: boolean;
@@ -593,12 +584,11 @@ function getAvailableStartTimes(
   ) {
     const dt = DateTime.fromMillis(t).setZone(timezone);
     // The break sits at the start of each slot, so the displayed start is
-    // pushed back by breakMinutes (e.g. a 9:00 slot shows as 9:10). The stored
-    // value (minutesFromMidnight) stays on the round slot boundary.
+    // pushed back by breakMinutes (e.g. a 9:00 slot shows as 9:10). The slot
+    // itself stays on the round boundary.
     const formattedTime = dt
       .plus({ minutes: breakMinutes })
       .toFormat(TIME_FORMAT);
-    const minutesFromMidnight = dt.hour * 60 + dt.minute;
     if (locationSelected) {
       const sessionNow = sortedSessions.find(
         (session) =>
@@ -608,7 +598,6 @@ function getAvailableStartTimes(
       if (sessionNow) {
         startTimes.push({
           formattedTime,
-          minutesFromMidnight,
           time: t,
           maxDuration: 0,
           available: false,
@@ -622,7 +611,6 @@ function getAvailableStartTimes(
           : day.endBookings.getTime();
         startTimes.push({
           formattedTime,
-          minutesFromMidnight,
           time: t,
           maxDuration: Math.min(
             (latestEndTime - t) / 1000 / 60,
@@ -634,7 +622,6 @@ function getAvailableStartTimes(
     } else {
       startTimes.push({
         formattedTime,
-        minutesFromMidnight,
         time: t,
         maxDuration: maxSessionDuration,
         available: true,

--- a/app/api/admin/create-session/route.ts
+++ b/app/api/admin/create-session/route.ts
@@ -10,9 +10,10 @@ export const dynamic = "force-dynamic";
 // header this route re-checks so it fails closed if the proxy didn't run.
 //
 // Unlike /api/add-session this returns the created id (which the RSVP step
-// needs), takes absolute ISO times instead of the SessionParams shape, and —
-// like the other admin seeding routes — has no scheduling-phase or
-// future-time gate: an importer routinely seeds past/fixed dates.
+// needs), takes an explicit end time instead of a duration and the day and
+// location objects of the SessionParams shape, and — like the other admin
+// seeding routes — has no scheduling-phase or future-time gate: an importer
+// routinely seeds past/fixed dates.
 //
 // Always creates a new session, same as adminCreateSessionAction: sessions
 // aren't deduplicated, so a repeated request is a location conflict (409),

--- a/app/api/session-form-utils.ts
+++ b/app/api/session-form-utils.ts
@@ -5,7 +5,6 @@ import type {
   Session,
   SessionCreateInput,
 } from "@/db/repositories/interfaces";
-import { DateTime } from "luxon";
 
 export type SessionParams = {
   id?: string;
@@ -15,10 +14,13 @@ export type SessionParams = {
   hosts: Guest[];
   location: Location;
   day: Day;
-  startTimeMinutes: number;
+  /**
+   * The chosen slot as an ISO instant, not a time of day: a day window may run
+   * past midnight, so a wall-clock time alone doesn't say which date it means.
+   */
+  startTime: string;
   duration: number;
   proposal?: string;
-  timezone: string;
 };
 
 export type SessionInterval = {
@@ -27,44 +29,20 @@ export type SessionInterval = {
 };
 
 export function buildSessionInterval(
-  day: Day,
-  startTimeMinutes: number,
-  durationMinutes: number,
-  timezone: string
+  startTime: Date,
+  durationMinutes: number
 ): SessionInterval {
-  const dayStart = DateTime.fromJSDate(new Date(day.start)).setZone(timezone);
-  const startDT = DateTime.fromObject(
-    {
-      year: dayStart.year,
-      month: dayStart.month,
-      day: dayStart.day,
-      hour: Math.floor(startTimeMinutes / 60),
-      minute: startTimeMinutes % 60,
-    },
-    { zone: timezone }
-  );
   return {
-    start: startDT.toJSDate(),
-    end: startDT.plus({ minutes: durationMinutes }).toJSDate(),
+    start: startTime,
+    end: new Date(startTime.getTime() + durationMinutes * 60 * 1000),
   };
 }
 
 export function prepareToInsert(params: SessionParams): SessionCreateInput {
-  const {
-    title,
-    description,
-    closed,
-    hosts,
-    location,
-    day,
-    startTimeMinutes,
-    duration,
-  } = params;
+  const { title, description, closed, hosts, location, day, duration } = params;
   const { start, end } = buildSessionInterval(
-    day,
-    startTimeMinutes,
-    duration,
-    params.timezone
+    new Date(params.startTime),
+    duration
   );
   return {
     title,

--- a/docs/public/organizers/admin-guide.md
+++ b/docs/public/organizers/admin-guide.md
@@ -44,6 +44,11 @@ One global row shown when there's more than one event (see
   separate Bookings open/close window controlling when attendees can
   self-book a blank bookable slot on that day. Deleting a day also deletes
   any sessions scheduled inside it (warned before confirming).
+  A day may end after midnight (e.g. Friday 09:00 → Saturday 03:00). Since a
+  session always belongs to exactly one day, that is how you allow late-night
+  sessions: extend the evening's day into the small hours instead of adding a
+  separate day for them. Hosts then pick that day and a time such as 01:00,
+  and the session is scheduled on the following calendar date.
 - **Deleting an event** requires typing the event name to confirm, and
   cascades to its days, proposals, sessions, RSVPs, and guest/location
   assignments.

--- a/scripts/seed/data/gamma-schedule.ts
+++ b/scripts/seed/data/gamma-schedule.ts
@@ -1,10 +1,11 @@
 // Conference Gamma (scheduling phase) gets a realistic, mostly filled grid:
 // most sessions are scheduled from its seeded proposals (matched by title),
 // plus organizer/attendee extras. Times are Berlin clock times on event day
-// 0-2. Keep the slots that tests/e2e/scheduling.spec.ts relies on free:
+// 0-2, day 2 running past midnight (09:00 → 03:00). Keep the slots that
+// tests/e2e/scheduling.spec.ts relies on free:
 //   day 0: Main Hall 16:00 and Garden Terrace 09:00 (asserted free),
-//   day 2: Workshop Room from 15:00 and Garden Terrace from 16:00
-//          (used by tests to create sessions).
+//   day 2: Workshop Room from 15:00, Garden Terrace from 16:00 and Main Hall
+//          01:00 the following morning (used by tests to create sessions).
 // rsvp.spec.ts RSVPs Bob Test to the Opening Keynote, so nothing may run in
 // parallel to it and Bob gets no seeded RSVP there (see RSVP seeding).
 export interface GammaSessionConfig {

--- a/scripts/seed/seed-database.ts
+++ b/scripts/seed/seed-database.ts
@@ -164,7 +164,10 @@ function generateEventDates() {
   e3PropStart.setDate(e3VoteStart.getDate() - phaseDuration);
   const e3PropEnd = new Date(e3VoteStart);
   const e3Start = berlinTime(e3SchedStart, schedulingLeadTime, 9, 0);
-  const e3End = berlinTime(e3Start, 2, 18, 0);
+  // Gamma's last day runs into the small hours (see the day seeding below), so
+  // the event — and with it the scheduling phase — ends at 03:00 the morning
+  // after day 2, not at 18:00.
+  const e3End = berlinTime(e3Start, 3, 3, 0);
   const e3SchedEnd = new Date(e3End);
 
   return [
@@ -389,18 +392,34 @@ async function seedTestData(profile: SeedProfile) {
   );
   db.insert(schema.eventLocations).values(eventLocationRows).run();
 
-  // Days (3 per event, 09:00–18:00 Berlin, bookable 09:00–17:30 Berlin)
+  // Days (3 per event, 09:00–18:00 Berlin, bookable 09:00–17:30 Berlin).
+  // Exception: Conference Gamma's last day is a party night that runs to 03:00
+  // the next morning, bookable until 02:30 — the fixture for scheduling
+  // sessions after midnight, on the night with no following day entry.
   console.log("  📅 Creating test days...");
   const dayRows = eventRows.flatMap((ev, eventIndex) => {
     const config = eventConfigs[eventIndex];
-    return [0, 1, 2].map((dayIndex) => ({
-      id: nanoid(),
-      start: berlinTime(config.start, dayIndex, 9, 0).toISOString(),
-      end: berlinTime(config.start, dayIndex, 18, 0).toISOString(),
-      startBookings: berlinTime(config.start, dayIndex, 9, 0).toISOString(),
-      endBookings: berlinTime(config.start, dayIndex, 17, 30).toISOString(),
-      eventId: ev.id,
-    }));
+    return [0, 1, 2].map((dayIndex) => {
+      const lateNight = ev.name === "Conference Gamma" && dayIndex === 2;
+      return {
+        id: nanoid(),
+        start: berlinTime(config.start, dayIndex, 9, 0).toISOString(),
+        end: berlinTime(
+          config.start,
+          lateNight ? dayIndex + 1 : dayIndex,
+          lateNight ? 3 : 18,
+          0
+        ).toISOString(),
+        startBookings: berlinTime(config.start, dayIndex, 9, 0).toISOString(),
+        endBookings: berlinTime(
+          config.start,
+          lateNight ? dayIndex + 1 : dayIndex,
+          lateNight ? 2 : 17,
+          30
+        ).toISOString(),
+        eventId: ev.id,
+      };
+    });
   });
   db.insert(schema.days).values(dayRows).run();
   console.log(

--- a/tests/e2e/scheduling.spec.ts
+++ b/tests/e2e/scheduling.spec.ts
@@ -1,4 +1,5 @@
 import { Page } from "@playwright/test";
+import { DateTime } from "luxon";
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
@@ -117,6 +118,28 @@ test("a host can delete a session and it disappears from the grid", async ({
   // Still gone after a full reload
   await page.reload();
   await expect(page.getByRole("link", { name: title })).toHaveCount(0);
+});
+
+test("a session booked after midnight lands on the next calendar date", async ({
+  page,
+}) => {
+  await login(page);
+  const title = `E2E Late Night Session ${Date.now()}`;
+
+  // Gamma's last day runs 09:00 → 03:00 the next morning (see the seed), so
+  // 01:10 is bookable under that day and belongs to the following date.
+  await createSessionViaForm(page, title, /Main Hall/, "01:10");
+
+  // The text view labels a session with the weekday of its actual start.
+  // Gamma runs today+14 … today+16, so the last night's 01:10 is today+17.
+  const afterMidnight = DateTime.now()
+    .setZone("Europe/Berlin")
+    .plus({ days: 17 });
+  await page.getByRole("button", { name: "Text" }).click();
+  await page.getByPlaceholder("Search sessions").fill(title);
+  await expect(
+    page.getByText(`${afterMidnight.toFormat("EEEE")}, 01:10`)
+  ).toBeVisible();
 });
 
 test("occupied start times are not offered in the same location but are in others", async ({

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -163,6 +163,17 @@ export async function createDay(
   return days.create({ start: base, end, startBookings, endBookings, eventId });
 }
 
+/**
+ * ISO instant of the slot `minutesIn` after the day's first bookable one — the
+ * `startTime` the session form posts. Derived from the day rather than written
+ * as a wall-clock time so it stays inside the booking window in any zone.
+ */
+export function slotStart(day: Day, minutesIn: number): string {
+  return new Date(
+    day.startBookings.getTime() + minutesIn * 60 * 1000
+  ).toISOString();
+}
+
 export async function createProposal(
   eventId: string,
   hostIds: string[],

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -20,6 +20,7 @@ import {
   createGuest,
   createLocation,
   createDay,
+  slotStart,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { POST } from "@/app/api/add-session/route";
@@ -81,9 +82,8 @@ function buildPayload(
     hosts: [host],
     location,
     day,
-    startTimeMinutes: 10 * 60,
+    startTime: slotStart(day, 60),
     duration: 60,
-    timezone: "UTC",
     ...overrides,
   };
 }
@@ -142,6 +142,33 @@ describe("POST /api/add-session", () => {
     );
   });
 
+  it("keeps a post-midnight slot on its own calendar date", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    // A party night: the day runs 09:00 → 03:00 the next morning, so its late
+    // slots belong to the following date rather than the day's own.
+    const dayStart = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    dayStart.setHours(9, 0, 0, 0);
+    const dayEnd = new Date(dayStart.getTime() + 18 * 60 * 60 * 1000);
+    const day = await createDay(event.id, {
+      start: dayStart,
+      end: dayEnd,
+      startBookings: dayStart,
+      endBookings: new Date(dayEnd.getTime() - 30 * 60 * 1000),
+    });
+
+    const oneAM = slotStart(day, 16 * 60);
+    const res = await POST(
+      makeReq(buildPayload(guest, location, day, { startTime: oneAM }))
+    );
+    expect(res.ok).toBe(true);
+
+    const [session] = await getRepositories().sessions.listByEvent(event.id);
+    expect(session.startTime!.toISOString()).toBe(oneAM);
+    expect(session.startTime!.getDate()).not.toBe(dayStart.getDate());
+  });
+
   it("rejects overlap in same location; only the pre-existing session remains", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
@@ -158,7 +185,7 @@ describe("POST /api/add-session", () => {
       makeReq(
         buildPayload(guest, location, day, {
           title: "Overlap",
-          startTimeMinutes: 10 * 60 + 30,
+          startTime: slotStart(day, 90),
         })
       )
     );

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -19,6 +19,7 @@ import {
   createGuest,
   createLocation,
   createDay,
+  slotStart,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import {
@@ -88,9 +89,8 @@ async function createScheduledSession(
     hosts: [host],
     location,
     day,
-    startTimeMinutes: 10 * 60,
+    startTime: slotStart(day, 60),
     duration: 60,
-    timezone: "UTC",
     ...overrides,
   };
   const res = await addPOST(makeAddReq(payload));

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -48,6 +48,7 @@ import {
   createGuest,
   createLocation,
   createDay,
+  slotStart,
   createProposal,
   createSession,
 } from "../helpers/factories";
@@ -107,9 +108,8 @@ const VERIFIERS: Record<string, Verifier> = {
           hosts: [guest],
           location,
           day,
-          startTimeMinutes: 600,
+          startTime: slotStart(day, 60),
           duration: 60,
-          timezone: "UTC",
         }),
         headers: { cookie: `${GUEST_COOKIE_NAME}=${openGuestValue(guest.id)}` },
       })
@@ -141,9 +141,8 @@ const VERIFIERS: Record<string, Verifier> = {
           hosts: [host],
           location,
           day,
-          startTimeMinutes: 600,
+          startTime: slotStart(day, 60),
           duration: 60,
-          timezone: "UTC",
         }),
         headers: { cookie: `${GUEST_COOKIE_NAME}=${openGuestValue(host.id)}` },
       })

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -22,6 +22,7 @@ import {
   createGuest,
   createLocation,
   createDay,
+  slotStart,
   createProposal as createProposalFixture,
   createSession,
 } from "../helpers/factories";
@@ -77,9 +78,8 @@ async function addSessionIn(phase: "proposal" | "voting" | "scheduling") {
     hosts: [guest],
     location,
     day,
-    startTimeMinutes: 10 * 60,
+    startTime: slotStart(day, 60),
     duration: 60,
-    timezone: "UTC",
   };
   const res = await addSession(makeReq("http://test/api/add-session", payload));
   const sessions = await getRepositories().sessions.listByEvent(event.id);

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -21,6 +21,7 @@ import {
   createGuest,
   createLocation,
   createDay,
+  slotStart,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import {
@@ -89,9 +90,8 @@ function basePayload(
     hosts: [host],
     location,
     day,
-    startTimeMinutes: 10 * 60,
+    startTime: slotStart(day, 60),
     duration: 60,
-    timezone: "UTC",
     ...overrides,
   };
 }
@@ -132,7 +132,7 @@ describe("POST /api/update-session", () => {
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day, {
-      startTimeMinutes: 10 * 60,
+      startTime: slotStart(day, 60),
     });
     await getRepositories().rsvps.create({
       sessionId: id,
@@ -144,7 +144,9 @@ describe("POST /api/update-session", () => {
     const res = await POST(
       makeUpdateReq(
         {
-          ...basePayload(host, location, day, { startTimeMinutes: 12 * 60 }),
+          ...basePayload(host, location, day, {
+            startTime: slotStart(day, 180),
+          }),
           id,
         },
         // The host makes the change, so only the RSVP'd guest is emailed.
@@ -166,7 +168,7 @@ describe("POST /api/update-session", () => {
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day, {
-      startTimeMinutes: 10 * 60,
+      startTime: slotStart(day, 60),
     });
     await getRepositories().rsvps.create({
       sessionId: id,
@@ -179,7 +181,7 @@ describe("POST /api/update-session", () => {
       makeUpdateReq(
         {
           ...basePayload(host, location, day, {
-            startTimeMinutes: 12 * 60,
+            startTime: slotStart(day, 180),
             hosts: [host, rsvper],
           }),
           id,
@@ -205,14 +207,16 @@ describe("POST /api/update-session", () => {
     const day = await createDay(event.id);
 
     const id = await createScheduledSession(event.id, guest, location, day, {
-      startTimeMinutes: 10 * 60,
+      startTime: slotStart(day, 60),
     });
     const before = (await getRepositories().sessions.findById(id))!;
 
     const res = await POST(
       makeUpdateReq(
         {
-          ...basePayload(guest, location, day, { startTimeMinutes: 12 * 60 }),
+          ...basePayload(guest, location, day, {
+            startTime: slotStart(day, 180),
+          }),
           id,
         },
         { editorGuestId: guest.id }
@@ -234,7 +238,7 @@ describe("POST /api/update-session", () => {
 
     await createScheduledSession(event.id, guest, location, day, {
       title: "Anchor",
-      startTimeMinutes: 10 * 60,
+      startTime: slotStart(day, 60),
     });
     const movingId = await createScheduledSession(
       event.id,
@@ -243,7 +247,7 @@ describe("POST /api/update-session", () => {
       day,
       {
         title: "Moving",
-        startTimeMinutes: 12 * 60,
+        startTime: slotStart(day, 180),
       }
     );
     const originalTime = (await getRepositories().sessions.findById(movingId))!
@@ -254,7 +258,7 @@ describe("POST /api/update-session", () => {
         {
           ...basePayload(guest, location, day, {
             title: "Moving",
-            startTimeMinutes: 10 * 60 + 30,
+            startTime: slotStart(day, 90),
           }),
           id: movingId,
         },
@@ -311,7 +315,7 @@ describe("POST /api/update-session", () => {
         {
           ...basePayload(guest, location, day, {
             title: "Renamed",
-            startTimeMinutes: 14 * 60,
+            startTime: slotStart(day, 300),
           }),
           id: created.id,
         },


### PR DESCRIPTION
The session form sent the chosen slot as minutes-from-midnight plus a day,
and the server rebuilt the instant from the day's own calendar date. On a
day running past midnight that put a 01:00 session almost a day early, where
it belonged to no day window and vanished from the schedule.

The slot list already knows each slot's absolute start, so send that instead
of re-deriving it. This also drops the wall-clock ambiguity around DST and
day windows longer than 24h.

issue schellingboard/schellingboard#698

<!-- jip:pushed-commit=f6cba6416b6157524e575ace00196afd46b81a92 -->