### PR TITLE
fix: make what a room offers findable, and readable on a phone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **What a room offers is easier to find**: room names on the schedule grid that have a description now carry an ⓘ,
+  and tapping or hovering the name opens it. Before, the description only appeared when a mouse happened to rest on
+  the name, with nothing to suggest it was there, and on a phone it was cut off at the edge of the screen
 - **"Back to ..." links look the same everywhere**: on the session form, the proposal form and the user import page
   they were red buttons or gray buttons that competed with the page's real action. All of them are now the same quiet
   "← Proposals" style already used elsewhere

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -7,6 +7,7 @@ import { getNumSlots, getNowOffsetPx } from "@/utils/slots";
 import { useKioskMode } from "./kiosk";
 import { useContext } from "react";
 import Image from "next/image";
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { Tooltip } from "./tooltip";
 import { DateTime } from "luxon";
 import type { Guest, Location } from "@/db/repositories/interfaces";
@@ -68,25 +69,39 @@ export function DayGrid(props: {
         </span>
       </div>
       {includedLocations.map((loc) => (
-        <Tooltip
+        <div
           key={loc.name}
-          content={
-            loc.description ? (
-              <div className="p-2 space-y-1">
-                <p className="text-xs font-semibold text-fg-muted">
-                  {loc.name}
-                </p>
-                <p className="text-sm">{loc.description}</p>
-              </div>
-            ) : undefined
-          }
-          placement="bottom-start"
-          className="sticky top-0 z-20 bg-surface border-b border-l border-line-subtle"
+          className="sticky top-0 z-20 bg-surface border-b border-l border-line-subtle p-1"
         >
-          <div className="p-1 h-full">
-            <h3 className="font-semibold text-xs sm:text-sm">{loc.name}</h3>
-          </div>
-        </Tooltip>
+          {/* What a room offers (projector, whiteboard, …) is behind its name.
+              The ⓘ is the only hint that there is anything to open, so it goes
+              in the button itself, where a tap or a hover finds it. */}
+          <h3 className="font-semibold text-xs sm:text-sm">
+            <Tooltip
+              toggleable
+              content={
+                loc.description ? (
+                  <div className="p-2 space-y-1">
+                    <p className="text-xs font-semibold text-fg-muted">
+                      {loc.name}
+                    </p>
+                    <p className="text-sm">{loc.description}</p>
+                  </div>
+                ) : undefined
+              }
+              placement="bottom-start"
+              triggerClassName="flex items-start gap-0.5 text-left rounded-sm hover:text-brand-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent"
+            >
+              {loc.name}
+              {loc.description && (
+                <InformationCircleIcon
+                  className="mt-px h-3 w-3 shrink-0 text-fg-subtle sm:h-3.5 sm:w-3.5"
+                  aria-hidden
+                />
+              )}
+            </Tooltip>
+          </h3>
+        </div>
       ))}
       {/* Row 2 — room description */}
       <div className="sticky top-0 z-20 bg-surface border-r border-line-subtle" />

--- a/app/(site)/[eventSlug]/tooltip.tsx
+++ b/app/(site)/[eventSlug]/tooltip.tsx
@@ -3,11 +3,15 @@ import {
   arrow,
   autoUpdate,
   flip,
+  FloatingPortal,
   offset,
   Placement,
   safePolygon,
   shift,
+  useClick,
+  useDismiss,
   useFloating,
+  useFocus,
   useHover,
   useInteractions,
   useRole,
@@ -21,20 +25,28 @@ export function Tooltip(props: {
   content?: ReactNode;
   children: ReactNode;
   className?: string;
+  triggerClassName?: string;
   placement?: Placement;
   noTap?: boolean;
   noFade?: boolean;
   hasSafePolygon?: boolean;
   suppressHydrationWarning?: boolean;
+  // For content worth seeking out rather than a hover-only nicety: the trigger
+  // becomes a real button, so it can be tapped or reached by keyboard, and the
+  // panel closes again on Escape or a press outside. The wrapper turns inline
+  // and the panel moves to a portal, so the trigger may sit inside a heading.
+  toggleable?: boolean;
 }) {
   const {
     content,
     children,
     className,
+    triggerClassName,
     noTap,
     noFade,
     hasSafePolygon,
     suppressHydrationWarning,
+    toggleable,
   } = props;
 
   const arrowRef = useRef(null);
@@ -63,9 +75,15 @@ export function Tooltip(props: {
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context, {
-      mouseOnly: noTap,
+      // A tap on a toggleable trigger has to go through useClick alone. A
+      // touch also fires a synthetic hover, and a panel opened by that hover
+      // is not one useClick will close, so the next tap does nothing.
+      mouseOnly: noTap || toggleable,
       handleClose: hasSafePolygon ? safePolygon({ buffer: -0.5 }) : null,
     }),
+    useFocus(context, { enabled: !!toggleable }),
+    useClick(context, { enabled: !!toggleable }),
+    useDismiss(context, { enabled: !!toggleable }),
     useRole(context, { role: "tooltip" }),
   ]);
   // which side of tooltip arrow is on. like: if tooltip is top-left, arrow is on bottom of tooltip
@@ -76,52 +94,63 @@ export function Tooltip(props: {
     left: "right",
   }[placement.split("-")[0]] as string;
 
+  const Wrapper = toggleable ? "span" : "div";
+  const Trigger = toggleable ? "button" : "span";
+
+  const panel = (
+    <Transition
+      show={open}
+      enter="transition ease-out duration-50"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave={noFade ? "" : "transition ease-in duration-150"}
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+      as="div"
+      // refs.setFloating is a callback ref from useFloating; assigning it
+      // here is the documented Floating UI pattern.
+      ref={(node) => {
+        refs.setFloating(node);
+      }}
+      role="tooltip"
+      style={{ position: strategy, top: y ?? 0, left: x ?? 0 }}
+      // Never wider than the screen it has to fit on: a fixed width leaves
+      // shift() nothing to work with and the text runs off a phone's edge.
+      className="z-40 w-[min(30rem,calc(100vw-1rem))] whitespace-normal rounded bg-surface-raised px-2 py-1 border shadow-md border-line-subtle"
+      suppressHydrationWarning={suppressHydrationWarning}
+      {...getFloatingProps()}
+    >
+      {content}
+      <div
+        ref={arrowRef}
+        className="absolute h-2 w-2 rotate-45 bg-surface-raised"
+        style={{
+          top: arrowY != null ? arrowY : "",
+          left: arrowX != null ? arrowX : "",
+          right: "",
+          bottom: "",
+          [arrowSide]: "-4px",
+        }}
+      />
+    </Transition>
+  );
+
   return content ? (
-    <div className={className}>
-      <span
+    <Wrapper className={className}>
+      <Trigger
+        type={toggleable ? "button" : undefined}
+        className={triggerClassName}
         suppressHydrationWarning={suppressHydrationWarning}
-        ref={(node) => {
+        ref={(node: HTMLElement | null) => {
           refs.setReference(node);
         }}
         {...getReferenceProps()}
       >
         {children}
-      </span>
-      <Transition
-        show={open}
-        enter="transition ease-out duration-50"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave={noFade ? "" : "transition ease-in duration-150"}
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-        as="div"
-        // refs.setFloating is a callback ref from useFloating; assigning it
-        // here is the documented Floating UI pattern.
-        ref={(node) => {
-          refs.setFloating(node);
-        }}
-        role="tooltip"
-        style={{ position: strategy, top: y ?? 0, left: x ?? 0 }}
-        className="z-40 max-w-lg w-120 whitespace-normal rounded bg-surface-raised px-2 py-1 border shadow-md border-line-subtle"
-        suppressHydrationWarning={suppressHydrationWarning}
-        {...getFloatingProps()}
-      >
-        {content}
-        <div
-          ref={arrowRef}
-          className="absolute h-2 w-2 rotate-45 bg-surface-raised"
-          style={{
-            top: arrowY != null ? arrowY : "",
-            left: arrowX != null ? arrowX : "",
-            right: "",
-            bottom: "",
-            [arrowSide]: "-4px",
-          }}
-        />
-      </Transition>
-    </div>
+      </Trigger>
+      {toggleable ? <FloatingPortal>{panel}</FloatingPortal> : panel}
+    </Wrapper>
   ) : (
-    <div className={className}>{children}</div>
+    <Wrapper className={className}>{children}</Wrapper>
   );
 }

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -109,6 +109,9 @@ Proposing and voting close.
 
 ![Simple scheduling grid with rooms as columns and time slots as rows](../screenshots/schedule-grid.webp)
 
+A room name with an **ⓘ** next to it has more to say — tap it (or hover it)
+to read what the room offers: projector, whiteboard, the kind of seating.
+
 ### Put a proposal on the schedule
 
 Two ways, whichever you find first:

--- a/docs/public/organizers/admin-guide.md
+++ b/docs/public/organizers/admin-guide.md
@@ -61,7 +61,9 @@ Locations are a **global pool**, not per-event — one location can be
 assigned to multiple events. The event's "Locations" tab only
 assigns/unassigns from this pool; it doesn't create new ones.
 
-- **Name, Capacity, Description, Area description, Color** (schedule grid).
+- **Name, Capacity, Description, Area description, Color** (schedule grid). The
+  description is what a room offers (projector, whiteboard, seating); attendees
+  open it from the ⓘ next to the room name.
 - **Bookable** — whether attendees can self-book blank slots here. A location
   that isn't bookable still shows on the grid and you can schedule sessions
   into it yourself; attendees just can't pick it.

--- a/tests/e2e/schedule-layout.spec.ts
+++ b/tests/e2e/schedule-layout.spec.ts
@@ -159,6 +159,72 @@ test("the footer follows short content in the RSVP'd view on a phone", async ({
   expect(box.y + box.height).toBeLessThan(viewportHeight - 40);
 });
 
+// What a room offers (projector, whiteboard, …) lives in its description. The
+// room name in the grid header is the way in: a button, so it is reachable by
+// tap and by keyboard, not just by hovering a mouse.
+const MAIN_HALL_DETAIL = "projector and sound system";
+
+// Session blocks have tooltips of their own, and one of them can already be
+// open (the browser reports the cursor over a block as soon as the page
+// loads), so pick out the room's panel by its text.
+const roomDetails = (page: import("@playwright/test").Page) =>
+  page.getByRole("tooltip").filter({ hasText: MAIN_HALL_DETAIL });
+
+// Narrower than the 500px the rest of this file uses, because that is wide
+// enough for the panel's full 480px: only on a real phone does the width have
+// to give way, so only here does the fix show.
+test.describe("on a phone", () => {
+  test.use({ viewport: { width: 375, height: 800 } });
+
+  test("a room's details open on tap and stay on screen", async ({ page }) => {
+    const details = roomDetails(page);
+    await expect(details).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Main Hall" }).first().click();
+    await expect(details).toContainText(MAIN_HALL_DETAIL);
+
+    // The whole panel fits the phone screen — the point of the exercise, since
+    // a fixed-width one gets cut off at the edges.
+    const box = (await details.boundingBox())!;
+    const viewportWidth = page.viewportSize()!.width;
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth);
+
+    // Tapping the next room hands the panel over instead of leaving both open.
+    await page.getByRole("button", { name: "Workshop Room" }).first().click();
+    await expect(details).toHaveCount(0);
+    await expect(
+      page.getByRole("tooltip").filter({ hasText: "whiteboards" })
+    ).toBeVisible();
+  });
+
+  test("a room's details open from the keyboard and close on Escape", async ({
+    page,
+  }) => {
+    const details = roomDetails(page);
+    const roomName = page.getByRole("button", { name: "Main Hall" }).first();
+
+    await roomName.press("Enter");
+    await expect(details).toContainText(MAIN_HALL_DETAIL);
+
+    await roomName.press("Escape");
+    await expect(details).toHaveCount(0);
+  });
+});
+
+test.describe("on a wide screen", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("hovering a room name shows its details", async ({ page }) => {
+    const details = roomDetails(page);
+    await page.getByRole("button", { name: "Main Hall" }).first().hover();
+    await expect(details).toContainText(MAIN_HALL_DETAIL);
+
+    await page.mouse.move(0, 400);
+    await expect(details).toHaveCount(0);
+  });
+});
+
 test("dragging the schedule pans it sideways", async ({ page }) => {
   // The last location's header starts beyond the right edge of the viewport.
   // (Each day repeats the header row — the first one is the visible one.)


### PR DESCRIPTION
The room description only appeared when a mouse happened to rest on the
name, with nothing to suggest it was there, and the fixed 480px panel ran
off the edge of a phone screen. The name is now a button carrying an ⓘ,
opens on tap, click, hover or keyboard focus, and the panel never grows
wider than the screen.

fixes schellingboard/schellingboard#854

<!-- jip:pushed-commit=5d2910db0c1be49adcf05c8d1f85588d284ebd34 -->