### PR TITLE
fix: turn away a day id that is not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `update-session` establishes that the caller hosts the session before it judges the times sent
   with the request, so a stranger gets `403 Only a host may edit this session` rather than a
   complaint about the booking window
+- The session routes check that the day id they were sent is a string before looking it up: any
+  other JSON value reached the query as an unbindable parameter and failed the request as a server
+  error
 
 ## [3.4.2] - 2026-08-24
 

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -21,7 +21,12 @@ export async function POST(req: NextRequest) {
   }
   const params = (await req.json()) as SessionParams;
   const repos = getRepositories();
-  const day = await repos.days.findById(params.dayId);
+  // Anything but a string reaches the query as an unbindable parameter, which
+  // fails as a server error rather than a rejected request.
+  const day =
+    typeof params.dayId === "string"
+      ? await repos.days.findById(params.dayId)
+      : undefined;
   if (!day) {
     return Response.json(
       { error: "That day is no longer part of this event" },

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -21,7 +21,12 @@ export async function POST(req: NextRequest) {
     return new Response("Session ID is required", { status: 400 });
   }
   const repos = getRepositories();
-  const day = await repos.days.findById(params.dayId);
+  // Anything but a string reaches the query as an unbindable parameter, which
+  // fails as a server error rather than a rejected request.
+  const day =
+    typeof params.dayId === "string"
+      ? await repos.days.findById(params.dayId)
+      : undefined;
   if (!day) {
     return Response.json(
       { error: "That day is no longer part of this event" },

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -251,6 +251,32 @@ describe("POST /api/add-session", () => {
     expect(sessions).toHaveLength(0);
   });
 
+  // The driver refuses to bind an object, an array or a boolean, so these used
+  // to reach it and crash the route instead of being turned away; a number or
+  // null binds fine and simply finds no day. Each case is wrapped because
+  // `it.each` spreads a bare array over the arguments.
+  it.each([[{}], [[]], [true]])(
+    "rejects a day id that is not one: %o",
+    async (id) => {
+      const event = await createEvent({ phase: "scheduling" });
+      const guest = await createGuest({ eventId: event.id });
+      const location = await createLocation({ eventId: event.id });
+      const day = await createDay(event.id);
+
+      const res = await POST(
+        makeReq(
+          buildPayload(guest, location, day, {
+            dayId: id as unknown as string,
+          })
+        )
+      );
+      expect(res.status).toBe(400);
+
+      const sessions = await getRepositories().sessions.listByEvent(event.id);
+      expect(sessions).toHaveLength(0);
+    }
+  );
+
   it("rejects a day that does not exist", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -386,6 +386,27 @@ describe("POST /api/update-session", () => {
     );
   });
 
+  it("rejects a day id that is not one", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        {
+          ...basePayload(host, location, day, {
+            dayId: {} as unknown as string,
+          }),
+          id,
+        },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("turns a non-host away before judging the times they sent", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });


### PR DESCRIPTION
A JSON object as dayId reached better-sqlite3 as an unbindable parameter and
threw out of the route handler, so a malformed request came back as a server
error instead of a rejected one.

<!-- jip:pushed-commit=c003948bf5838c0ed2bbc40b231770552a5d4ea0 -->