### PR TITLE
fix: say which day the hours after midnight belong to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **The session form shows which day owns the small hours**: a day that runs past midnight is now labelled with the
+  hour it ends ("Friday, June 13 (until 03:00 Sat)"), and its start times after midnight carry their weekday ("Sat
+  01:10"), so it's clear that the late slots belong to the evening's day. Day names also follow the event's timezone
+  instead of the reader's, which could show the day before or after near midnight
 - **Sessions after midnight are scheduled on the right date**: on a day that runs past midnight (say Friday 09:00 to
   Saturday 03:00), booking a session at 01:00 saved it on the Friday morning instead — almost a day early — where it
   vanished from the schedule entirely. Late-night times now land on the following calendar date, including on the last
@@ -35,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   copied five, three and two times. Copies had already drifted: the "Host(s)" header was the only one not left-aligned,
   only "My proposals" announced itself as pressed to a screen reader, and the "No proposals found" row stopped one
   column short of the table during the scheduling phase
+- `date-fns` is gone from the dependencies. The day picker held its last import; every other date is formatted with
+  luxon, which is what the timezone-aware formatting needs anyway
 - The admin cookie check for server actions and server components is one `isAdminRequest` in
   `utils/acting-admin.ts`, the counterpart to `utils/acting-guest.ts`, instead of the same private
   helper copied into all eleven admin action modules, the admin layout and `require-admin.ts`

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useState, useContext } from "react";
-import { format } from "date-fns";
 import { DateTime } from "luxon";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
@@ -10,7 +9,9 @@ import { SelectHosts } from "@/app/select-hosts";
 import {
   convertParamDateTime,
   dateOnDay,
+  formatDayLabel,
   formatDuration,
+  formatSlotLabel,
   durationMinusBreak,
   TIME_FORMAT,
 } from "@/utils/utils";
@@ -453,7 +454,7 @@ export function SessionForm(props: {
           Day
           <RequiredStar />
         </label>
-        <SelectDay days={days} day={day} setDay={setDay} />
+        <SelectDay days={days} day={day} setDay={setDay} timezone={timezone} />
       </div>
       <div className="flex flex-col gap-1 w-72">
         <label className="font-medium">
@@ -582,13 +583,14 @@ function getAvailableStartTimes(
     t < day.endBookings.getTime();
     t += slotIncrementMinutes * 60 * 1000
   ) {
-    const dt = DateTime.fromMillis(t).setZone(timezone);
     // The break sits at the start of each slot, so the displayed start is
     // pushed back by breakMinutes (e.g. a 9:00 slot shows as 9:10). The slot
     // itself stays on the round boundary.
-    const formattedTime = dt
-      .plus({ minutes: breakMinutes })
-      .toFormat(TIME_FORMAT);
+    const formattedTime = formatSlotLabel(
+      new Date(t + breakMinutes * 60 * 1000),
+      day.start,
+      timezone
+    );
     if (locationSelected) {
       const sessionNow = sortedSessions.find(
         (session) =>
@@ -674,13 +676,14 @@ function SelectDay(props: {
   days: Day[];
   day: Day;
   setDay: (day: Day) => void;
+  timezone: string;
 }) {
-  const { days, day, setDay } = props;
+  const { days, day, setDay, timezone } = props;
   return (
     <fieldset>
       <div className="space-y-4">
         {days.map((d) => {
-          const formattedDay = format(d.start, "EEEE, MMMM d");
+          const formattedDay = formatDayLabel(d, timezone);
           return (
             <div key={d.id} className="flex items-center">
               <input

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@tailwindcss/forms": "^0.5.11",
         "better-sqlite3": "^13.0.3",
         "clsx": "^2.1.1",
-        "date-fns": "^4.4.0",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.45.2",
         "fuse.js": "^7.5.0",
@@ -705,8 +704,6 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
-
-    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "better-sqlite3": "^13.0.3",
     "clsx": "^2.1.1",
-    "date-fns": "^4.4.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "fuse.js": "^7.5.0",

--- a/tests/e2e/scheduling.spec.ts
+++ b/tests/e2e/scheduling.spec.ts
@@ -142,6 +142,36 @@ test("a session booked after midnight lands on the next calendar date", async ({
   ).toBeVisible();
 });
 
+test("a day running past midnight says so, and its late slots name the day", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await page.getByRole("link", { name: "Add session" }).first().click();
+  await expect(
+    page.getByRole("heading", { name: /Add a session/i })
+  ).toBeVisible();
+
+  // Gamma's last day runs 09:00 → 03:00; the earlier ones end at 18:00.
+  await expect(dayRadios(page).first()).toHaveAccessibleName(
+    /^[A-Z][a-z]+, [A-Z][a-z]+ \d+$/
+  );
+  await expect(dayRadios(page).last()).toHaveAccessibleName(
+    /\(until 03:00 [A-Z][a-z]{2}\)$/
+  );
+
+  await dayRadios(page).last().check();
+  await listboxButton(page, /^Start Time/).click();
+  // Times before midnight stand alone; the ones after it carry their weekday,
+  // so "01:10" can't be read as an hour earlier in the day than "23:10".
+  await expect(
+    page.getByRole("option", { name: "23:10", exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: /^[A-Z][a-z]{2} 01:10$/ })
+  ).toBeVisible();
+});
+
 test("occupied start times are not offered in the same location but are in others", async ({
   page,
 }) => {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -5,6 +5,8 @@ import {
   eventNameToSlug,
   normalizeWebsiteUrl,
   dateOnDay,
+  formatDayLabel,
+  formatSlotLabel,
   getPercentThroughDay,
   getStartTimePlusBreak,
   votesApiUrl,
@@ -152,6 +154,83 @@ describe("dateOnDay", () => {
 
   it("returns false when date is after the day", () =>
     expect(dateOnDay(new Date("2025-06-15T18:00:01Z"), DAY)).toBe(false));
+});
+
+// ── formatDayLabel ───────────────────────────────────────────────────────────
+
+describe("formatDayLabel", () => {
+  const dayIn = (start: string, end: string): Day => ({
+    ...DAY,
+    start: new Date(start),
+    end: new Date(end),
+  });
+
+  // Asserted under two zones because the test runner's own zone is not pinned:
+  // reading the same instant in Berlin and in New York lands on either side of
+  // midnight, so a label built from the ambient zone fails one of the two
+  // wherever the suite runs.
+  it("names the weekday and date in the event's zone, not the runner's", () => {
+    const day = dayIn("2025-06-15T23:30:00Z", "2025-06-16T15:00:00Z");
+    expect(formatDayLabel(day, "Europe/Berlin")).toBe("Monday, June 16");
+    expect(formatDayLabel(day, "America/New_York")).toBe(
+      "Sunday, June 15 (until 11:00 Mon)"
+    );
+  });
+
+  it("adds no suffix for a day that ends on its own date", () =>
+    expect(
+      formatDayLabel(
+        dayIn("2025-06-15T07:00:00Z", "2025-06-15T16:00:00Z"),
+        "Europe/Berlin"
+      )
+    ).toBe("Sunday, June 15"));
+
+  it("says where a day ends when it runs past midnight", () =>
+    expect(
+      formatDayLabel(
+        dayIn("2025-06-13T07:00:00Z", "2025-06-14T01:00:00Z"),
+        "Europe/Berlin"
+      )
+    ).toBe("Friday, June 13 (until 03:00 Sat)"));
+
+  it("treats a day ending exactly at midnight as not spilling over", () =>
+    expect(
+      formatDayLabel(
+        dayIn("2025-06-13T07:00:00Z", "2025-06-13T22:00:00Z"),
+        "Europe/Berlin"
+      )
+    ).toBe("Friday, June 13"));
+});
+
+// ── formatSlotLabel ──────────────────────────────────────────────────────────
+
+describe("formatSlotLabel", () => {
+  const dayStart = new Date("2025-06-13T07:00:00Z"); // 09:00 Berlin
+
+  it("shows the time alone for a slot on the day's own date", () =>
+    expect(
+      formatSlotLabel(
+        new Date("2025-06-13T21:10:00Z"),
+        dayStart,
+        "Europe/Berlin"
+      )
+    ).toBe("23:10"));
+
+  it("decides the date in the event's zone, not the runner's", () => {
+    const slot = new Date("2025-06-13T23:10:00Z");
+    expect(formatSlotLabel(slot, dayStart, "Europe/Berlin")).toBe("Sat 01:10");
+    // Still the 13th in New York, where the day started at 03:00.
+    expect(formatSlotLabel(slot, dayStart, "America/New_York")).toBe("19:10");
+  });
+
+  it("prefixes the weekday once the slot falls on the next date", () =>
+    expect(
+      formatSlotLabel(
+        new Date("2025-06-13T23:10:00Z"),
+        dayStart,
+        "Europe/Berlin"
+      )
+    ).toBe("Sat 01:10"));
 });
 
 // ── getPercentThroughDay ─────────────────────────────────────────────────────

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -33,6 +33,40 @@ export const convertParamDateTime = (
   return DateTime.fromISO(`${date}T${time}:00`, { zone: timezone }).toJSDate();
 };
 
+/**
+ * How a day is named where one has to be picked: "Friday, June 13", and for a
+ * day whose window runs past midnight the hour it ends — "Friday, June 13
+ * (until 03:00 Sat)". Without that suffix nothing tells a host which of two
+ * adjacent days owns 01:00.
+ */
+export function formatDayLabel(day: Day, timezone: string): string {
+  const start = DateTime.fromJSDate(day.start).setZone(timezone);
+  const end = DateTime.fromJSDate(day.end).setZone(timezone);
+  const label = start.toFormat("EEEE, MMMM d");
+  // Strictly past midnight, not merely a different date: a day ending at
+  // exactly 00:00 has no hours on the next date to explain.
+  const spillsOver = end > start.startOf("day").plus({ days: 1 });
+  return spillsOver
+    ? `${label} (until ${end.toFormat(TIME_FORMAT)} ${end.toFormat("EEE")})`
+    : label;
+}
+
+/**
+ * How a start time is offered: the clock time alone, or "Sat 01:10" once the
+ * slot has crossed into the next date — on a day running past midnight the
+ * times restart from 00:00, which otherwise reads as an earlier slot.
+ */
+export function formatSlotLabel(
+  slot: Date,
+  dayStart: Date,
+  timezone: string
+): string {
+  const dt = DateTime.fromJSDate(slot).setZone(timezone);
+  const start = DateTime.fromJSDate(dayStart).setZone(timezone);
+  const time = dt.toFormat(TIME_FORMAT);
+  return dt.hasSame(start, "day") ? time : `${dt.toFormat("EEE")} ${time}`;
+}
+
 export const dateOnDay = (date: Date, day: Day) => {
   return (
     date.getTime() >= day.start.getTime() && date.getTime() <= day.end.getTime()


### PR DESCRIPTION
A day running 09:00–03:00 sits next to one starting at 09:00 the next
morning, and nothing in the form said which of them owns 01:00 — the day
labels showed a bare date, and the start times restarted at 00:00 as if they
came before the evening ones. Labels now name the hour a day runs to, late
slots carry their weekday, and both are formatted in the event's timezone
rather than the reader's.

That was date-fns' last import, so it leaves with it.

issue schellingboard/schellingboard#698

<!-- jip:pushed-commit=864c9f9febf5312853635f59aca9e0e9f498f53a -->