### PR TITLE
refactor: authorize the session editor before judging their payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The admin cookie check for server actions and server components is one `isAdminRequest` in
   `utils/acting-admin.ts`, the counterpart to `utils/acting-guest.ts`, instead of the same private
   helper copied into all eleven admin action modules, the admin layout and `require-admin.ts`
+- `update-session` establishes that the caller hosts the session before it judges the times sent
+  with the request, so a stranger gets `403 Only a host may edit this session` rather than a
+  complaint about the booking window
 
 ## [3.4.2] - 2026-08-24
 

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -47,6 +47,13 @@ export async function POST(req: NextRequest) {
   if (prevSession.adminManaged || prevSession.blocker) {
     return new Response("Cannot edit via web app", { status: 400 });
   }
+  const actor = await verifiedCurrentUser(req.cookies);
+  if (!actor || !prevSession.hosts.some((h) => h.id === actor)) {
+    return Response.json(
+      { error: "Only a host may edit this session" },
+      { status: 403 }
+    );
+  }
   const windowError = sessionBookingWindowError(
     day,
     input.startTime!,
@@ -64,13 +71,6 @@ export async function POST(req: NextRequest) {
   );
   if (durationError) {
     return Response.json({ error: durationError }, { status: 400 });
-  }
-  const actor = await verifiedCurrentUser(req.cookies);
-  if (!actor || !prevSession.hosts.some((h) => h.id === actor)) {
-    return Response.json(
-      { error: "Only a host may edit this session" },
-      { status: 403 }
-    );
   }
   const eventGuestIds = new Set(
     (await repos.guests.listByEvent(event.id)).map((g) => g.id)

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -386,6 +386,32 @@ describe("POST /api/update-session", () => {
     );
   });
 
+  it("turns a non-host away before judging the times they sent", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const stranger = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        {
+          ...basePayload(host, location, day, {
+            startTime: slotStart(day, 12 * 60),
+          }),
+          id,
+        },
+        { editorGuestId: stranger.id }
+      )
+    );
+    expect(res.status).toBe(403);
+    // Named, so it can't pass on one of the handler's other 403s.
+    expect(await res.json()).toEqual({
+      error: "Only a host may edit this session",
+    });
+  });
+
   it("rejects a host who is not part of the event", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });


### PR DESCRIPTION
The window and duration checks ran ahead of the host check, so someone who
does not host the session learned whether the times they made up were valid
and got a 400 about the booking window instead of a 403.

<!-- jip:pushed-commit=fba97f196a50a9f39f2c321c68b0a96f3e6ce954 -->