### PR TITLE
test: wait for ?kiosk=0 to actually clear the cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   voting-disabled state, admin login, the RSVP capacity test). Each now waits for the state it
   expects, and the RSVP capacity test books a slot that overlaps nothing, so whether it has to
   confirm a clash warning no longer depends on what else is scheduled
+- The kiosk E2E test waits for the `kiosk` cookie to be gone before it navigates on. `?kiosk=0`
+  leaves the now line out of the server render, so the assertion after it could pass before the page
+  had hydrated and run the effect that clears the cookie — and the page after that came up in kiosk
+  mode again. The rule behind it — an assertion the server render already satisfies says nothing
+  about what a page does on hydration — is written down in
+  [docs/dev/testing.md § E2E conventions](docs/dev/testing.md#e2e-conventions)
 - The E2E name-switcher helper taps the header chip again when neither the menu nor the modal
   opened. The header comes from the server render, so the chip satisfies every check Playwright
   makes a moment before React has attached its handler, and a click in that window is dropped — the

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -186,6 +186,12 @@ Dates must be formatted in an explicit zone — the event's — never the proces
 - A cross-test invariant that only a comment states ("no other test votes on this proposal") is
   enforced by nothing. Put it in the seed or the fixture where it can be relied on, or write the
   assertion so it does not need the invariant
+- Nothing a page does in an effect is covered by an assertion the server render already satisfies.
+  `toHaveCount(0)` on something the markup never contained passes instantly, and a click on a
+  server-rendered control satisfies every actionability check a moment before React attaches its
+  handler — so both come up green while hydration is still pending. Where the behavior under test
+  lives in an effect, wait for that effect's own result before acting on it: `kiosk.spec.ts` polls
+  until the `kiosk` cookie is gone before it navigates on, `helpers/user.ts` taps the chip again
 
 ## Test data
 

--- a/tests/e2e/kiosk.spec.ts
+++ b/tests/e2e/kiosk.spec.ts
@@ -106,8 +106,20 @@ test("?kiosk=0 clears the cookie and leaves kiosk mode", async ({ page }) => {
   await page.goto("/Conference-Gamma?kiosk=0");
   await expect(page.getByTestId("now-line")).toHaveCount(0);
 
-  // A plain reload (no parameter at all) should stay out of kiosk mode too,
-  // proving the cookie was actually cleared rather than just overridden.
+  // ?kiosk=0 hides the now line from the server render alone, so the check
+  // above says nothing about hydration — while the cookie is cleared by an
+  // effect that only runs once the page has hydrated. Navigating away before
+  // that lands leaves the cookie behind, and the next page is in kiosk mode
+  // again.
+  await expect
+    .poll(async () =>
+      (await page.context().cookies()).map((cookie) => cookie.name)
+    )
+    .not.toContain("kiosk");
+
+  // A plain reload (no parameter at all) should stay out of kiosk mode too:
+  // the poll above proves the cookie is gone, this that nothing else puts the
+  // display back into kiosk mode once it is.
   await page.goto("/Conference-Gamma");
   await expect(page.getByTestId("now-line")).toHaveCount(0);
 });


### PR DESCRIPTION
Without the parameter the now line is absent from the server render already, so
the assertion could pass before hydration had run the effect that clears the
cookie; the navigation right after then came up in kiosk mode again.

The general rule — an assertion the server render already satisfies says nothing
about what the page does on hydration — goes into the E2E conventions, since the
suite works around it in three other places.

<!-- jip:pushed-commit=3df19ac074f528fea2302aef671cde6ab6c34932 -->