### PR TITLE
test: wait for the state an E2E test expects instead of sampling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- E2E tests no longer decide what to assert from a single `isVisible()` sample (quick voting, the
+  voting-disabled state, admin login, the RSVP capacity test). Each now waits for the state it
+  expects, and the RSVP capacity test books a slot that overlaps nothing, so whether it has to
+  confirm a clash warning no longer depends on what else is scheduled
 - The emoji, label and display order of a vote live only in `app/(site)/votes.ts`, and `VotesContext` exposes
   `proposalVoteLabel` beside `proposalVoteEmoji`. The choice→label mapping had been copied into three components, each
   free to drift from the emoji next to it

--- a/tests/e2e/rsvp.spec.ts
+++ b/tests/e2e/rsvp.spec.ts
@@ -116,11 +116,17 @@ test("a full session blocks further RSVPs when the event enforces capacity", asy
   // Hosts are prefilled with the selected user (Alice). Pick a fixed slot on
   // the last day that no other spec relies on, so parallel tests (e.g.
   // scheduling.spec.ts asserting free slots on day 1) never compete for it.
+  // 20:00–21:00 (offered as "20:10", slot plus break) also overlaps nothing
+  // else in *any* room: the seeded day ends at 17:00 and the other specs all
+  // book earlier. Bob can therefore hold no RSVP clashing with this session,
+  // so the RSVPs below never have to confirm a clash warning — an earlier
+  // slot would, since update-session.spec.ts RSVPs Bob to a 15:00 slot in a
+  // parallel worker.
   await dayRadios(page).last().check();
   await listboxButton(page, /^Location/).click();
   await page.getByRole("option", { name: /Workshop Room/ }).click();
   await listboxButton(page, /^Start Time/).click();
-  await page.getByRole("option", { name: "16:10" }).click();
+  await page.getByRole("option", { name: "20:10" }).click();
   await page.getByRole("button", { name: "Submit" }).click();
   // Let the post-submit navigation to the overview land fully before leaving
   // for /admin: aborting its in-flight RSC fetch logs a console error, which
@@ -193,15 +199,6 @@ test("a full session blocks further RSVPs when the event enforces capacity", asy
   await selectUser(page, /Bob Test/i);
   await openSession();
   await dialog.getByRole("button", { name: "RSVP", exact: true }).click();
-  // Bob may hold a seeded RSVP that overlaps the new session's slot, in
-  // which case a clash warning must be confirmed first.
-  const clashConfirm = page.getByRole("button", { name: "Yes" });
-  await expect(
-    dialog.getByRole("button", { name: "Un-RSVP" }).or(clashConfirm)
-  ).toBeVisible();
-  if (await clashConfirm.isVisible()) {
-    await clashConfirm.click();
-  }
   await expect(dialog.getByRole("button", { name: "Un-RSVP" })).toBeVisible();
   await closeSession();
 

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -8,9 +8,14 @@ const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
 async function adminLogin(page: Page) {
   await page.goto("/admin");
   // Already authenticated (cookie set earlier in the test): /admin redirects
-  // straight to the events list, with no login form.
-  if (await page.getByLabel("Password").isVisible()) {
-    await page.getByLabel("Password").fill(ADMIN_PASSWORD);
+  // straight to the events list, with no login form. Wait for whichever of
+  // the two landed before branching — a single isVisible() sample takes the
+  // "already logged in" branch on a login form that has yet to render.
+  const password = page.getByLabel("Password");
+  const eventsHeading = page.getByRole("heading", { name: "Events" });
+  await expect(password.or(eventsHeading)).toBeVisible();
+  if (await password.isVisible()) {
+    await password.fill(ADMIN_PASSWORD);
     await page.getByRole("button", { name: "Access Admin" }).click();
   }
   await expect(page).toHaveURL(/\/admin\/events$/);

--- a/tests/e2e/update-session.spec.ts
+++ b/tests/e2e/update-session.spec.ts
@@ -44,7 +44,10 @@ test("updating a session emails the RSVP'd guest and the added co-host", async (
   const title = `E2E Email Session ${Date.now()}`;
 
   // Charlie creates a session on the last event day (Garden Terrace 15:10 —
-  // a slot no other spec claims; see the note in scheduling.spec.ts).
+  // a slot no other spec claims; see the note in scheduling.spec.ts). Bob
+  // RSVPs to it below and never withdraws, so no parallel spec may make him
+  // RSVP anything overlapping this time in any room: he'd get a clash warning
+  // to confirm, here or there.
   await page.goto("/Conference-Gamma");
   await selectUser(page, /Charlie Test/i);
   await page.getByRole("link", { name: "Add session" }).first().click();

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -69,33 +69,27 @@ test("should navigate to quick voting and allow voting on proposals", async ({
   await expect(page).toHaveURL(/\/Conference-Beta\/proposals\/quick-voting$/);
   await expect(page.getByText(/Quick Voting/i)).toBeVisible();
 
-  // Verify voting progress is shown
-  await expect(page.getByText(/You have voted on/)).toBeVisible();
-
-  // Check if there's a proposal to vote on
+  // Bob always has something left to vote on: the three event-specific Beta
+  // proposals are seeded without any votes at all (see
+  // eventSpecificTitlePatterns in scripts/seed/data/templates.ts) and Bob
+  // hosts at most one of them.
+  const progress = page.getByText(/You have voted on \d+ \/ \d+ proposals/);
+  await expect(progress).toBeVisible();
+  const before = Number(/\d+/.exec((await progress.textContent()) ?? "")?.[0]);
   const interestedButton = page.getByRole("button", { name: /❤️ Interested/i });
+  await expect(interestedButton).toBeVisible();
 
-  // If there are proposals to vote on, vote on one
-  if (await interestedButton.isVisible()) {
-    // Vote "Interested" on the current proposal
-    await interestedButton.click();
+  await interestedButton.click();
 
-    // After voting, either a new proposal should appear or we should see completion message
-    const hasMoreProposals = await interestedButton
-      .isVisible({ timeout: 2000 })
-      .catch(() => false);
-    const completionMessage = await page
-      .getByText(/You have voted on all proposals/)
-      .isVisible({ timeout: 2000 })
-      .catch(() => false);
-
-    expect(hasMoreProposals || completionMessage).toBe(true);
-  } else {
-    // If no proposals to vote on, we should see the completion message
-    await expect(
-      page.getByText(/You have voted on all proposals/)
-    ).toBeVisible();
-  }
+  // The counter is this page's own state, updated optimistically — so it
+  // counts up by exactly one even when another worker votes as Bob too.
+  await expect(progress).toHaveText(
+    new RegExp(`You have voted on ${before + 1} / `)
+  );
+  // ...and the page moves on to the next proposal, or to the end of the queue.
+  await expect(
+    interestedButton.or(page.getByText(/You have voted on all proposals/))
+  ).toBeVisible();
 
   // Navigate back to proposals overview
   await page.getByRole("link", { name: /← Proposals/i }).click();
@@ -192,26 +186,24 @@ test("should show voting disabled state when not logged in as a user", async ({
   const firstProposalRow = page.getByRole("row").nth(1);
   await expect(firstProposalRow).toBeVisible();
 
-  // Check that voting buttons are disabled or not present for non-logged in users
-  // The buttons should either be disabled or not visible when no user is selected
-  const interestedButton = firstProposalRow.getByRole("button", { name: "❤️" });
-  const maybeButton = firstProposalRow.getByRole("button", { name: "⭐" });
-  const skipButton = firstProposalRow.getByRole("button", { name: "👋🏽" });
-
-  if (await interestedButton.isVisible()) {
-    // If buttons are visible, they should be disabled
-    await expect(interestedButton).toBeDisabled();
-    await expect(maybeButton).toBeDisabled();
-    await expect(skipButton).toBeDisabled();
-  }
-
-  // Check that the "Go to Quick Voting!" button is disabled
+  // Quick voting is offered but unavailable, and says why on hover.
   const quickVotingLink = page.getByRole("link", {
     name: /Go to Quick Voting!/i,
   });
-  if (await quickVotingLink.isVisible()) {
-    await expect(quickVotingLink).toHaveClass(/opacity-50|cursor-not-allowed/);
-  }
+  await expect(quickVotingLink).toHaveClass(/opacity-50|cursor-not-allowed/);
+  await expect(quickVotingLink).toHaveAttribute("aria-disabled", "true");
+
+  // Without a name selected there is nobody to vote as, so the per-proposal
+  // vote buttons are not rendered at all.
+  await expect(
+    firstProposalRow.getByRole("button", { name: "❤️" })
+  ).toHaveCount(0);
+  await expect(
+    firstProposalRow.getByRole("button", { name: "⭐" })
+  ).toHaveCount(0);
+  await expect(
+    firstProposalRow.getByRole("button", { name: "👋🏽" })
+  ).toHaveCount(0);
 });
 
 // Conference Gamma is in the scheduling phase, where the vote breakdown is


### PR DESCRIPTION
`if (await x.isVisible())` reads the DOM once: before hydration or during a
slow render the test takes the wrong branch and fails having done nothing
wrong. The voting-disabled test even asserted nothing at all, since the vote
buttons are never rendered without a selected name.

The RSVP capacity test now books 20:00-21:00 on the last day, late enough that
nothing overlaps it — neither a seeded session nor one a parallel spec creates,
update-session.spec.ts in particular, which leaves Bob RSVP'd to a 15:00 slot.
No guest can hold a clashing RSVP there, so the clash-warning branch is gone.

<!-- jip:pushed-commit=f1b446ef03b113fe12e881d2e60dfe4f507f65d3 -->