### PR TITLE
fix: hold a self-booked session to the event's maximum duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   closed, running on into the hours you kept for yourself, or off the schedule grid. The day is now looked up in the
   site's own records and the session required to start and finish inside its booking window. Organizers are
   unaffected: the admin pages place sessions as before
+- **A booked session can't outlast the event's maximum**: the length also came from the form and was never rechecked,
+  so a hand-crafted request could hold a room for the whole booking window. Hosts booking for themselves are now held
+  to the longest duration the form offers
 
 ### Internal
 

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -9,6 +9,7 @@ import {
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
 import { sessionBookingWindowError } from "@/utils/day-window";
+import { sessionDurationError } from "@/utils/slots";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
@@ -43,6 +44,15 @@ export async function POST(req: NextRequest) {
   );
   if (windowError) {
     return Response.json({ error: windowError }, { status: 400 });
+  }
+  const durationError = sessionDurationError(
+    input.startTime!,
+    input.endTime!,
+    event.slotIncrementMinutes,
+    event.maxSessionDuration
+  );
+  if (durationError) {
+    return Response.json({ error: durationError }, { status: 400 });
   }
   const eventGuestIds = new Set(
     (await repos.guests.listByEvent(event.id)).map((g) => g.id)

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/utils/notifications";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { sessionBookingWindowError } from "@/utils/day-window";
+import { sessionDurationError } from "@/utils/slots";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
@@ -54,6 +55,15 @@ export async function POST(req: NextRequest) {
   );
   if (windowError) {
     return Response.json({ error: windowError }, { status: 400 });
+  }
+  const durationError = sessionDurationError(
+    input.startTime!,
+    input.endTime!,
+    event.slotIncrementMinutes,
+    event.maxSessionDuration
+  );
+  if (durationError) {
+    return Response.json({ error: durationError }, { status: 400 });
   }
   const actor = await verifiedCurrentUser(req.cookies);
   if (!actor || !prevSession.hosts.some((h) => h.id === actor)) {

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -209,6 +209,31 @@ describe("POST /api/add-session", () => {
     expect(sessions).toHaveLength(0);
   });
 
+  it("rejects a session longer than the event allows", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const day = await createDay(event.id);
+
+    // Three hours, where the event's maximum is two.
+    const res = await POST(
+      makeReq(
+        buildPayload(guest, location, day, {
+          startTime: slotStart(day, 60),
+          duration: 180,
+        })
+      )
+    );
+    expect(res.status).toBe(400);
+    // Named, so the rejection can't be mistaken for the booking-window rule.
+    expect(await res.json()).toEqual({
+      error: "Sessions can last at most 120 minutes",
+    });
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(0);
+  });
+
   it("rejects times that miss the day's slot grid", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -355,6 +355,37 @@ describe("POST /api/update-session", () => {
     expect(unchanged.startTime!.toISOString()).toBe(slotStart(day, 60));
   });
 
+  it("rejects stretching a session beyond the event's maximum duration", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day, {
+      startTime: slotStart(day, 60),
+    });
+
+    const res = await POST(
+      makeUpdateReq(
+        {
+          // Three hours, where the event's maximum is two.
+          ...basePayload(host, location, day, { duration: 180 }),
+          id,
+        },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.status).toBe(400);
+    // Named, so the rejection can't be mistaken for the booking-window rule.
+    expect(await res.json()).toEqual({
+      error: "Sessions can last at most 120 minutes",
+    });
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.endTime!.getTime() - unchanged.startTime!.getTime()).toBe(
+      60 * 60 * 1000
+    );
+  });
+
   it("rejects a host who is not part of the event", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });

--- a/tests/unit/slots.test.ts
+++ b/tests/unit/slots.test.ts
@@ -6,6 +6,7 @@ import {
   getNumSlots,
   getNowOffsetPx,
   isSlotAligned,
+  sessionDurationError,
   slotDurationOptions,
   snapDurationToSlots,
 } from "@/utils/slots";
@@ -117,6 +118,29 @@ describe("slotDurationOptions", () => {
 
   it("max below the increment still offers one slot", () => {
     expect(slotDurationOptions(45, 30)).toEqual([45]);
+  });
+});
+
+// ── sessionDurationError ─────────────────────────────────────────────────────
+
+describe("sessionDurationError", () => {
+  const at = (h: number, m = 0) => new Date(Date.UTC(2026, 8, 1, h, m));
+
+  it("accepts a duration the form offers", () => {
+    expect(sessionDurationError(at(9), at(11), 30, 120)).toBeNull();
+  });
+
+  it("rejects one longer than the event allows", () => {
+    expect(sessionDurationError(at(9), at(11, 30), 30, 120)).toMatch(/120/);
+  });
+
+  it("allows only whole slots: 45-min slots cap 120 at 90", () => {
+    expect(sessionDurationError(at(9), at(10, 30), 45, 120)).toBeNull();
+    expect(sessionDurationError(at(9), at(11), 45, 120)).toMatch(/90/);
+  });
+
+  it("a maximum below the increment still allows one slot", () => {
+    expect(sessionDurationError(at(9), at(9, 45), 45, 30)).toBeNull();
   });
 });
 

--- a/utils/slots.ts
+++ b/utils/slots.ts
@@ -70,6 +70,28 @@ export function slotDurationOptions(
 }
 
 /**
+ * Why a self-booked session is too long, or null. The form only offers the
+ * durations above, so anything longer is a hand-crafted payload claiming more
+ * of a room than the event allows.
+ *
+ * An interval of invalid dates compares false here and passes, so callers must
+ * have rejected those already — `sessionBookingWindowError` runs first and does.
+ */
+export function sessionDurationError(
+  start: Date,
+  end: Date,
+  incrementMinutes: number,
+  maxSessionDuration: number
+): string | null {
+  const options = slotDurationOptions(incrementMinutes, maxSessionDuration);
+  const longest = options[options.length - 1];
+  const minutes = (end.getTime() - start.getTime()) / MS_PER_MINUTE;
+  return minutes > longest
+    ? `Sessions can last at most ${longest} minutes`
+    : null;
+}
+
+/**
  * Snap a free-form duration (e.g. from a proposal) to the nearest selectable
  * option. Ties round up so the session gets at least the proposed time.
  */


### PR DESCRIPTION
The duration came from the form and was never rechecked, so a hand-crafted
request could hold a bookable room for the whole booking window. Both session
routes now measure the interval against the longest duration the form offers —
derived from slotDurationOptions so the two cannot drift apart. Organizers are
unconstrained as before; the admin entry points do not call this.

<!-- jip:pushed-commit=ad004a468fc63f5c40bebaa3df29addbbf1b52ca -->