### PR TITLE
fix: don't let the modal's cancelled RSVP request throw at the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   voting-disabled state, admin login, the RSVP capacity test). Each now waits for the state it
   expects, and the RSVP capacity test books a slot that overlaps nothing, so whether it has to
   confirm a clash warning no longer depends on what else is scheduled
+- The session modal cancels its RSVP request when it closes and ignores one the browser kills on the
+  way out of the page. The rejection had nowhere to go and surfaced as an uncaught "NetworkError
+  when attempting to fetch resource" — noise in the browser console, and a failed E2E run whenever a
+  reload caught the request in flight
 - The kiosk E2E test waits for the `kiosk` cookie to be gone before it navigates on. `?kiosk=0`
   leaves the now line out of the server render, so the assertion after it could pass before the page
   had hydrated and run the effect that clears the cookie — and the page after that came up in kiosk

--- a/app/(site)/[eventSlug]/session-modal.tsx
+++ b/app/(site)/[eventSlug]/session-modal.tsx
@@ -39,15 +39,16 @@ export function SessionModal({
   }, [onDismiss]);
 
   useEffect(() => {
-    let cancelled = false;
-    void fetch(`/api/rsvps?session=${sessionId}`)
+    const controller = new AbortController();
+    void fetch(`/api/rsvps?session=${sessionId}`, { signal: controller.signal })
       .then((res) => (res.ok ? (res.json() as Promise<Rsvp[]>) : []))
-      .then((data) => {
-        if (!cancelled) setLoaded({ id: sessionId, rsvps: data });
-      });
-    return () => {
-      cancelled = true;
-    };
+      .then((data) => setLoaded({ id: sessionId, rsvps: data }))
+      // Closing the modal aborts the request, and leaving the page has the
+      // browser kill it; either way there is nothing left to show and nobody
+      // to tell. Unhandled, that rejection reaches the window as an uncaught
+      // "NetworkError when attempting to fetch resource".
+      .catch(() => undefined);
+    return () => controller.abort();
   }, [sessionId]);
 
   if (!event) return null;

--- a/tests/e2e/view-session.spec.ts
+++ b/tests/e2e/view-session.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 
+const KEYNOTE = /Opening Keynote/;
+
 test("hard-navigating to a session URL renders the modal without hydration errors", async ({
   page,
 }) => {
@@ -9,10 +11,7 @@ test("hard-navigating to a session URL renders the modal without hydration error
   await page.goto("/Conference-Gamma");
   await expect(page.getByRole("button", { name: "Grid" })).toBeVisible();
 
-  await page
-    .getByRole("link", { name: /Opening Keynote/ })
-    .first()
-    .click();
+  await page.getByRole("link", { name: KEYNOTE }).first().click();
   await expect(
     page.getByRole("dialog", { name: "Session details" })
   ).toBeVisible();
@@ -40,4 +39,48 @@ test("hard-navigating to a session URL renders the modal without hydration error
   // Settle again so async hydration warnings have time to fire before the
   // console guard checks.
   await page.waitForLoadState("networkidle");
+});
+
+test("leaving a session modal whose RSVPs are still loading is quiet", async ({
+  page,
+}) => {
+  await login(page);
+
+  // Hold the modal's first RSVP request, so the reload below is certain to
+  // catch it in flight. That is where the browser kills the request; an
+  // unhandled rejection there reaches the window as an uncaught "NetworkError
+  // when attempting to fetch resource", which the console guard fails on. On a
+  // real network it takes a slow server and an impatient visitor; here it is
+  // every run.
+  const { promise: firstRsvpsHeld, resolve: releaseFirstRsvps } =
+    Promise.withResolvers<void>();
+  let heldOne = false;
+  await page.route("**/api/rsvps?session=*", async (route) => {
+    if (!heldOne) {
+      heldOne = true;
+      await firstRsvpsHeld;
+    }
+    // The held one belongs to a page that is gone by now, and continuing it
+    // fails; the request after the reload is served as usual.
+    await route.continue().catch(() => undefined);
+  });
+
+  await page.goto("/Conference-Gamma");
+  await page.getByRole("link", { name: KEYNOTE }).first().click();
+  await expect(
+    page.getByRole("dialog", { name: "Session details" })
+  ).toBeVisible();
+
+  await page.reload();
+  releaseFirstRsvps();
+  await expect(
+    page.getByRole("dialog", { name: "Session details" })
+  ).toBeVisible();
+
+  await page.waitForLoadState("networkidle");
+
+  // Nothing above fails if the route stops matching — the request is simply
+  // never held, the reload no longer catches one in flight, and the test goes
+  // green without exercising anything.
+  expect(heldOne, "the modal's RSVP request was never intercepted").toBe(true);
 });


### PR DESCRIPTION
The fetch had no rejection handler, so a reload or a link that killed it
mid-flight surfaced an uncaught "NetworkError when attempting to fetch
resource" — once in 40 E2E hunt runs, and console noise for anyone leaving a
session modal quickly. Closing the modal now aborts the request deliberately,
which replaces the cancelled flag too.

<!-- jip:pushed-commit=e4ea83a8140d55eb7016c3aa3322a9da0cf1025f -->