### PR TITLE
test: add a flake hunt for the E2E suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ data.*.db-journal
 # `make test-e2e-docker` (see docs/dev/testing.md § Testing the Docker image)
 /.e2e-docker
 
+# Results and traces of scripts/e2e-flake-hunt.sh
+# (see docs/dev/testing.md § Flake hunting)
+/.flake-hunt
+
 # Nix
 flake.nix
 flake.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- `scripts/e2e-flake-hunt.sh` runs the E2E suite N times against one build and keeps every run's JSON
+  report plus traces of what failed; `scripts/e2e-flake-report.ts` aggregates those into a report
+  ranking flaky tests by failure rate and grouping them by error signature. See
+  [docs/dev/testing.md § Flake hunting](docs/dev/testing.md#flake-hunting)
 - Throwaway names in E2E tests carry the worker's process id and a counter, not just `Date.now()`:
   two parallel workers can land in the same millisecond, and the duplicate name would surface as an
   unreproducible locator failure somewhere else entirely

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,10 @@ clean:
 	rm -rf uploads uploads-test
 	rm -rf coverage
 
+# Not in `clean`: a flake hunt is hours of machine time, and its results are
+# read days later when comparing a hunt from before a fix with one from after.
 clean-all: clean
+	rm -rf .flake-hunt
 	rm -rf node_modules
 
 dev-migrate-up: install

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -168,6 +168,61 @@ component that formats a date in the ambient zone renders identically on both
 sides and its hydration mismatch stays invisible. In the image it does not.
 Dates must be formatted in an explicit zone — the event's — never the process's.
 
+## Flake hunting
+
+A test that fails once in twenty runs is invisible to a normal `make test-e2e`.
+`scripts/e2e-flake-hunt.sh` runs the suite repeatedly and keeps the evidence, so
+flakes can be ranked by failure rate instead of by whoever noticed one last:
+
+```bash
+scripts/e2e-flake-hunt.sh                      # 20 runs of the whole suite
+scripts/e2e-flake-hunt.sh 5 -- tests/e2e/voting.spec.ts --repeat-each=3
+nohup scripts/e2e-flake-hunt.sh 20 > flake-hunt.log 2>&1 &   # overnight
+```
+
+Everything lands in `.flake-hunt/<UTC timestamp>/` (gitignored): `meta.json`
+(commit, worker count, machine), then one `run-NNN/` per iteration holding that
+run's `results.json` (the Playwright JSON report), its console log, and traces
+of whatever failed. Traces are recorded with `--trace=retain-on-failure`, so a
+failure comes with network log, console and per-action DOM snapshots — open one
+with `bun x playwright show-trace <path>`.
+
+The app is built and started **once** for the whole hunt, not per run: a
+`next build` per iteration would dominate the runtime, while the part that has
+to repeat — reseeding the database in `globalSetup` — still happens once per
+run. Retries are forced to 0: the hunt wants raw failure rates, not
+Playwright's own flake classification.
+
+Two knobs, both environment variables:
+
+- `E2E_WORKERS=N` — passed on as `--workers`. Setting it at or above the core
+  count overloads the CPU deliberately, which makes timing-dependent flakes
+  surface in far fewer runs.
+- `HUNT_KEEP_PASSING=0` — shrink green runs' `results.json` to their stats
+  block. Only worth it for very long hunts: the report still counts those runs
+  as passes, but their per-test durations are gone, so the duration-outlier
+  section is left looking at the red runs alone.
+
+The hunt ends by aggregating itself. To re-aggregate, or to compare a hunt from
+before a fix with one from after:
+
+```bash
+bun scripts/e2e-flake-report.ts .flake-hunt/<ts>
+bun scripts/e2e-flake-report.ts .flake-hunt/<before> .flake-hunt/<after>
+```
+
+The report — printed and written to `report.md` in the last directory given —
+lists flaky tests (failed in some runs, passed in others) with their failure
+rate, normalized error signature and the runs whose traces to open; persistent
+failures separately, since failing every time is a breakage rather than a
+flake; tests whose p95 duration is within striking distance of their timeout;
+and failures grouped by signature, which is what reveals that several tests
+share one root cause.
+
+If the mail variables are set in `.env.test.local`, start mailpit (`make
+mailpit`) before a hunt — otherwise the email specs fail identically in every
+run and clutter the report as persistent failures.
+
 ## E2E conventions
 
 - Imitate human behavior — click visible elements, navigate naturally

--- a/scripts/e2e-flake-hunt.sh
+++ b/scripts/e2e-flake-hunt.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Run the E2E suite N times and keep machine-readable results, so flaky tests
+# can be found by rate instead of by anecdote. Typically started once and left
+# to run (overnight):
+#
+#     nohup scripts/e2e-flake-hunt.sh 20 > flake-hunt.log 2>&1 &
+#     scripts/e2e-flake-hunt.sh 5 -- tests/e2e/voting.spec.ts --repeat-each=3
+#
+# Results land in .flake-hunt/<UTC timestamp>/run-NNN/ (results.json, the
+# Playwright JSON report, plus traces of whatever failed). The run ends by
+# aggregating them with scripts/e2e-flake-report.ts.
+#
+# Knobs:
+#   E2E_WORKERS=N       passed to playwright as --workers; setting it to (or
+#                       above) the core count overloads the CPU on purpose,
+#                       which is what makes timing flakes show up sooner.
+#   HUNT_KEEP_PASSING=0 shrink a green run's results.json to its stats block.
+#                       Only worth it for very long hunts — the per-test data
+#                       it drops is what the duration-outlier section needs.
+#
+# The server is built and started once for the whole hunt, not per run: a
+# `next build` per iteration would dominate the runtime, while the part that
+# actually has to repeat — reseeding the database in globalSetup — still runs
+# once per iteration.
+#
+# If the mail variables are set in .env.test.local, mailpit must be running
+# (`make mailpit`), otherwise every run fails the email specs identically. The
+# report calls that out as a persistent failure rather than a flake.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Playwright and the package scripts get this for free from their runner; a
+# plain shell script has to put `next` on the PATH itself.
+PATH="$PWD/node_modules/.bin:$PATH"
+export PATH
+
+RUNS=20
+if [ $# -gt 0 ] && [ "$1" != "--" ]; then
+  RUNS="$1"
+  shift
+fi
+if [ $# -gt 0 ]; then
+  if [ "$1" != "--" ]; then
+    echo "usage: $0 [runs] [-- extra playwright args]" >&2
+    exit 2
+  fi
+  shift
+fi
+EXTRA=("$@")
+
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "runs must be a positive integer, got \"$RUNS\"" >&2
+  exit 2
+fi
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT=".flake-hunt/$TIMESTAMP"
+mkdir -p "$OUT"
+
+PORT="$(bun -e 'const s=require("net").createServer();s.listen(0,()=>{process.stdout.write(String(s.address().port));s.close();})')"
+BASE_URL="http://localhost:$PORT"
+
+server_answering() { curl -fsS "$BASE_URL/api/health" >/dev/null 2>&1; }
+
+SERVER_PID=""
+cleanup() {
+  status=$?
+  if [ -n "$SERVER_PID" ]; then
+    # setsid put the server in its own process group, so the whole tree
+    # (bun → sh → next-server) goes down with one signal.
+    kill -- "-$SERVER_PID" 2>/dev/null || kill "$SERVER_PID" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+      if ! server_answering; then break; fi
+      sleep 0.5
+    done
+    if server_answering; then
+      echo "warning: something is still answering $BASE_URL — kill it by hand" >&2
+    fi
+  fi
+  exit $status
+}
+trap cleanup EXIT
+
+echo "==> Building the app"
+bun set-env.ts test "next build"
+
+echo "==> Starting the server on $BASE_URL"
+# SITE_URL ends up in the links of sent mail; a real environment variable beats
+# the .env.test value (see set-env.ts), so the email specs follow links back to
+# this hunt's server.
+SITE_URL="$BASE_URL" setsid bun set-env.ts test "next start -p $PORT" \
+  >"$OUT/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 120); do
+  if server_answering; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "The server exited before answering — see $OUT/server.log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+if [ -z "${ready:-}" ]; then
+  echo "The server did not answer $BASE_URL/api/health within 120s" >&2
+  exit 1
+fi
+
+PW_ARGS=(--reporter=json --trace=retain-on-failure)
+# Raw failure rates are the point, so no retries — and with one server shared
+# by every run, a retry would re-enter a database the suite has already
+# mutated. (CI=1 in the environment would otherwise switch retries on.)
+PW_ARGS+=(--retries=0)
+if [ -n "${E2E_WORKERS:-}" ]; then
+  PW_ARGS+=("--workers=$E2E_WORKERS")
+fi
+
+HUNT_META_COMMAND="$0 $RUNS${EXTRA[*]:+ -- ${EXTRA[*]}}" \
+  HUNT_META_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)" \
+  HUNT_META_DIRTY="$(test -n "$(git status --porcelain 2>/dev/null)" && echo 1 || echo 0)" \
+  HUNT_META_RUNS="$RUNS" \
+  HUNT_META_WORKERS="${E2E_WORKERS:-default}" \
+  HUNT_META_NPROC="$(nproc 2>/dev/null || echo unknown)" \
+  HUNT_META_PLAYWRIGHT="$(bun x playwright --version 2>/dev/null || echo unknown)" \
+  HUNT_META_PORT="$PORT" \
+  bun -e 'console.log(JSON.stringify({
+    command: process.env.HUNT_META_COMMAND,
+    startedAt: new Date().toISOString(),
+    commit: process.env.HUNT_META_COMMIT,
+    dirty: process.env.HUNT_META_DIRTY === "1",
+    runs: Number(process.env.HUNT_META_RUNS),
+    workers: process.env.HUNT_META_WORKERS,
+    nproc: process.env.HUNT_META_NPROC,
+    playwright: process.env.HUNT_META_PLAYWRIGHT,
+    port: Number(process.env.HUNT_META_PORT),
+  }, null, 2))' >"$OUT/meta.json"
+
+echo "==> $RUNS runs into $OUT"
+for i in $(seq 1 "$RUNS"); do
+  RUN_DIR="$OUT/$(printf 'run-%03d' "$i")"
+  mkdir -p "$RUN_DIR"
+  started=$(date +%s)
+
+  set +e
+  PLAYWRIGHT_JSON_OUTPUT_FILE="$RUN_DIR/results.json" \
+    E2E_EXTERNAL_SERVER=1 \
+    E2E_PORT="$PORT" \
+    SITE_URL="$BASE_URL" \
+    bun set-env.ts test bun x playwright test \
+    "${PW_ARGS[@]}" --output="$RUN_DIR/test-results" "${EXTRA[@]}" \
+    >"$RUN_DIR/run.log" 2>&1
+  exit_code=$?
+  set -e
+  echo "$exit_code" >"$RUN_DIR/exit-code"
+
+  elapsed=$(($(date +%s) - started))
+  failed="$(RESULTS="$RUN_DIR/results.json" bun -e '
+    const fs = require("fs");
+    try {
+      const r = JSON.parse(fs.readFileSync(process.env.RESULTS, "utf8"));
+      process.stdout.write(String(r.stats?.unexpected ?? "?"));
+    } catch {
+      process.stdout.write("?");
+    }' 2>/dev/null || echo "?")"
+
+  if [ "$failed" = "0" ] && [ "${HUNT_KEEP_PASSING:-1}" = "0" ]; then
+    RESULTS="$RUN_DIR/results.json" bun -e '
+      const fs = require("fs");
+      const r = JSON.parse(fs.readFileSync(process.env.RESULTS, "utf8"));
+      fs.writeFileSync(
+        process.env.RESULTS,
+        JSON.stringify({
+          stats: r.stats,
+          errors: r.errors,
+          suites: [],
+          // Read by e2e-flake-report.ts: without it the run would drop out of
+          // the failure-rate denominator and turn every flake into a
+          // persistent failure.
+          shrunk: true,
+        })
+      );'
+  fi
+
+  printf 'run %03d: %s failed, exit %s (%ds)\n' "$i" "$failed" "$exit_code" "$elapsed"
+done
+
+echo "==> Aggregating"
+bun scripts/e2e-flake-report.ts "$OUT"

--- a/scripts/e2e-flake-report.ts
+++ b/scripts/e2e-flake-report.ts
@@ -1,0 +1,482 @@
+/**
+ * Aggregate the results of one or more flake hunts (see e2e-flake-hunt.sh)
+ * into a markdown report: which tests fail intermittently, how often, with
+ * what error signature, and where their traces are.
+ *
+ *   bun scripts/e2e-flake-report.ts .flake-hunt/<ts> [more hunt dirs...]
+ *
+ * Passing several hunt directories adds a before/after comparison table. The
+ * report is printed and written to report.md in the last directory given.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+// Only the parts of the Playwright JSON reporter's output this report reads.
+// Everything is optional: a run killed mid-suite still writes a file.
+interface JsonError {
+  message?: string;
+}
+interface JsonAttachment {
+  name?: string;
+  path?: string;
+}
+interface JsonResult {
+  status?: string;
+  duration?: number;
+  errors?: JsonError[];
+  error?: JsonError;
+  attachments?: JsonAttachment[];
+}
+interface JsonTest {
+  status?: string;
+  timeout?: number;
+  results?: JsonResult[];
+}
+interface JsonSpec {
+  title?: string;
+  file?: string;
+  tests?: JsonTest[];
+}
+interface JsonSuite {
+  title?: string;
+  file?: string;
+  specs?: JsonSpec[];
+  suites?: JsonSuite[];
+}
+interface JsonStats {
+  duration?: number;
+  unexpected?: number;
+}
+interface JsonReport {
+  suites?: JsonSuite[];
+  errors?: JsonError[];
+  stats?: JsonStats;
+  // Not Playwright's: set by e2e-flake-hunt.sh when HUNT_KEEP_PASSING=0 threw
+  // a green run's per-test data away.
+  shrunk?: boolean;
+}
+
+interface Observation {
+  key: string;
+  status: string;
+  durationMs: number;
+  timeoutMs: number;
+  signature?: string;
+  hasTrace: boolean;
+}
+
+interface Run {
+  name: string;
+  green: boolean;
+  shrunk: boolean;
+  durationMs: number;
+  observations: Observation[];
+}
+
+interface TestAggregate {
+  key: string;
+  runsSeen: number;
+  fails: number;
+  durations: number[];
+  timeoutMs: number;
+  signatures: Map<string, number>;
+  failedIn: string[];
+  tracesIn: string[];
+}
+
+interface Hunt {
+  dir: string;
+  runs: Run[];
+  tests: Map<string, TestAggregate>;
+  meta: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+// A test consistently spending most of its budget is one slow machine away
+// from a timeout, so flag it before it starts failing.
+const OUTLIER_FRACTION = 0.6;
+
+function readJson(file: string): JsonReport | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8")) as JsonReport;
+  } catch {
+    return undefined;
+  }
+}
+
+// Built at runtime because a literal escape byte in a regex trips
+// eslint's no-control-regex.
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+function normalizeSignature(message: string): string {
+  const firstLine = message.replace(ANSI, "").split("\n")[0]?.trim() ?? "";
+  return firstLine
+    .replace(/\d{4}-\d{2}-\d{2}T[\d:.]+Z?/g, "<ts>")
+    .replace(/localhost:\d+/g, "localhost:<port>")
+    .replace(/\b\d+(\.\d+)?\s?(ms|s)\b/g, "<dur>")
+    .replace(/\b\d{9,}\b/g, "<n>")
+    .replace(/\b[0-9a-f]{8,}\b/gi, "<hex>")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function collectSpecs(
+  suites: JsonSuite[],
+  ancestors: string[]
+): { spec: JsonSpec; titlePath: string[] }[] {
+  const out: { spec: JsonSpec; titlePath: string[] }[] = [];
+  for (const suite of suites) {
+    // The file-level suite is titled with the file path itself; describe
+    // blocks below it carry real titles.
+    const title = suite.title && suite.title !== suite.file ? suite.title : "";
+    const nextAncestors = title ? [...ancestors, title] : ancestors;
+    for (const spec of suite.specs ?? []) {
+      out.push({ spec, titlePath: nextAncestors });
+    }
+    out.push(...collectSpecs(suite.suites ?? [], nextAncestors));
+  }
+  return out;
+}
+
+function observationsOf(report: JsonReport): Observation[] {
+  const observations: Observation[] = [];
+  for (const { spec, titlePath } of collectSpecs(report.suites ?? [], [])) {
+    const name = [...titlePath, spec.title ?? "(untitled)"].join(" › ");
+    const key = `${spec.file ?? "(unknown file)"} › ${name}`;
+    for (const test of spec.tests ?? []) {
+      const results = test.results ?? [];
+      const durationMs = results.reduce((sum, r) => sum + (r.duration ?? 0), 0);
+      const failing = results.find(
+        (r) => r.status && r.status !== "passed" && r.status !== "skipped"
+      );
+      const message =
+        failing?.errors?.[0]?.message ?? failing?.error?.message ?? "";
+      const hasTrace = results
+        .flatMap((r) => r.attachments ?? [])
+        .some((a) => a.name === "trace" && a.path);
+      observations.push({
+        key,
+        status: test.status ?? "unknown",
+        durationMs,
+        timeoutMs: test.timeout ?? DEFAULT_TIMEOUT_MS,
+        signature: message ? normalizeSignature(message) : undefined,
+        hasTrace,
+      });
+    }
+  }
+  return observations;
+}
+
+function loadHunt(dir: string): Hunt {
+  const runDirs = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("run-"))
+    .map((entry) => entry.name)
+    .sort();
+  if (runDirs.length === 0) {
+    throw new Error(`No run-* directories in ${dir}`);
+  }
+
+  const runs: Run[] = [];
+  for (const name of runDirs) {
+    const runDir = path.join(dir, name);
+    const report = readJson(path.join(runDir, "results.json"));
+    if (!report) {
+      runs.push({
+        name,
+        green: false,
+        shrunk: false,
+        durationMs: 0,
+        observations: [],
+      });
+      continue;
+    }
+    runs.push({
+      name,
+      green: (report.stats?.unexpected ?? 0) === 0,
+      shrunk: report.shrunk === true,
+      durationMs: report.stats?.duration ?? 0,
+      observations: observationsOf(report),
+    });
+  }
+
+  const tests = new Map<string, TestAggregate>();
+  for (const run of runs) {
+    for (const observation of run.observations) {
+      if (observation.status === "skipped") continue;
+      let aggregate = tests.get(observation.key);
+      if (!aggregate) {
+        aggregate = {
+          key: observation.key,
+          runsSeen: 0,
+          fails: 0,
+          durations: [],
+          timeoutMs: observation.timeoutMs,
+          signatures: new Map(),
+          failedIn: [],
+          tracesIn: [],
+        };
+        tests.set(observation.key, aggregate);
+      }
+      aggregate.runsSeen += 1;
+      aggregate.durations.push(observation.durationMs);
+      if (observation.status !== "expected") {
+        aggregate.fails += 1;
+        aggregate.failedIn.push(run.name);
+        const signature = observation.signature ?? "(no error message)";
+        aggregate.signatures.set(
+          signature,
+          (aggregate.signatures.get(signature) ?? 0) + 1
+        );
+        if (observation.hasTrace) aggregate.tracesIn.push(run.name);
+      }
+    }
+  }
+
+  // A shrunk run kept only its stats, but it was green, so every test that
+  // ran anywhere in the hunt passed in it. Without this the denominator of
+  // the failure rate would count red runs only, and a flake that failed once
+  // in twenty runs would read as 1/1 — a persistent failure, the opposite of
+  // what the hunt found. (A test skipped only in some runs is credited a pass
+  // it never earned; the alternative is not reporting failure rates at all.)
+  const shrunkRuns = runs.filter((run) => run.shrunk).length;
+  for (const aggregate of tests.values()) aggregate.runsSeen += shrunkRuns;
+
+  const metaFile = path.join(dir, "meta.json");
+  const meta = fs.existsSync(metaFile)
+    ? fs.readFileSync(metaFile, "utf8").trim()
+    : "";
+
+  return { dir, runs, tests, meta };
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(p * sorted.length) - 1)
+  );
+  return sorted[index] ?? 0;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 90) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m${String(Math.round(seconds % 60)).padStart(2, "0")}s`;
+}
+
+function cell(text: string, maxLength = 140): string {
+  const trimmed =
+    text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+  return trimmed.replace(/\|/g, "\\|");
+}
+
+function dominantSignature(aggregate: TestAggregate): string {
+  let best = "";
+  let bestCount = 0;
+  for (const [signature, count] of aggregate.signatures) {
+    if (count > bestCount) {
+      best = signature;
+      bestCount = count;
+    }
+  }
+  const others = aggregate.signatures.size - 1;
+  return others > 0 ? `${best} _(+${others} other)_` : best;
+}
+
+function runList(names: string[]): string {
+  if (names.length === 0) return "—";
+  const shown = names.slice(0, 5).join(", ");
+  return names.length > 5 ? `${shown}, +${names.length - 5}` : shown;
+}
+
+function huntSection(hunt: Hunt): string[] {
+  const lines: string[] = [];
+  const green = hunt.runs.filter((run) => run.green).length;
+  const durations = hunt.runs.map((run) => run.durationMs);
+
+  lines.push(`## ${hunt.dir}`, "");
+  lines.push(
+    `- Runs: **${hunt.runs.length}** (green ${green}, red ${hunt.runs.length - green})`
+  );
+  lines.push(
+    `- Wall clock per run: p50 ${formatDuration(percentile(durations, 0.5))}, p95 ${formatDuration(percentile(durations, 0.95))}`
+  );
+  const shrunk = hunt.runs.filter((run) => run.shrunk).length;
+  if (shrunk > 0) {
+    lines.push(
+      `- ${shrunk} green run(s) kept only their stats (\`HUNT_KEEP_PASSING=0\`):` +
+        " counted as passes below, but their durations are missing, so the" +
+        " duration outliers are drawn from the red runs alone"
+    );
+  }
+  if (hunt.meta) {
+    lines.push("", "<details><summary>meta.json</summary>", "");
+    lines.push("```json", hunt.meta, "```", "</details>");
+  }
+  lines.push("");
+
+  const aggregates = [...hunt.tests.values()];
+  const persistent = aggregates
+    .filter((a) => a.fails > 0 && a.fails === a.runsSeen)
+    .sort((a, b) => b.fails - a.fails);
+  const flaky = aggregates
+    .filter((a) => a.fails > 0 && a.fails < a.runsSeen)
+    .sort((a, b) => b.fails / b.runsSeen - a.fails / a.runsSeen);
+
+  lines.push("### Flaky tests", "");
+  if (flaky.length === 0) {
+    lines.push("None — no test failed in some runs and passed in others.", "");
+  } else {
+    lines.push("| Test | Fails | Signature | Traces in |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const aggregate of flaky) {
+      lines.push(
+        `| ${cell(aggregate.key)} | ${aggregate.fails}/${aggregate.runsSeen} | ${cell(
+          dominantSignature(aggregate)
+        )} | ${runList(aggregate.tracesIn)} |`
+      );
+    }
+    lines.push("");
+  }
+
+  if (persistent.length > 0) {
+    lines.push("### Persistent failures", "");
+    lines.push(
+      "Failed in every run they were part of — a breakage, not a flake.",
+      ""
+    );
+    lines.push("| Test | Fails | Signature | Traces in |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const aggregate of persistent) {
+      lines.push(
+        `| ${cell(aggregate.key)} | ${aggregate.fails}/${aggregate.runsSeen} | ${cell(
+          dominantSignature(aggregate)
+        )} | ${runList(aggregate.tracesIn)} |`
+      );
+    }
+    lines.push("");
+  }
+
+  const outliers = aggregates
+    .map((aggregate) => ({
+      aggregate,
+      p95: percentile(aggregate.durations, 0.95),
+    }))
+    .filter(
+      ({ aggregate, p95 }) => p95 > OUTLIER_FRACTION * aggregate.timeoutMs
+    )
+    .sort((a, b) => b.p95 - a.p95);
+
+  lines.push(
+    `### Duration outliers (p95 above ${OUTLIER_FRACTION * 100}% of the timeout)`,
+    ""
+  );
+  if (outliers.length === 0) {
+    lines.push("None.", "");
+  } else {
+    lines.push("| Test | p50 | p95 | Timeout |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const { aggregate, p95 } of outliers) {
+      lines.push(
+        `| ${cell(aggregate.key)} | ${formatDuration(
+          percentile(aggregate.durations, 0.5)
+        )} | ${formatDuration(p95)} | ${formatDuration(aggregate.timeoutMs)} |`
+      );
+    }
+    lines.push("");
+  }
+
+  // One root cause often hits several tests, so the same signature appearing
+  // across them is the strongest hint the report can give.
+  const bySignature = new Map<string, { count: number; tests: Set<string> }>();
+  for (const aggregate of aggregates) {
+    for (const [signature, count] of aggregate.signatures) {
+      const entry = bySignature.get(signature) ?? {
+        count: 0,
+        tests: new Set(),
+      };
+      entry.count += count;
+      entry.tests.add(aggregate.key);
+      bySignature.set(signature, entry);
+    }
+  }
+  lines.push("### Failure signatures", "");
+  if (bySignature.size === 0) {
+    lines.push("None.", "");
+  } else {
+    lines.push("| Signature | Failures | Tests |");
+    lines.push("| --- | --- | --- |");
+    for (const [signature, entry] of [...bySignature].sort(
+      (a, b) => b[1].count - a[1].count
+    )) {
+      lines.push(
+        `| ${cell(signature)} | ${entry.count} | ${entry.tests.size} |`
+      );
+    }
+    lines.push("");
+  }
+
+  return lines;
+}
+
+function comparisonSection(hunts: Hunt[]): string[] {
+  const keys = new Set<string>();
+  for (const hunt of hunts) {
+    for (const [key, aggregate] of hunt.tests) {
+      if (aggregate.fails > 0) keys.add(key);
+    }
+  }
+  if (keys.size === 0) return [];
+
+  const lines: string[] = ["## Comparison", ""];
+  lines.push(`| Test | ${hunts.map((h) => cell(h.dir, 40)).join(" | ")} |`);
+  lines.push(`| --- | ${hunts.map(() => "---").join(" | ")} |`);
+  for (const key of [...keys].sort()) {
+    const cells = hunts.map((hunt) => {
+      const aggregate = hunt.tests.get(key);
+      if (!aggregate) return "—";
+      return `${aggregate.fails}/${aggregate.runsSeen}`;
+    });
+    lines.push(`| ${cell(key)} | ${cells.join(" | ")} |`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function buildReport(hunts: Hunt[]): string {
+  const lines = [
+    "# E2E flake hunt report",
+    "",
+    `Generated ${new Date().toISOString()}`,
+    "",
+  ];
+  for (const hunt of hunts) lines.push(...huntSection(hunt));
+  if (hunts.length > 1) lines.push(...comparisonSection(hunts));
+  return lines.join("\n");
+}
+
+function main() {
+  const dirs = process.argv.slice(2);
+  if (dirs.length === 0) {
+    console.error(
+      "usage: bun scripts/e2e-flake-report.ts <hunt dir> [more hunt dirs...]"
+    );
+    process.exit(2);
+  }
+
+  const report = buildReport(dirs.map(loadHunt));
+  const target = path.join(dirs[dirs.length - 1], "report.md");
+  fs.writeFileSync(target, `${report}\n`);
+  console.log(report);
+  console.log(`\nWritten to ${target}`);
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  main();
+}
+
+export { normalizeSignature, loadHunt, buildReport };

--- a/tests/unit/e2e-flake-report.test.ts
+++ b/tests/unit/e2e-flake-report.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  normalizeSignature,
+  loadHunt,
+  buildReport,
+} from "@/scripts/e2e-flake-report";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** A Playwright JSON report holding one passing and one optionally failing test. */
+function report(failing: boolean) {
+  const test = (title: string, ok: boolean, durationMs: number) => ({
+    title,
+    file: "tests/e2e/x.spec.ts",
+    tests: [
+      {
+        status: ok ? "expected" : "unexpected",
+        timeout: 30_000,
+        results: [
+          {
+            status: ok ? "passed" : "failed",
+            duration: durationMs,
+            errors: ok ? [] : [{ message: "Error: locator.click: Timeout" }],
+            attachments: ok
+              ? []
+              : [{ name: "trace", path: "/abs/test-results/x/trace.zip" }],
+          },
+        ],
+      },
+    ],
+  });
+  return {
+    stats: { duration: 60_000, unexpected: failing ? 1 : 0 },
+    errors: [],
+    suites: [
+      {
+        title: "tests/e2e/x.spec.ts",
+        file: "tests/e2e/x.spec.ts",
+        specs: [test("steady", true, 1_000), test("wobbly", !failing, 25_000)],
+        suites: [],
+      },
+    ],
+  };
+}
+
+/** Lay out a hunt directory whose run `redRuns` (1-based) failed. */
+function hunt(runs: number, redRuns: number[], shrinkGreen = false): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "flake-hunt-"));
+  tmpDirs.push(dir);
+  for (let i = 1; i <= runs; i++) {
+    const runDir = path.join(dir, `run-${String(i).padStart(3, "0")}`);
+    fs.mkdirSync(runDir);
+    const red = redRuns.includes(i);
+    const full = report(red);
+    const written =
+      !red && shrinkGreen
+        ? { stats: full.stats, errors: full.errors, suites: [], shrunk: true }
+        : full;
+    fs.writeFileSync(
+      path.join(runDir, "results.json"),
+      JSON.stringify(written)
+    );
+  }
+  return dir;
+}
+
+describe("normalizeSignature", () => {
+  it("keeps the first line and strips ANSI colouring", () => {
+    const esc = String.fromCharCode(27);
+    expect(
+      normalizeSignature(`${esc}[31mError: boom${esc}[39m\n  at foo.ts:1`)
+    ).toBe("Error: boom");
+  });
+
+  it("collapses the detail that differs between two runs of the same failure", () => {
+    const a = normalizeSignature(
+      "Timeout 5000ms exceeded at 2026-08-29T10:00:00Z on localhost:41234 for id a1b2c3d4e5"
+    );
+    const b = normalizeSignature(
+      "Timeout 30s exceeded at 2026-01-02T03:04:05Z on localhost:9 for id ffffffffff"
+    );
+    expect(a).toBe(b);
+    expect(a).toBe(
+      "Timeout <dur> exceeded at <ts> on localhost:<port> for id <hex>"
+    );
+  });
+});
+
+describe("loadHunt", () => {
+  it("counts a test's failures against every run it took part in", () => {
+    const { tests } = loadHunt(hunt(3, [3]));
+    const wobbly = tests.get("tests/e2e/x.spec.ts › wobbly");
+    expect(wobbly).toBeDefined();
+    expect(wobbly?.fails).toBe(1);
+    expect(wobbly?.runsSeen).toBe(3);
+    expect(wobbly?.failedIn).toEqual(["run-003"]);
+  });
+
+  it("still counts green runs that were shrunk to their stats block", () => {
+    const { tests } = loadHunt(hunt(3, [3], true));
+    const wobbly = tests.get("tests/e2e/x.spec.ts › wobbly");
+    // Otherwise a flake that failed once in twenty runs reads as 1/1 — a
+    // persistent failure — which is the opposite of what the hunt found.
+    expect(wobbly?.fails).toBe(1);
+    expect(wobbly?.runsSeen).toBe(3);
+  });
+
+  it("rejects a directory with no runs in it", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "flake-hunt-"));
+    tmpDirs.push(empty);
+    expect(() => loadHunt(empty)).toThrow(/No run-\* directories/);
+  });
+});
+
+describe("buildReport", () => {
+  it("reports a test that failed in some runs as flaky", () => {
+    const report = buildReport([loadHunt(hunt(3, [3]))]);
+    const flaky = report.slice(
+      report.indexOf("### Flaky tests"),
+      report.indexOf("### Duration outliers")
+    );
+    expect(flaky).toContain("wobbly");
+    expect(flaky).toContain("1/3");
+    expect(report).not.toContain("### Persistent failures");
+  });
+
+  it("reports a test that failed in every run as a persistent failure", () => {
+    const report = buildReport([loadHunt(hunt(3, [1, 2, 3]))]);
+    expect(report).toContain("### Persistent failures");
+    const flaky = report.slice(
+      report.indexOf("### Flaky tests"),
+      report.indexOf("### Persistent failures")
+    );
+    expect(flaky).toContain("None");
+  });
+
+  it("keeps a shrunk hunt's flake out of the persistent failures", () => {
+    const report = buildReport([loadHunt(hunt(3, [3], true))]);
+    expect(report).not.toContain("### Persistent failures");
+    expect(report).toContain("1/3");
+  });
+});


### PR DESCRIPTION
A flake that fires once in twenty runs is invisible to a single `make
test-e2e`, so it gets argued about instead of fixed. The hunt runs the suite
N times against one build, keeps each run's JSON report and the traces of
whatever failed, and aggregates them into a report that ranks tests by
failure rate and groups them by error signature.

The aggregation is unit tested: its failure-rate arithmetic is the whole
point of the tool, and a report that quietly miscounts is worse than no
report.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=8f39f830eea9e21affa6cf6ce6bcac9b96bd5de2 -->