### PR TITLE
test: make throwaway E2E names unique across workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Throwaway names in E2E tests carry the worker's process id and a counter, not just `Date.now()`:
+  two parallel workers can land in the same millisecond, and the duplicate name would surface as an
+  unreproducible locator failure somewhere else entirely
 - E2E specs that change site-wide settings run in their own Playwright project, after the parallel
   bulk and with the site to themselves. `settings.spec.ts` restored what it changed, but only after
   asserting on it, and nothing stopped a future test from reading the site title in that window

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -179,8 +179,10 @@ Dates must be formatted in an explicit zone — the event's — never the proces
   seeded rows ("Alice sorts above Ahmad"), which stays true however many rows appear around them.
   Comparing one count against another (fewer after a filter than before) holds only where no row a
   parallel spec can add moves the two the same way
-- Give anything a test creates a name of its own (`E2E Admin User <timestamp>`), distinctive enough
-  that no other spec's search or filter can match it
+- Give anything a test creates a name of its own (`E2E Admin User ${uniqueSuffix()}`), distinctive
+  enough that no other spec's search or filter can match it. Take the suffix from
+  `tests/e2e/helpers/unique.ts`, never a bare `Date.now()`: workers are separate processes sharing
+  one database, and two of them can land in the same millisecond
 - A cross-test invariant that only a comment states ("no other test votes on this proposal") is
   enforced by nothing. Put it in the seed or the fixture where it can be relied on, or write the
   assertion so it does not need the invariant

--- a/tests/e2e/add-session.spec.ts
+++ b/tests/e2e/add-session.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { login } from "./helpers/auth";
 import { dismissToast, toast } from "./helpers/toast";
 
@@ -19,7 +20,7 @@ test("a newly added session appears on the overview and can be opened", async ({
 
   // Unique per attempt: the DB is seeded once for the whole run, so a retry
   // would otherwise find the session its failed predecessor already created.
-  const sessionTitle = `Yak shaving ${Date.now()}`;
+  const sessionTitle = `Yak shaving ${uniqueSuffix()}`;
   await page.getByRole("textbox").first().fill(sessionTitle);
 
   // Add a host via the combobox (a host is required to enable Submit).

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,6 +1,7 @@
 import { Page, Route } from "@playwright/test";
 import sharp from "sharp";
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto } from "./helpers/auth";
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
@@ -154,7 +155,7 @@ test.describe("Admin UI", () => {
     await adminLogin(page);
     await gotoUsers(page);
 
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const email = `e2e-admin-${unique}@test.example`;
     const name = `E2E Admin User ${unique}`;
     const renamed = `${name} Renamed`;
@@ -221,7 +222,7 @@ test.describe("Admin UI", () => {
     await adminLogin(page);
     await gotoUsers(page);
 
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const newName = `CSV Import User ${unique}`;
     const newEmail = `csv-import-${unique}@test.example`;
     // bob@test.com already exists in the seed, so he must be skipped.
@@ -355,7 +356,7 @@ test.describe("Admin UI events", () => {
     await expect(page.getByText("Conference Alpha")).toBeVisible();
 
     // Create a new event
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Event ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -378,7 +379,7 @@ test.describe("Admin UI events", () => {
     await adminLogin(page);
     await page.goto("/admin/events");
 
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Tabs ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -440,7 +441,7 @@ test.describe("Admin UI events", () => {
     await page.goto("/admin/events");
 
     // Create a throwaway event so we never touch the shared seeded events
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const original = `E2E Edit ${unique}`;
     const renamed = `E2E Edit Updated ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
@@ -490,7 +491,7 @@ test.describe("Admin UI events", () => {
     await page.goto("/admin/events");
 
     // Create a throwaway event
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `Delete Me ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -520,7 +521,7 @@ test.describe("Admin UI events", () => {
     await page.goto("/admin/events");
 
     // Create a throwaway event with no phases initially
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Phases ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -601,7 +602,7 @@ test.describe("Admin UI days", () => {
     await page.goto("/admin/events");
 
     // Create a throwaway event so we never touch seeded events
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Days ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -703,7 +704,7 @@ test.describe("Admin UI guest assignment", () => {
     await page.goto("/admin/events");
 
     // Create a throwaway event
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Guests ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -784,7 +785,7 @@ test.describe("Admin UI guest assignment", () => {
     await page.goto("/admin/events");
 
     // Fresh event so all seeded guests start unassigned.
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Bulk Guests ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -913,7 +914,7 @@ test.describe("Admin UI locations", () => {
 
       // Create a throwaway event (seeded locations are linked to seeded events
       // only, so a fresh event starts with none assigned)
-      const unique = Date.now();
+      const unique = uniqueSuffix();
       const eventName = `E2E Locations ${unique}`;
       await page.getByRole("button", { name: "New event" }).click();
       await page.getByLabel("Name *").fill(eventName);
@@ -1079,7 +1080,7 @@ test.describe("Admin UI locations", () => {
     await page.goto("/admin/events");
 
     // Fresh event so all seeded locations start "Not assigned".
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const eventName = `E2E Loc Selection ${unique}`;
     await page.getByRole("button", { name: "New event" }).click();
     await page.getByLabel("Name *").fill(eventName);
@@ -1205,7 +1206,7 @@ test.describe("Admin UI proposals", () => {
     // at the end so the shared seed data stays intact.
     const original =
       "Conference Alpha Panel: Industry Leaders Share Their Insights";
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const edited = `Panel EDITED ${unique}`;
 
     await proposals
@@ -1245,7 +1246,7 @@ test.describe("Admin UI proposals", () => {
   test("deletes a proposal via named confirm", async ({ page }) => {
     // Create a fresh proposal so we never permanently delete seeded data
     await loginAndGoto(page, "/Conference-Alpha/proposals/new");
-    const title = `E2E Delete Test ${Date.now()}`;
+    const title = `E2E Delete Test ${uniqueSuffix()}`;
     await page.getByLabel("Title").fill(title);
     await Promise.all([
       page.waitForURL(/\/Conference-Alpha\/proposals$/),
@@ -1368,7 +1369,7 @@ test.describe("Admin UI sessions", () => {
 
     const sessions = page.getByRole("region", { name: "Sessions" });
     const original = "Opening Keynote - Conference Alpha";
-    const edited = `Keynote EDITED ${Date.now()}`;
+    const edited = `Keynote EDITED ${uniqueSuffix()}`;
 
     await sessions
       .getByRole("listitem")
@@ -1407,7 +1408,7 @@ test.describe("Admin UI sessions", () => {
     await openEventTab(page, "Sessions");
 
     const sessions = page.getByRole("region", { name: "Sessions" });
-    const title = `Lunch Blocker ${Date.now()}`;
+    const title = `Lunch Blocker ${uniqueSuffix()}`;
 
     await sessions.getByRole("button", { name: "Add session" }).click();
     await sessions.getByLabel("Title *").fill(title);
@@ -1590,7 +1591,7 @@ test.describe("Admin UI locations", () => {
     await gotoLocations(page);
     const region = page.getByRole("region", { name: "Locations" });
 
-    const unique = Date.now();
+    const unique = uniqueSuffix();
     const nameA = `E2E Room A ${unique}`;
     const nameB = `E2E Room B ${unique}`;
 
@@ -1664,7 +1665,7 @@ test.describe("Admin UI locations", () => {
     await gotoLocations(page);
     const region = page.getByRole("region", { name: "Locations" });
 
-    const name = `E2E Photo Room ${Date.now()}`;
+    const name = `E2E Photo Room ${uniqueSuffix()}`;
     await region.getByRole("button", { name: "New location" }).click();
     await region.getByLabel("Name", { exact: true }).fill(name);
 

--- a/tests/e2e/helpers/unique.ts
+++ b/tests/e2e/helpers/unique.ts
@@ -1,0 +1,12 @@
+let counter = 0;
+
+/**
+ * A suffix that makes a name unique across the whole run. `Date.now()` on its
+ * own is not enough: the database is seeded once and shared, so a name has to
+ * be unique across parallel workers too, and two of them can easily land in
+ * the same millisecond. The process id separates the workers, the counter the
+ * names within one.
+ */
+export function uniqueSuffix(): string {
+  return `${process.pid}-${Date.now()}-${counter++}`;
+}

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { login } from "./helpers/auth";
 import { PROMPT_POOL } from "@/model/prompt-pool";
 import sharp from "sharp";
@@ -68,7 +69,7 @@ test.describe("Edit profile", () => {
       page.getByRole("heading", { name: /Edit profile/i })
     ).toBeVisible();
 
-    const aboutMe = `Conference enthusiast ${Date.now()}`;
+    const aboutMe = `Conference enthusiast ${uniqueSuffix()}`;
     await page.getByLabel("About me").fill(aboutMe);
     const pronounsEntry = page.getByLabel("Pronouns");
     await pronounsEntry.fill("She/Her");
@@ -138,7 +139,7 @@ test.describe("Edit profile", () => {
     await page.getByRole("link", { name: /Edit profile/i }).click();
 
     // Reset the avatar
-    const aboutMe = `Conference enthusiast ${Date.now()}`;
+    const aboutMe = `Conference enthusiast ${uniqueSuffix()}`;
     await page.getByLabel("About me").fill(aboutMe);
     await page.getByRole("button", { name: /^Save$/ }).click();
 
@@ -224,8 +225,15 @@ test.describe("Edit profile", () => {
     // A retry of this test runs against the profile saved by the previous
     // attempt, so clear the rows it left behind before adding new ones.
     const leftoverRows = page.getByRole("button", { name: "Remove" });
-    while ((await leftoverRows.count()) > 0) {
+    let left = await leftoverRows.count();
+    while (left > 0) {
       await leftoverRows.first().click();
+      // Wait for the row to actually go: a bare count() loop can click the
+      // same row twice while the first removal is still landing, and then
+      // never reaches zero. Re-read afterwards rather than counting down, so a
+      // row that renders late still gets removed.
+      await expect(leftoverRows).toHaveCount(left - 1);
+      left = await leftoverRows.count();
     }
 
     await page
@@ -567,7 +575,7 @@ test("sorts the attendee directory by recently updated", async ({ page }) => {
   await selectCurrentUser(page);
   await page.getByRole("link", { name: "Attendees", exact: true }).click();
   await page.getByRole("link", { name: /Edit profile/i }).click();
-  await page.getByLabel("About me").fill(`Freshly edited ${Date.now()}`);
+  await page.getByLabel("About me").fill(`Freshly edited ${uniqueSuffix()}`);
   await page.getByRole("button", { name: /^Save$/ }).click();
   await expect(page).toHaveURL(/\/guests\/[^/]+$/);
   // The save redirects here itself; a click that lands while that navigation

--- a/tests/e2e/proposals.spec.ts
+++ b/tests/e2e/proposals.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto, login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
 
@@ -17,7 +18,7 @@ test("should create a new session proposal, edit it, and add hosts", async ({
   // Go to proposals list first (optional, helps ensure baseline loaded)
   await page.goto("/Conference-Alpha/proposals");
   // Generate a unique title to avoid collisions between runs
-  const proposalTitle = `Playwright Test Proposal ${Date.now()}`;
+  const proposalTitle = `Playwright Test Proposal ${uniqueSuffix()}`;
   await expect(page.getByText(proposalTitle).first()).toHaveCount(0); // ensure not present
 
   await page
@@ -87,7 +88,7 @@ test("should delete a proposal from its edit page", async ({ page }) => {
   await page.goto("/Conference-Alpha/proposals");
 
   // Create a throwaway proposal so seeded data stays untouched
-  const proposalTitle = `Playwright Delete Proposal ${Date.now()}`;
+  const proposalTitle = `Playwright Delete Proposal ${uniqueSuffix()}`;
   await page.getByRole("link", { name: /Add Proposal/i }).click();
   await page.getByLabel("Title").fill(proposalTitle);
   await Promise.all([
@@ -124,7 +125,7 @@ test("a non-host cannot edit or delete another guest's proposal", async ({
 }) => {
   await login(page);
   await page.goto("/Conference-Alpha/proposals");
-  const proposalTitle = `Playwright Ownership Proposal ${Date.now()}`;
+  const proposalTitle = `Playwright Ownership Proposal ${uniqueSuffix()}`;
 
   // Alice creates a proposal; she's prefilled as its only host.
   await selectUser(page, /Alice Test/i);

--- a/tests/e2e/scheduling.spec.ts
+++ b/tests/e2e/scheduling.spec.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { DateTime } from "luxon";
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
 import { dismissToast, toast } from "./helpers/toast";
@@ -75,7 +76,7 @@ test("a host can edit a session's title and the change persists", async ({
   page,
 }) => {
   await login(page);
-  const unique = Date.now();
+  const unique = uniqueSuffix();
   const title = `E2E Editable Session ${unique}`;
   const renamed = `E2E Renamed Session ${unique}`;
 
@@ -100,7 +101,7 @@ test("a host can delete a session and it disappears from the grid", async ({
   page,
 }) => {
   await login(page);
-  const title = `E2E Doomed Session ${Date.now()}`;
+  const title = `E2E Doomed Session ${uniqueSuffix()}`;
 
   await createSessionViaForm(page, title, /Garden Terrace/, "16:10");
 
@@ -124,7 +125,7 @@ test("a session booked after midnight lands on the next calendar date", async ({
   page,
 }) => {
   await login(page);
-  const title = `E2E Late Night Session ${Date.now()}`;
+  const title = `E2E Late Night Session ${uniqueSuffix()}`;
 
   // Gamma's last day runs 09:00 → 03:00 the next morning (see the seed), so
   // 01:10 is bookable under that day and belongs to the following date.

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import sharp from "sharp";
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto } from "./helpers/auth";
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
@@ -45,7 +46,7 @@ test.describe("Admin site settings", () => {
     await adminLogin(page);
     await gotoSettings(page);
 
-    const unique = `E2E Conf ${Date.now()}`;
+    const unique = `E2E Conf ${uniqueSuffix()}`;
     await page.getByLabel("Title").fill(unique);
     await page.getByRole("button", { name: "Save settings" }).click();
     await expect(page.getByText("Settings saved.")).toBeVisible();

--- a/tests/e2e/update-session.spec.ts
+++ b/tests/e2e/update-session.spec.ts
@@ -1,5 +1,6 @@
 import { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
 import { dismissToast, toast } from "./helpers/toast";
@@ -41,7 +42,7 @@ test("updating a session emails the RSVP'd guest and the added co-host", async (
   // The title doubles as the unique token for finding this test's emails
   // (both notification emails carry it in the subject), so leftover
   // mailbox contents from other tests or runs never match.
-  const title = `E2E Email Session ${Date.now()}`;
+  const title = `E2E Email Session ${uniqueSuffix()}`;
 
   // Charlie creates a session on the last event day (Garden Terrace 15:10 —
   // a slot no other spec claims; see the note in scheduling.spec.ts). Bob

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto, login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
 
@@ -108,7 +109,7 @@ test("votes from two users persist independently across reloads", async ({
   // in this file votes as Bob in a parallel worker, and quick voting never
   // offers proposals the current user hosts, so no other test can add votes
   // to this proposal.
-  const title = `E2E Vote Target ${Date.now()}`;
+  const title = `E2E Vote Target ${uniqueSuffix()}`;
   await page.getByRole("link", { name: /Add Proposal/i }).click();
   await page.getByLabel("Title").fill(title);
   await page.getByLabel("Host(s)").click();


### PR DESCRIPTION
Date.now() alone is not unique: the suite shares one database and four workers
can hit the same millisecond, and the duplicate then shows up as a strict-mode
locator violation in whichever test loses. The process id and a counter settle
it. docs/dev/testing.md said to use a bare timestamp, so it now names the
helper instead.

The leftover-row cleanup in profile.spec.ts also waits for each row to actually
go before clicking the next, so it can't click the same one twice and spin
without ever reaching zero.

<!-- jip:pushed-commit=81ab0bff7853c1f5d12e25c993b48c8344a92a17 -->