### PR TITLE
fix: drop the extra top margin above the session form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **"Back to ..." links look the same everywhere**: on the session form, the proposal form and the user import page
   they were red buttons or gray buttons that competed with the page's real action. All of them are now the same quiet
   "← Proposals" style already used elsewhere
+- **The session form starts where every other form does**: the add and edit session pages left an empty band above the
+  form that no other page has
 
 ### Fixed
 

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -32,7 +32,7 @@ export async function renderSessionForm(props: {
   const proposals = currentUserProposals.concat(hostlessProposals);
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <div className="max-w-2xl mx-2 sm:mx-auto mt-20 mb-6 sm:mb-24">
+      <div className="max-w-2xl mx-auto px-4 sm:px-0 mb-6 sm:mb-24">
         <SessionForm
           event={event}
           days={days}


### PR DESCRIPTION
The page added mt-20 on top of the layout's own pt-20/sm:pt-24, so the add
and edit session forms started 80px lower than every other form.

<!-- jip:pushed-commit=481912089eaeb13c3a8a13bfdd5c54d07568675e -->