### PR TITLE
test: assert directory order between two attendees, not against the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- The attendee-directory E2E tests assert the order of two named seeded attendees instead of who
+  sits first in the whole list, which a user created by a parallel admin test could take. The rule
+  behind it — never assert on a global aggregate of shared data — is written down in
+  [docs/dev/testing.md § E2E conventions](docs/dev/testing.md#e2e-conventions)
 - The schedule-layout E2E tests scroll until what they assert on has moved, instead of wheeling a
   fixed amount and waiting 300–500ms for it. The room-details hover retries too: under load the
   mouse could arrive before the grid had hydrated, and that first hover was simply lost

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -155,6 +155,17 @@ Dates must be formatted in an explicit zone — the event's — never the proces
 - Imitate human behavior — click visible elements, navigate naturally
 - Use semantic locators (`getByRole`, `getByText`, `getByLabel`), not IDs or CSS classes
 - Never construct URLs with internal IDs or replay raw API payloads
+- Never assert on a global aggregate of shared data — an exact total, "first in the list". The
+  whole suite shares one database and runs in parallel, so another spec creating a user or editing
+  a profile can move any of them. Assert within data the test created itself, or between two named
+  seeded rows ("Alice sorts above Ahmad"), which stays true however many rows appear around them.
+  Comparing one count against another (fewer after a filter than before) holds only where no row a
+  parallel spec can add moves the two the same way
+- Give anything a test creates a name of its own (`E2E Admin User <timestamp>`), distinctive enough
+  that no other spec's search or filter can match it
+- A cross-test invariant that only a comment states ("no other test votes on this proposal") is
+  enforced by nothing. Put it in the seed or the fixture where it can be relied on, or write the
+  assertion so it does not need the invariant
 
 ## Test data
 

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -505,6 +505,12 @@ test("filters the directory to filled-in profiles", async ({ page }) => {
   expect(await shown()).toBeGreaterThan(0);
 });
 
+// Directory order is asserted between two seeded attendees, never as a
+// position in the list as a whole: admin.spec.ts creates and imports users in
+// parallel, and one of those may legitimately sort above both.
+const firstOfAliceOrAhmad = (attendees: import("@playwright/test").Locator) =>
+  attendees.filter({ hasText: /Alice Test|Ahmad Karimi/ }).first();
+
 test("searches, filters and sorts without going back to the server", async ({
   page,
 }) => {
@@ -515,7 +521,7 @@ test("searches, filters and sorts without going back to the server", async ({
     .getByRole("list")
     .filter({ has: page.getByRole("link", { name: "Alice Test" }) })
     .getByRole("listitem");
-  await expect(attendees.first()).toContainText("Ahmad Karimi");
+  await expect(firstOfAliceOrAhmad(attendees)).toContainText("Ahmad Karimi");
 
   // The browser holds the whole directory, so every toggle re-renders the list
   // in place. Anything asking /guests for a fresh list would re-render the page
@@ -535,9 +541,11 @@ test("searches, filters and sorts without going back to the server", async ({
   await page.getByRole("button", { name: /Filter by Has profile/ }).click();
   await expect(page.getByRole("link", { name: "Amara Okafor" })).toHaveCount(0);
 
-  // Alice is the first guest seeded, so she carries the most recent stamp.
+  // Alice is the first guest seeded, so she carries the most recent stamp —
+  // and only this file's own tests ever edit a profile, so she stays ahead of
+  // Ahmad whatever else the run is doing.
   await page.getByLabel("Sort by").selectOption("Recently updated");
-  await expect(attendees.first()).toContainText("Alice Test");
+  await expect(firstOfAliceOrAhmad(attendees)).toContainText("Alice Test");
 
   // Only Olga is based there, and no editing test writes that city.
   await page.getByLabel("Search").fill("Novosibirsk");
@@ -578,12 +586,15 @@ test("sorts the attendee directory by recently updated", async ({ page }) => {
     .getByRole("listitem");
 
   // The seeded update times are all hours or days old, so the edit above makes
-  // Alice the most recent — and alphabetically she is not first.
-  await expect(attendees.first()).toContainText("Ahmad Karimi");
+  // Alice the most recently updated of the two — and alphabetically she is the
+  // later one.
+  await expect(firstOfAliceOrAhmad(attendees)).toContainText("Ahmad Karimi");
 
   await page.getByLabel("Sort by").selectOption("Recently updated");
-  await expect(attendees.first()).toContainText("Alice Test");
-  await expect(attendees.first()).toContainText("updated just now");
+  await expect(firstOfAliceOrAhmad(attendees)).toContainText("Alice Test");
+  await expect(firstOfAliceOrAhmad(attendees)).toContainText(
+    "updated just now"
+  );
 
   // A search is ranked by relevance, so sorting is off the table while one is
   // active.

--- a/tests/e2e/user-auth.spec.ts
+++ b/tests/e2e/user-auth.spec.ts
@@ -14,7 +14,10 @@ const PRIYA_EMAIL = "priya.sharma@example.com";
 const PRIYA_PASSWORD = "priya-e2e-password";
 const PRIYA_NEW_PASSWORD = "priya-e2e-password-2";
 
-// Ahmad Karimi is used by no other spec, likewise.
+// Ahmad Karimi, likewise, for his protection settings. His profile is another
+// matter: profile.spec.ts asserts the directory order between him and Alice, so
+// nothing may edit it. Protecting a name doesn't — profileUpdatedAt is stamped
+// only by a profile save.
 const AHMAD_EMAIL = "ahmad.karimi@example.com";
 const AHMAD_PASSWORD = "ahmad-e2e-password";
 const AHMAD_NEW_PASSWORD = "ahmad-e2e-password-2";


### PR DESCRIPTION
"Alice is first once sorted by recency" and "Ahmad is first by name" are claims
about the whole directory, which admin.spec.ts grows with created and imported
users while these run. Between Alice and Ahmad the order is the seed's to
decide and stays true however many rows appear around them.

The rule this is an instance of now lives in testing.md, since the suite is
full of invariants that only a comment states.

<!-- jip:pushed-commit=16c642b2393af7b496093e47326fc04c7bff02f8 -->