### PR TITLE
test: settle the page before reloading it, not after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- E2E tests settle the page before reloading it rather than after. The kiosk tests wait for the
+  dev clock's refresh to finish streaming, and the view-session test for the fetches the session
+  modal starts; a reload aborts whatever is still in flight, which logs the RSC-payload and
+  `NetworkError` failures the console guard fails on. Waiting only afterwards was too late
 - Mail E2E tests wait for the mail they triggered by its identity instead of counting how many
   match its subject. Mailpit answers a search with the newest 50 matches and keeps only the newest
   500 messages, so once a few suite runs had filled those the count of "Set your password" mails

--- a/tests/e2e/kiosk.spec.ts
+++ b/tests/e2e/kiosk.spec.ts
@@ -29,15 +29,27 @@ const duringGammaDayOne = DateTime.now()
 // wait for the simulated date to show so the override cookie is committed.
 async function setDevClock(page: Page, target: DateTime) {
   await expect(page.getByText("Dev clock")).toBeVisible();
-  await page
-    .getByLabel("Pick date and time")
-    .fill(target.toFormat("yyyy-MM-dd'T'HH:mm"));
+  // Applying the clock triggers a router.refresh(); a navigation started while
+  // its RSC payload is still streaming aborts it, which logs an RSC-payload
+  // error the console guard fails on. So wait for that very response, body and
+  // all — "networkidle" is both later and less certain, since Next goes on
+  // prefetching in the background. A refresh asks for RSC without the
+  // prefetch header, which is what tells it apart from those prefetches.
+  const [refreshed] = await Promise.all([
+    page.waitForResponse(
+      (res) =>
+        res.ok() &&
+        res.request().headers()["rsc"] === "1" &&
+        !res.request().headers()["next-router-prefetch"]
+    ),
+    page
+      .getByLabel("Pick date and time")
+      .fill(target.toFormat("yyyy-MM-dd'T'HH:mm")),
+  ]);
   // The toolbar prints the simulated instant in UTC; the calendar date is the
   // same as Berlin's for a 16:00 target, so match on the date alone.
   await expect(page.getByText(target.toFormat("yyyy-MM-dd"))).toBeVisible();
-  // Applying the clock triggers a router.refresh(); let its RSC fetch finish so
-  // a following navigation doesn't abort it (which logs an RSC-payload error).
-  await page.waitForLoadState("networkidle");
+  await refreshed.finished();
 }
 
 // Land the browser on `path` with the fake clock already inside Gamma's first

--- a/tests/e2e/view-session.spec.ts
+++ b/tests/e2e/view-session.spec.ts
@@ -17,6 +17,15 @@ test("hard-navigating to a session URL renders the modal without hydration error
     page.getByRole("dialog", { name: "Session details" })
   ).toBeVisible();
 
+  // Opening the modal starts fetches of its own (the RSVP counts, and Next's
+  // prefetches of the links it renders). Let them finish before reloading: the
+  // reload aborts whatever is still in flight, and Firefox reports an aborted
+  // fetch as an uncaught "NetworkError when attempting to fetch resource" that
+  // the console guard fails on. "networkidle" is discouraged in general, but a
+  // quiet network is the condition wanted here, and fixed waits of 1s and 3s
+  // in its place both flaked under parallel load.
+  await page.waitForLoadState("networkidle");
+
   // Reload with viewSession now in the URL. This is the "paste link" /
   // "refresh while modal is open" scenario — the page is server-rendered
   // with viewSession in the URL and then hydrated on the client.
@@ -28,6 +37,7 @@ test("hard-navigating to a session URL renders the modal without hydration error
     page.getByRole("dialog", { name: "Session details" })
   ).toBeVisible();
 
-  // Settle so any async hydration warnings have time to fire.
+  // Settle again so async hydration warnings have time to fire before the
+  // console guard checks.
   await page.waitForLoadState("networkidle");
 });


### PR DESCRIPTION
Both reloads aborted requests that were still in flight, and the console guard
fails on what the abort logs.

kiosk: applying the dev clock schedules a router.refresh(), and "networkidle"
can go quiet just before it — the reload then killed the refresh mid-stream and
logged an RSC-payload error. Wait for that response to finish streaming instead.

view-session: opening the session modal starts an /api/rsvps fetch and Next
prefetches of the links it renders; the reload aborted those, which Firefox
reports as an uncaught "NetworkError when attempting to fetch resource". The
wait was after the reload, where it cannot help — moved ahead of it. The
trailing "networkidle" stays, for its other job: giving async hydration warnings
time to fire.

<!-- jip:pushed-commit=e58230d96795037fd7d98ebb26b0001f9cab662e -->