### PR TITLE
test: run the site-settings specs apart from the parallel bulk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ jj squash --from <commit> --to @ -m "message" -- <path>
   - `bun set-env.ts test bun x playwright test tests/e2e/proposals.spec.ts` (one file)
   - `bun set-env.ts test bun x playwright test tests/e2e/proposals.spec.ts:42` (one test by line)
   - `bun set-env.ts test bun x playwright test -g "creates a proposal"` (by title substring)
+  - add `--no-deps` for a spec in the `firefox-globals` project (`settings.spec.ts`), or the whole
+    project it depends on runs first
 - Full test strategy and TDD rules are in [docs/dev/testing.md](docs/dev/testing.md) — read it before writing any test
 - Before running tests for the first time in a session, check whether mailpit is running (`docker compose -f docker-compose.dev.yml $(test -f .env.dev.local && echo --env-file .env.dev.local) ps mailpit` — mirrors the `mailpit` Makefile target, including its `--env-file` conditional, since `.env.dev.local` can set a per-clone `COMPOSE_PROJECT_NAME`); if not, ask the user whether to start it (`make mailpit`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- E2E specs that change site-wide settings run in their own Playwright project, after the parallel
+  bulk and with the site to themselves. `settings.spec.ts` restored what it changed, but only after
+  asserting on it, and nothing stopped a future test from reading the site title in that window
 - The attendee-directory E2E tests assert the order of two named seeded attendees instead of who
   sits first in the whole list, which a user created by a parallel admin test could take. The rule
   behind it — never assert on a global aggregate of shared data — is written down in

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -83,6 +83,24 @@ bun set-env.ts test bun x playwright test tests/e2e/proposals.spec.ts:42   # sin
 bun set-env.ts test bun x playwright test -g "creates a proposal"          # by title substring
 ```
 
+The suite runs as two projects. `firefox` holds everything and runs in
+parallel; `firefox-globals` holds the specs that change site-wide settings —
+one row every other test reads — and depends on `firefox`, so it starts only
+once the parallel bulk is done and has the site to itself. It runs on a single
+worker, so its specs don't race each other either. `settings.spec.ts` is the
+only member today; add a spec here (via `GLOBALS_MUTATING_SPECS` in
+`playwright.config.ts`) when it mutates a singleton rather than data of its
+own.
+
+The price of the dependency: a failure anywhere in `firefox` skips
+`firefox-globals` altogether, so those specs report nothing until the bulk is
+green again. Run them on their own to see where they stand. That also pulls in
+the whole project they depend on, so pass `--no-deps`:
+
+```bash
+bun set-env.ts test bun x playwright test tests/e2e/settings.spec.ts --no-deps
+```
+
 Run against a different environment (e.g. dev database — still resets it):
 
 ```bash

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,6 +74,12 @@ const baseURL = `http://localhost:${port}`;
 // .env.test names.
 process.env.SITE_URL = baseURL;
 
+// Specs that mutate the site-settings singleton, run apart from everything
+// else (see the "firefox-globals" project below). Anchored: an unanchored
+// pattern would swallow user-settings.spec.ts, which only touches one guest's
+// own preferences.
+const GLOBALS_MUTATING_SPECS = /[\\/]settings\.spec\.ts$/;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -110,6 +116,27 @@ export default defineConfig({
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
+      testIgnore: GLOBALS_MUTATING_SPECS,
+    },
+
+    /* Specs that change site-wide settings — one row every other test reads.
+     * They restore what they changed, but only after asserting on it, and
+     * nothing stops a future test from looking at the site title while that
+     * window is open. `dependencies` holds them until the parallel bulk above
+     * is done, so they have the site to themselves; `workers: 1` keeps them
+     * from racing each other once there is more than one such spec (a file's
+     * own `serial` mode only orders the tests within it).
+     *
+     * A failure anywhere in `firefox` skips this project entirely — Playwright
+     * does not run a project whose dependency failed. The run fails either
+     * way, but the site-settings specs go unreported until the bulk is green. */
+    {
+      name: "firefox-globals",
+      use: { ...devices["Desktop Firefox"] },
+      testMatch: GLOBALS_MUTATING_SPECS,
+      dependencies: ["firefox"],
+      fullyParallel: false,
+      workers: 1,
     },
 
     //  {


### PR DESCRIPTION
settings.spec.ts changes the site title and the venue map — one row every other
test reads — and restores them only after asserting on them. Nothing today
looks at either in that window, which is luck rather than design. A second
project, depending on the first, gives those specs the site to themselves.

<!-- jip:pushed-commit=e2d18351a72ee2ff633d6e5ede7bd821ae6761bd -->