### PR TITLE
fix: give every "back to X" link the shared BackLink style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Moving between attendee profiles slides instead of jumping**: Prev, Next and the arrow keys now slide one profile
   out as the next slides in, the way a swipe already moves between them
 
+### Changed
+
+- **"Back to ..." links look the same everywhere**: on the session form, the proposal form and the user import page
+  they were red buttons or gray buttons that competed with the page's real action. All of them are now the same quiet
+  "← Proposals" style already used elsewhere
+
 ### Fixed
 
 - **The session form shows which day owns the small hours**: a day that runs past midnight is now labelled with the

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { cookies } from "next/headers";
+import { BackLink } from "@/app/components/back-link";
 import { getRepositories } from "@/db/container";
 import { SessionProposalForm } from "@/app/(site)/[eventSlug]/session-proposal-form";
 import {
@@ -11,13 +11,8 @@ import { notFound } from "next/navigation";
 function CantEdit(props: { eventSlug: string; children: React.ReactNode }) {
   return (
     <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
+      <BackLink href={`/${props.eventSlug}/proposals`}>Proposals</BackLink>
       <p className="text-fg-muted">{props.children}</p>
-      <Link
-        href={`/${props.eventSlug}/proposals`}
-        className="bg-brand text-on-brand font-semibold py-2 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
-      >
-        Back to proposals
-      </Link>
     </div>
   );
 }

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -34,6 +34,7 @@ import { buildSessionInterval } from "@/app/api/session-form-utils";
 import { revalidateEvent } from "./session-actions";
 import { detectHostClashes, type HostClash } from "./clash-actions";
 import { MarkdownHint } from "@/app/(site)/markdown";
+import { BackLink } from "@/app/components/back-link";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
 
 interface ErrorResponse {
@@ -348,12 +349,7 @@ export function SessionForm(props: {
 
   return (
     <div className="flex flex-col gap-4">
-      <Link
-        className="bg-brand text-on-brand font-semibold py-2 px-4 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
-        href={`/${event.slug}`}
-      >
-        Back to schedule
-      </Link>
+      <BackLink href={`/${event.slug}`}>Schedule</BackLink>
       <div>
         <h2 className="text-2xl font-bold">
           {eventName}: {sessionID ? "Edit" : "Add a"} session

--- a/app/(site)/[eventSlug]/session-proposal-form.tsx
+++ b/app/(site)/[eventSlug]/session-proposal-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useContext, useMemo, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { Input } from "@/app/input";
@@ -21,6 +20,7 @@ import { useController, useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { sessionProposalSchema } from "@/model/session";
 import { z } from "zod";
+import { BackLink } from "@/app/components/back-link";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
 import { FormErrorSummary } from "@/app/components/form-error-summary";
 import { setActionErrors } from "@/utils/forms";
@@ -120,12 +120,7 @@ export function SessionProposalForm(props: {
 
   return (
     <div className="flex flex-col gap-4">
-      <Link
-        className="bg-brand text-on-brand font-semibold py-2 px-4 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
-        href={`/${eventSlug}/proposals`}
-      >
-        Back to Proposals
-      </Link>
+      <BackLink href={`/${eventSlug}/proposals`}>Proposals</BackLink>
       <div>
         <h2 className="text-2xl font-bold">
           {proposal ? "Edit" : "Add"} Session Proposal

--- a/app/admin/users/import/page.tsx
+++ b/app/admin/users/import/page.tsx
@@ -1,3 +1,4 @@
+import { BackLink } from "@/app/components/back-link";
 import { getRepositories } from "@/db/container";
 import { requireAdminPage } from "../../require-admin";
 import { UserImportForm } from "./user-import-form";
@@ -9,6 +10,9 @@ export default async function AdminUserImportPage() {
 
   return (
     <div className="w-full max-w-3xl mx-auto space-y-6">
+      <div>
+        <BackLink href="/admin/users">Users</BackLink>
+      </div>
       <h1 className="text-2xl font-bold text-fg">Import users</h1>
       <p className="text-sm text-fg-muted">
         Upload a CSV file with a header row containing <code>name</code> and{" "}

--- a/app/admin/users/import/user-import-form.tsx
+++ b/app/admin/users/import/user-import-form.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import Link from "next/link";
 import { SelectHosts } from "@/app/select-hosts";
 import {
   importGuestsAction,
   type ImportGuestsResult,
 } from "@/app/actions/admin-guest-import";
-import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "../../buttons";
+import { PRIMARY_BUTTON } from "../../buttons";
 
 type EventOption = { id: string; name: string };
 
@@ -87,18 +86,13 @@ export function UserImportForm({ events }: { events: EventOption[] }) {
         </p>
       )}
 
-      <div className="flex gap-2">
-        <button
-          type="submit"
-          disabled={isPending || !file}
-          className={PRIMARY_BUTTON}
-        >
-          {isPending ? "Importing..." : "Import"}
-        </button>
-        <Link href="/admin/users" className={SECONDARY_BUTTON}>
-          Back to users
-        </Link>
-      </div>
+      <button
+        type="submit"
+        disabled={isPending || !file}
+        className={PRIMARY_BUTTON}
+      >
+        {isPending ? "Importing..." : "Import"}
+      </button>
     </form>
   );
 }

--- a/tests/e2e/proposals.spec.ts
+++ b/tests/e2e/proposals.spec.ts
@@ -148,7 +148,7 @@ test("a non-host cannot edit or delete another guest's proposal", async ({
   await expect(
     page.getByRole("button", { name: "Your name: Bob Test" })
   ).toBeVisible();
-  await page.getByRole("link", { name: /Back to Proposals/i }).click();
+  await page.getByRole("link", { name: /← Proposals/i }).click();
   await page.waitForURL(/\/Conference-Alpha\/proposals$/);
   await expect(
     page.getByRole("row", { name: new RegExp(proposalTitle) })


### PR DESCRIPTION
A red, brand-coloured button for "go back" carries the same visual weight as
the page's real primary action.

fixes schellingboard/schellingboard#862

<!-- jip:pushed-commit=f14fa5c875d9ca0de2223c7ddea0ce157c8077b3 -->