### PR TITLE
test: tap the name chip again when nothing opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   voting-disabled state, admin login, the RSVP capacity test). Each now waits for the state it
   expects, and the RSVP capacity test books a slot that overlaps nothing, so whether it has to
   confirm a clash warning no longer depends on what else is scheduled
+- The E2E name-switcher helper taps the header chip again when neither the menu nor the modal
+  opened. The header comes from the server render, so the chip satisfies every check Playwright
+  makes a moment before React has attached its handler, and a click in that window is dropped — the
+  test then sat out its full 90s waiting for a modal that was never going to open
 - The emoji, label and display order of a vote live only in `app/(site)/votes.ts`, and `VotesContext` exposes
   `proposalVoteLabel` beside `proposalVoteEmoji`. The choice→label mapping had been copied into three components, each
   free to drift from the emoji next to it

--- a/tests/e2e/helpers/user.ts
+++ b/tests/e2e/helpers/user.ts
@@ -1,6 +1,23 @@
 import { Locator, Page, expect } from "@playwright/test";
 import { login } from "./auth";
 
+// Clicks `trigger` until `opened` shows up. The header is server-rendered, so
+// its buttons are clickable — by every check Playwright makes — a moment
+// before React has attached their handlers, and a click in that window is
+// simply dropped. Waiting for hydration is not observable; clicking again is.
+// Re-checking first keeps a retry from clicking what the previous attempt
+// already opened: that would toggle the menu shut again, and with the modal it
+// would hang outright, since the dialog's backdrop makes the chip unclickable
+// and nothing bounds a click's actionability wait.
+async function tapUntilOpen(trigger: Locator, opened: Locator): Promise<void> {
+  await expect(async () => {
+    if (!(await opened.isVisible())) {
+      await trigger.click();
+    }
+    await expect(opened).toBeVisible({ timeout: 2000 });
+  }).toPass();
+}
+
 // Opens the name-switcher modal via the site header and returns the
 // "My name is:" combobox. The active name lives in a header chip (accessible
 // name starts with "Your name"). With no name set, tapping it opens the
@@ -16,9 +33,8 @@ export async function openNameSwitcher(page: Page): Promise<Locator> {
   // menu and the modal never match at the same time below.
   await expect(nameBox).toBeHidden();
   const chip = page.getByRole("button", { name: /your name/i });
-  await chip.click();
   const logOut = page.getByRole("menuitem", { name: "Log out" });
-  await expect(logOut.or(nameBox)).toBeVisible();
+  await tapUntilOpen(chip, logOut.or(nameBox));
   if (await logOut.isVisible()) {
     await logOut.click();
     // Logging out clears the site login too (see logoutAction), and the
@@ -38,7 +54,7 @@ export async function openNameSwitcher(page: Page): Promise<Locator> {
     await expect(
       page.getByRole("button", { name: "Your name", exact: true })
     ).toBeVisible();
-    await chip.click();
+    await tapUntilOpen(chip, nameBox);
   }
   await nameBox.click();
   return nameBox;


### PR DESCRIPTION
The header is server-rendered, so the chip passes every actionability check a
moment before React attaches its handler; a click that lands in that window is
dropped and the helper then waited out the whole test timeout for a modal that
would never open. Seen once in 40 hunt runs, after a re-login.

<!-- jip:pushed-commit=2ae1ad4663d68e340ac34a7dd234f4406a5e096a -->