### PR TITLE
fix: redirect from the proposal delete, don't re-render the deleted page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Deleting a proposal goes straight to the list**: the delete could throw an error into the browser
+  on the way out, because the page of the proposal just deleted was rendered once more before the
+  list appeared
 - **The session form shows which day owns the small hours**: a day that runs past midnight is now labelled with the
   hour it ends ("Friday, June 13 (until 03:00 Sat)"), and its start times after midnight carry their weekday ("Sat
   01:10"), so it's clear that the late slots belong to the evening's day. Day names also follow the event's timezone

--- a/app/(site)/[eventSlug]/proposals/actions.ts
+++ b/app/(site)/[eventSlug]/proposals/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
@@ -149,7 +150,10 @@ export async function updateProposal(
 
 // Same reasoning as updateProposal: no phase gate, so a host can withdraw
 // their proposal in any phase, including scheduling.
-export async function deleteProposal(id: string, eventSlug: string) {
+export async function deleteProposal(
+  id: string,
+  eventSlug: string
+): Promise<{ error: string } | undefined> {
   try {
     const proposal = await getRepositories().sessionProposals.findById(id);
     if (!proposal) {
@@ -172,5 +176,10 @@ export async function deleteProposal(id: string, eventSlug: string) {
     console.error("Error deleting proposal:", error);
     return { error: "Failed to delete proposal" };
   }
-  return { success: true };
+  // Leaving the navigation to the caller would have Next re-render the page
+  // this action ran on first — the deleted proposal's own edit page, whose
+  // notFound() then reaches the browser as an uncaught error. Redirecting
+  // here replaces that render with the list's. Outside the try: redirect()
+  // works by throwing, and the catch above would swallow it.
+  redirect(`/${eventSlug}/proposals`);
 }

--- a/app/(site)/[eventSlug]/session-proposal-form.tsx
+++ b/app/(site)/[eventSlug]/session-proposal-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useContext, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useContext, useMemo, useTransition } from "react";
+import { useRouter, unstable_rethrow } from "next/navigation";
 
 import { Input } from "@/app/input";
 import { UserContext, useBreakMinutes, useSlotIncrement } from "../context";
@@ -41,7 +41,7 @@ export function SessionProposalForm(props: {
   ];
   const { user: currentUserId } = useContext(UserContext);
   const router = useRouter();
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleting, startDeleting] = useTransition();
 
   const defaultHosts = useMemo(() => {
     if (proposal) return proposal.hosts.map((h) => h.id);
@@ -97,25 +97,28 @@ export function SessionProposalForm(props: {
     }
   };
 
-  const handleDelete = async (): Promise<void> => {
+  // In a transition, because the action ends in a redirect: Next carries that
+  // out from inside one, while a redirect thrown outside a transition is left
+  // to the caller and ends up an unhandled rejection.
+  const handleDelete = (): void => {
     if (!proposal) return;
 
-    setIsDeleting(true);
+    startDeleting(async () => {
+      try {
+        // A delete that went through redirects to the proposals list, so
+        // anything that comes back here is a refusal.
+        const result = await deleteProposal(proposal.id, eventSlug);
 
-    try {
-      const result = await deleteProposal(proposal.id, eventSlug);
-
-      if (result.error) {
-        form.setError("root", { message: result.error });
-      } else {
-        router.push(`/${eventSlug}/proposals`);
+        if (result?.error) {
+          form.setError("root", { message: result.error });
+        }
+      } catch (err) {
+        // The redirect, on its way out to Next — not a failure to report.
+        unstable_rethrow(err);
+        form.setError("root", { message: "An unexpected error occurred" });
+        console.error(err);
       }
-    } catch (err) {
-      form.setError("root", { message: "An unexpected error occurred" });
-      console.error(err);
-    } finally {
-      setIsDeleting(false);
-    }
+    });
   };
 
   return (

--- a/app/(site)/modals.tsx
+++ b/app/(site)/modals.tsx
@@ -105,7 +105,9 @@ export function CurrentUserModal(props: {
 
 export function ConfirmDeletionModal(props: {
   btnDisabled: boolean;
-  confirm: () => Promise<void>;
+  // Void as well as async: a confirm that hands the work to a transition
+  // returns before the work is done.
+  confirm: () => void | Promise<void>;
   itemName: string;
 }) {
   const { btnDisabled, confirm, itemName } = props;

--- a/tests/integration/delete-proposal.test.ts
+++ b/tests/integration/delete-proposal.test.ts
@@ -8,8 +8,22 @@ import {
   vi,
 } from "vitest";
 
+const { redirects, revalidated } = vi.hoisted(() => ({
+  redirects: [] as string[],
+  revalidated: [] as string[],
+}));
+
 vi.mock("next/cache", () => ({
-  revalidatePath: vi.fn(),
+  revalidatePath: (path: string) => revalidated.push(path),
+}));
+
+vi.mock("next/navigation", () => ({
+  // The real redirect() throws to abandon the rest of the action; a mock that
+  // returned would let code after it run and hide that.
+  redirect: (url: string) => {
+    redirects.push(url);
+    throw new Error(`NEXT_REDIRECT;${url}`);
+  },
 }));
 
 const cookieJar = new Map<string, string>();
@@ -49,12 +63,28 @@ async function protectGuest(guestId: string): Promise<void> {
   });
 }
 
+// A delete that went through ends in a redirect to the proposals list, not in
+// a returned value: the page the action ran on is the deleted proposal's own
+// edit page, and re-rendering it (which any revalidation makes Next do) hits
+// its notFound().
+async function deleteAndFollowRedirect(
+  proposalId: string,
+  eventSlug: string
+): Promise<string | undefined> {
+  await expect(deleteProposal(proposalId, eventSlug)).rejects.toThrow(
+    /NEXT_REDIRECT/
+  );
+  return redirects.at(-1);
+}
+
 describe("deleteProposal", () => {
   beforeAll(() => setupTestDb());
 
   beforeEach(() => {
     resetTestDb();
     cookieJar.clear();
+    redirects.length = 0;
+    revalidated.length = 0;
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
   });
   afterEach(() => vi.unstubAllEnvs());
@@ -83,8 +113,12 @@ describe("deleteProposal", () => {
     await repos.sessions.update(session.id, { proposalId: proposal.id });
 
     cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(host.id));
-    const result = await deleteProposal(proposal.id, "test-event");
-    expect(result).toEqual({ success: true });
+    expect(await deleteAndFollowRedirect(proposal.id, "test-event")).toBe(
+      "/test-event/proposals"
+    );
+    // The redirect lands on a list the router may have prefetched before the
+    // delete, so the list still has to be revalidated as well.
+    expect(revalidated).toContain("/test-event/proposals");
 
     expect(await repos.sessionProposals.findById(proposal.id)).toBeUndefined();
 
@@ -116,6 +150,8 @@ describe("deleteProposal", () => {
 
     const result = await deleteProposal(proposal.id, "test-event");
     expect(result).toHaveProperty("error");
+    // The message has to reach the form, so a refusal must not navigate away.
+    expect(redirects).toEqual([]);
 
     expect(await repos.sessionProposals.findById(proposal.id)).toBeDefined();
   });
@@ -137,8 +173,9 @@ describe("deleteProposal", () => {
     const event = await createEvent();
     const proposal = await createProposal(event.id, []);
 
-    const result = await deleteProposal(proposal.id, "test-event");
-    expect(result).toEqual({ success: true });
+    expect(await deleteAndFollowRedirect(proposal.id, "test-event")).toBe(
+      "/test-event/proposals"
+    );
 
     expect(await repos.sessionProposals.findById(proposal.id)).toBeUndefined();
   });
@@ -165,8 +202,9 @@ describe("deleteProposal", () => {
     const proposal = await createProposal(event.id, [host.id]);
     cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(host.id));
 
-    const result = await deleteProposal(proposal.id, "test-event");
-    expect(result).toEqual({ success: true });
+    expect(await deleteAndFollowRedirect(proposal.id, "test-event")).toBe(
+      "/test-event/proposals"
+    );
 
     expect(await repos.sessionProposals.findById(proposal.id)).toBeUndefined();
   });


### PR DESCRIPTION
Revalidating and then navigating from the client makes Next re-render the route
the action ran on — the deleted proposal's own edit page — and ship it with the
action's response. Its notFound() then reaches the browser as an uncaught
"Server Components render" error whenever that render wins the race against
router.push (once in 40 E2E hunt runs). A redirecting action returns the list
instead, and still revalidates it so a prefetched copy can't show the proposal.

The form has to dispatch it in a transition: Next only carries out a redirect
thrown inside one, and outside it the throw surfaces as an unhandled rejection.

<!-- jip:pushed-commit=7038e995e6013d766d2e5df19f4426722f727b90 -->