### PR TITLE
feat: comment on sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Comments on sessions**: a session's details now have the same comment section proposals already had — threaded
+  replies, likes, editing and deleting your own comments. Open any session in the schedule to discuss times, rooms or
+  last-minute changes
 - **Moving between attendee profiles slides instead of jumping**: Prev, Next and the arrow keys now slide one profile
   out as the next slides in, the way a swipe already moves between them
 

--- a/app/(site)/[eventSlug]/comment-actions.ts
+++ b/app/(site)/[eventSlug]/comment-actions.ts
@@ -11,6 +11,7 @@ import {
   commentLikeSchema,
   commentUpdateSchema,
   proposalCommentSchema,
+  sessionCommentSchema,
 } from "@/model/comment";
 import { notifyProposalCommented } from "@/utils/notifications";
 import { serverNow } from "@/utils/dev-clock-server";
@@ -42,6 +43,15 @@ function toResult(
   }
   console.error(failure, error);
   return { error: failure };
+}
+
+// Only surfaces that server-render their comments need cache invalidation —
+// proposals. Sessions reload through their own endpoint, so they pass no slug
+// and nothing is revalidated for them.
+function revalidateEvent(eventSlug: string | undefined): void {
+  if (eventSlug) {
+    revalidatePath(`/${eventSlug}`, "layout");
+  }
 }
 
 async function requireGuest(): Promise<string> {
@@ -107,8 +117,46 @@ export async function createProposalComment(
       body,
       createdTime: await serverNow(),
     });
-    revalidatePath(`/${eventSlug}`, "layout");
+    revalidateEvent(eventSlug);
     after(() => notifyProposalCommented({ proposalId, comment }));
+    return { success: true };
+  } catch (error) {
+    return toResult(error, "Failed to post comment");
+  }
+}
+
+export async function createSessionComment(
+  comment: z.input<typeof sessionCommentSchema>
+): Promise<CommentActionResult>;
+export async function createSessionComment(
+  input: unknown
+): Promise<CommentActionResult> {
+  try {
+    const guest = await requireGuest();
+    const { sessionId, parentId, body } = await requireParsed(
+      sessionCommentSchema,
+      input
+    );
+
+    // validation
+    if (!(await getRepositories().sessions.findById(sessionId))) {
+      return { error: "Session not found" };
+    }
+    if (parentId) {
+      const parentOf =
+        await getRepositories().sessionComments.findSubjectId(parentId);
+      if (!parentOf || parentOf !== sessionId) {
+        return { error: "The comment being replied to is invalid" };
+      }
+    }
+
+    await getRepositories().sessionComments.create({
+      subjectId: sessionId,
+      authorId: guest,
+      parentId,
+      body,
+      createdTime: await serverNow(),
+    });
     return { success: true };
   } catch (error) {
     return toResult(error, "Failed to post comment");
@@ -133,7 +181,7 @@ export async function updateComment(
       body,
       editedTime: await serverNow(),
     });
-    revalidatePath(`/${eventSlug}`, "layout");
+    revalidateEvent(eventSlug);
     return { success: true };
   } catch (error) {
     return toResult(error, "Failed to update comment");
@@ -163,7 +211,7 @@ export async function toggleCommentLike(
       guestId: guest,
       createdTime: await serverNow(),
     });
-    revalidatePath(`/${eventSlug}`, "layout");
+    revalidateEvent(eventSlug);
     return { success: true, liked };
   } catch (error) {
     return toResult(error, "Failed to like comment");
@@ -185,7 +233,7 @@ export async function deleteComment(
     await requireOwnComment(commentId, guest);
 
     await getRepositories().comments.delete(commentId);
-    revalidatePath(`/${eventSlug}`, "layout");
+    revalidateEvent(eventSlug);
     return { success: true };
   } catch (error) {
     return toResult(error, "Failed to delete comment");

--- a/app/(site)/[eventSlug]/comment-likes.tsx
+++ b/app/(site)/[eventSlug]/comment-likes.tsx
@@ -18,7 +18,9 @@ export function CommentLikes({
   onChanged,
 }: {
   comment: Pick<Comment, "id" | "likes">;
-  eventSlug: string;
+  // Only the cache invalidation target for pages that server-render their
+  // comments — proposals. Sessions omit it.
+  eventSlug?: string;
   onChanged: () => void;
 }) {
   const { user: currentUserId } = useContext(UserContext);

--- a/app/(site)/[eventSlug]/comments-section.tsx
+++ b/app/(site)/[eventSlug]/comments-section.tsx
@@ -12,6 +12,7 @@ import type { CommentActionResult } from "./comment-actions";
 import { deleteComment, updateComment } from "./comment-actions";
 import { useLocalZone } from "@/utils/hooks";
 import { CommentLikes } from "./comment-likes";
+import type { LoadedComments } from "./use-comments";
 import { formatInLocalZone } from "@/utils/utils";
 
 export type CommentCreateInput = { parentId?: string; body: string };
@@ -59,20 +60,23 @@ export function CommentsSection({
   permalinkFor,
   changed,
 }: {
-  eventSlug: string;
+  // Only the cache invalidation target for pages that server-render their
+  // comments — proposals. Sessions omit it.
+  eventSlug?: string;
   timezone: string;
-  comments: Comment[];
-  // Scope-specific: the action called and where a permalink points differ per
-  // subject. Everything else about commenting is shared.
+  comments?: LoadedComments;
+  // Scope-specific: proposals and sessions differ in the action called and in
+  // where a permalink points. Everything else about commenting is shared.
   create: (input: CommentCreateInput) => Promise<CommentActionResult>;
   permalinkFor: (commentId: string) => string;
   changed: () => void;
 }) {
   const { user: currentUserId } = useContext(UserContext);
-  const roots = useMemo(() => buildTree(comments), [comments]);
+  const loaded = Array.isArray(comments) ? comments : null;
+  const roots = useMemo(() => (loaded ? buildTree(loaded) : []), [loaded]);
   const total = useMemo(
-    () => comments.filter((c) => !c.deleted).length,
-    [comments]
+    () => loaded?.filter((c) => !c.deleted)?.length,
+    [loaded]
   );
   const localZone = useLocalZone();
   const [highlightedId, highlight] = useHighlightedComment();
@@ -85,7 +89,32 @@ export function CommentsSection({
     document
       .getElementById(`comment-${highlightedId}`)
       ?.scrollIntoView({ block: "center" });
-  }, [highlightedId, comments]);
+  }, [highlightedId, loaded]);
+
+  if (comments === "error") {
+    return (
+      <section className="mt-8 border-t border-line-subtle pt-6">
+        <h2 className="text-lg font-semibold mb-4">
+          Comments could not be loaded
+        </h2>
+        <p className="text-sm text-fg-subtle">
+          Reload the page to try again — the comments are still there.
+        </p>
+      </section>
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <section className="mt-8 border-t border-line-subtle pt-6">
+        <h2 className="text-lg font-semibold mb-4">Loading comments...</h2>
+        <div aria-hidden="true" className="flex flex-col gap-2 animate-pulse">
+          <div className="h-4 w-28 rounded bg-surface-muted" />
+          <div className="h-4 w-56 rounded bg-surface-muted" />
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="mt-8 border-t border-line-subtle pt-6">
@@ -144,7 +173,7 @@ function CommentThread({
 }: {
   node: CommentNode;
   depth: number;
-  eventSlug: string;
+  eventSlug?: string;
   timezone: string;
   create: (input: CommentCreateInput) => Promise<CommentActionResult>;
   permalinkFor: (commentId: string) => string;

--- a/app/(site)/[eventSlug]/session-comments.tsx
+++ b/app/(site)/[eventSlug]/session-comments.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createSessionComment } from "./comment-actions";
+import { CommentsSection } from "./comments-section";
+import { useComments } from "./use-comments";
+
+// The session modal opens by pushing the URL locally, without an RSC
+// roundtrip, so its comments can't arrive as server props: they load through
+// /api/session/[sessionId]/comments instead, and every mutation reloads them.
+export function SessionComments({
+  sessionId,
+  eventSlug,
+  timezone,
+}: {
+  sessionId: string;
+  eventSlug: string;
+  timezone: string;
+}) {
+  const { comments, changed } = useComments(
+    `/api/session/${sessionId}/comments`
+  );
+
+  return (
+    <CommentsSection
+      timezone={timezone}
+      comments={comments}
+      create={(input) => createSessionComment({ sessionId, ...input })}
+      permalinkFor={(commentId) =>
+        `/${eventSlug}?viewSession=${sessionId}#comment-${commentId}`
+      }
+      changed={changed}
+    />
+  );
+}

--- a/app/(site)/[eventSlug]/use-comments.ts
+++ b/app/(site)/[eventSlug]/use-comments.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { Comment } from "@/db/repositories/interfaces";
+
+type SerializedComment = Omit<Comment, "createdTime" | "editedTime"> & {
+  createdTime: string;
+  editedTime: string | null;
+};
+
+/**
+ * What a comment section knows about its thread: `null` while the first load
+ * is still in flight, `"error"` when it failed, the comments otherwise. The
+ * three are deliberately distinct — an unreachable server must not render as
+ * an empty thread, and an empty thread must not render as a spinner.
+ */
+export type LoadedComments = Comment[] | "error" | null;
+
+function withDates(comment: SerializedComment): Comment {
+  return {
+    ...comment,
+    createdTime: new Date(comment.createdTime),
+    editedTime: comment.editedTime ? new Date(comment.editedTime) : null,
+  };
+}
+
+/**
+ * Loads the comments at `path` and reloads them whenever the returned
+ * `changed` is called. Modals that push their URL locally, without an RSC
+ * roundtrip, can't get their comments as server props and use this instead.
+ *
+ * A failed *reload* keeps what is already shown rather than wiping the thread;
+ * only a failed first load reports "error".
+ */
+export function useComments(path: string): {
+  comments: LoadedComments;
+  changed: () => void;
+} {
+  // Tagged with the path it came from, so a previous subject's comments never
+  // show through while the next ones load.
+  const [loaded, setLoaded] = useState<{
+    path: string;
+    comments: LoadedComments;
+  } | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(`${path}?reload=${reloadKey}`, { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`${res.status} loading ${path}`);
+        }
+        return (await res.json()) as SerializedComment[];
+      })
+      .then((data) => setLoaded({ path, comments: data.map(withDates) }))
+      .catch((e: unknown) => {
+        // Closing the modal or leaving the page aborts the request; there is
+        // nothing left to show and nobody to tell. Unhandled, that rejection
+        // reaches the window as an uncaught NetworkError.
+        if (controller.signal.aborted) {
+          return;
+        }
+        console.warn("Could not load comments", e);
+        setLoaded((previous) =>
+          previous?.path === path ? previous : { path, comments: "error" }
+        );
+      });
+    return () => controller.abort();
+  }, [path, reloadKey]);
+
+  const changed = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  return {
+    comments: loaded?.path === path ? loaded.comments : null,
+    changed,
+  };
+}

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -15,6 +15,7 @@ import { sessionsOverlap } from "../../session_utils";
 import { LockIcon } from "../../lock-icon";
 import { LocationTag } from "../session-text";
 import { viewProposalLinkFromElsewhere } from "../modal-nav";
+import { SessionComments } from "../session-comments";
 import { Markdown } from "@/app/(site)/markdown";
 
 export function ViewSession(props: {
@@ -340,6 +341,11 @@ export function ViewSession(props: {
           .
         </p>
       )}
+      <SessionComments
+        sessionId={session.id}
+        eventSlug={eventSlug}
+        timezone={event.timezone}
+      />
     </div>
   );
 }

--- a/app/api/session/[sessionId]/comments/route.ts
+++ b/app/api/session/[sessionId]/comments/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { getRepositories } from "@/db/container";
+
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response
+// and show stale comments after a reload.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
+// Comments are displayed to everyone in the session details, so like
+// per-session RSVPs they stay openly readable.
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  try {
+    const { sessions, sessionComments } = getRepositories();
+    // Without this an unknown id would answer with an empty thread, which is
+    // indistinguishable from a session nobody has commented on.
+    if (!(await sessions.findById(sessionId))) {
+      return NextResponse.json(
+        { error: "Session not found" },
+        { ...NO_STORE, status: 404 }
+      );
+    }
+    return NextResponse.json(await sessionComments.list(sessionId), NO_STORE);
+  } catch (error) {
+    console.error("Error fetching comments:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch comments" },
+      { ...NO_STORE, status: 500 }
+    );
+  }
+}

--- a/db/container.ts
+++ b/db/container.ts
@@ -37,6 +37,7 @@ export type Repositories = {
   /** Scope-agnostic comment operations (find, edit, like, delete). */
   comments: CommentsRepository;
   proposalComments: SubjectCommentsRepository;
+  sessionComments: SubjectCommentsRepository;
   days: DaysRepository;
   events: EventsRepository;
   guests: GuestsRepository;
@@ -57,6 +58,7 @@ function buildRepositories(sqlite: Database.Database): Repositories {
     authCodes: new SqliteAuthCodesRepository(db),
     comments: new SqliteCommentsRepository(db),
     proposalComments: sqliteSubjectCommentsRepository(db, "proposal"),
+    sessionComments: sqliteSubjectCommentsRepository(db, "session"),
     days: new SqliteDaysRepository(db),
     events: new SqliteEventsRepository(db),
     guests: new SqliteGuestsRepository(db),

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -677,9 +677,9 @@ export type Comment = {
 
 /**
  * Scope-agnostic comment operations. A comment is attached to exactly one
- * subject — so far only a session proposal — but finding, editing, liking and
- * deleting work identically whatever it hangs off, so they live here.
- * Attaching comments to a subject is a SubjectCommentsRepository.
+ * subject — a session proposal or a scheduled session — but finding, editing,
+ * liking and deleting work identically for all, so they live here. Attaching
+ * comments to a subject is a SubjectCommentsRepository.
  */
 export interface CommentsRepository {
   findById(commentId: string): Promise<Comment | undefined>;
@@ -699,8 +699,9 @@ export interface CommentsRepository {
 
 /**
  * Comments attached to one kind of subject. Which kind is fixed by the
- * repository itself — `proposalComments` on {@link Repositories} — so
- * `subjectId` below is always a proposal id.
+ * repository itself — `proposalComments` and `sessionComments` on
+ * {@link Repositories} — so `subjectId` below is always a proposal or session
+ * id respectively.
  */
 export interface SubjectCommentsRepository {
   /** All comments on the subject, oldest first, likes included. */

--- a/db/repositories/sqlite/comments.ts
+++ b/db/repositories/sqlite/comments.ts
@@ -253,7 +253,7 @@ type CommentJoin = {
   attach: (tx: Tx, commentId: string, subjectId: string) => void;
 };
 
-const JOINS: Record<"proposal", CommentJoin> = {
+const JOINS: Record<"proposal" | "session", CommentJoin> = {
   proposal: {
     table: schema.proposalComments,
     commentId: schema.proposalComments.commentId,
@@ -263,6 +263,13 @@ const JOINS: Record<"proposal", CommentJoin> = {
         .insert(schema.proposalComments)
         .values({ commentId, proposalId })
         .run(),
+  },
+  session: {
+    table: schema.sessionComments,
+    commentId: schema.sessionComments.commentId,
+    subjectId: schema.sessionComments.sessionId,
+    attach: (tx, commentId, sessionId) =>
+      tx.insert(schema.sessionComments).values({ commentId, sessionId }).run(),
   },
 };
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -321,6 +321,22 @@ export const proposalComments = sqliteTable(
   ]
 );
 
+export const sessionComments = sqliteTable(
+  "session_comments",
+  {
+    commentId: text("comment_id")
+      .notNull()
+      .references(() => comments.id, { onDelete: "cascade" }),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.commentId] }),
+    index("session_comments_session_idx").on(t.sessionId),
+  ]
+);
+
 export const votes = sqliteTable(
   "votes",
   {

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -174,6 +174,12 @@ Unlike votes, hosts plan around it. If you change your mind, take it back with
 - A session marked **closed** warns that you can be at most five minutes late,
   but doesn't block your RSVP.
 
+### Discuss a session
+
+Open a session to find the same comment section proposals have — useful for
+"which room did this move to?" and other last-minute coordination. Everything works as described under
+[Discuss a proposal](#discuss-a-proposal): threaded replies, likes, editing and deleting your own comments.
+
 ## Attendee directory & profiles
 
 The directory lists everyone at the event on a single page — photo and the

--- a/drizzle/0026_session_comments.sql
+++ b/drizzle/0026_session_comments.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `session_comments`
+(
+  `comment_id` text PRIMARY KEY NOT NULL,
+  `session_id` text             NOT NULL,
+  FOREIGN KEY (`comment_id`) REFERENCES `comments` (`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`session_id`) REFERENCES `sessions` (`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `session_comments_session_idx` ON `session_comments` (`session_id`);

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,1368 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0e054d3e-ab25-408b-9733-1e57e74cd1cf",
+  "prevId": "0a3e659f-e07a-43e9-a904-053b706f9548",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1786525223340,
       "tag": "0025_guest_profile_updated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1787430579703,
+      "tag": "0026_session_comments",
+      "breakpoints": true
     }
   ]
 }

--- a/model/comment.ts
+++ b/model/comment.ts
@@ -17,18 +17,27 @@ export const proposalCommentSchema = z.object({
   body,
 });
 
+export const sessionCommentSchema = z.object({
+  sessionId: z.string().min(1),
+  parentId: z.string().min(1).optional(),
+  body,
+});
+
+// eventSlug is only the cache invalidation target for pages that
+// server-render their comments — proposals. Sessions fetch theirs
+// client-side and omit it.
 export const commentUpdateSchema = z.object({
   commentId: z.string().min(1),
-  eventSlug: z.string().min(1),
+  eventSlug: z.string().min(1).optional(),
   body,
 });
 
 export const commentDeleteSchema = z.object({
   commentId: z.string().min(1),
-  eventSlug: z.string().min(1),
+  eventSlug: z.string().min(1).optional(),
 });
 
 export const commentLikeSchema = z.object({
   commentId: z.string().min(1),
-  eventSlug: z.string().min(1),
+  eventSlug: z.string().min(1).optional(),
 });

--- a/tests/e2e/session-comments.spec.ts
+++ b/tests/e2e/session-comments.spec.ts
@@ -1,0 +1,312 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+import {
+  openReplyForm,
+  postedComment,
+  submitReply,
+  toggleUntil,
+} from "./helpers/comments";
+
+// Conference Gamma is in the scheduling phase, so only its schedule has
+// sessions. Each test claims its own session: the suite runs in parallel
+// against one shared database, so two tests commenting on the same session
+// would see each other's comments.
+const CRDT_SESSION = /Hallway Track: CRDT Show & Tell/;
+const EDIT_SESSION = /Design Systems: Creating Consistency at Scale/;
+const THREAD_SESSION =
+  /Open Source Sustainability: Funding and Community Building/;
+const TOMBSTONE_SESSION = /API Design: RESTful vs GraphQL vs gRPC/;
+const LIKE_SESSION = /Microservices Architecture: Lessons from the Trenches/;
+const CLOSING_SESSION = /Closing Session & Farewell/;
+const SIBLINGS_SESSION =
+  /Blockchain Beyond Cryptocurrency: Practical Applications/;
+
+async function openSession(page: Page, title: RegExp) {
+  await page.getByRole("link", { name: title }).click();
+  const modal = page.getByRole("dialog", { name: "Session details" });
+  await expect(modal).toBeVisible();
+  return modal;
+}
+
+// selectUser logs out and back in; navigating before that settles aborts the
+// request and drops the selection.
+async function actAs(page: Page, name: RegExp) {
+  await selectUser(page, name);
+  await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
+}
+
+test("posts a comment on a session and renders it as markdown", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  // Bob hasn't RSVP'd here, so his only link in the modal will be as the
+  // comment's author.
+  await actAs(page, /Bob Test/i);
+
+  const modal = await openSession(page, CRDT_SESSION);
+  await expect(
+    modal.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+
+  const body = "bringing my laptop — **very** ready";
+  await modal.getByPlaceholder("Add a comment").fill(body);
+  await modal.getByRole("button", { name: "Comment", exact: true }).click();
+
+  await expect(modal.getByRole("heading", { name: "1 comment" })).toBeVisible();
+  await expect(
+    modal.locator("section p strong", { hasText: "very" })
+  ).toHaveCSS("font-weight", "700");
+  await expect(modal.getByRole("link", { name: "Bob Test" })).toBeVisible();
+  await expect(modal.getByPlaceholder("Add a comment")).toHaveValue("");
+
+  // Comments load through their own endpoint when the modal opens, so
+  // reopening must show them without any refresh.
+  await page.keyboard.press("Escape");
+  await expect(modal).toBeHidden();
+  const reopened = await openSession(page, CRDT_SESSION);
+  await expect(
+    reopened.getByRole("heading", { name: "1 comment" })
+  ).toBeVisible();
+  await expect(reopened.getByText("bringing my laptop").first()).toBeVisible();
+});
+
+test("edits a comment, showing when it was edited, then deletes it", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await actAs(page, /Alice Test/i);
+
+  const modal = await openSession(page, EDIT_SESSION);
+  await modal.getByPlaceholder("Add a comment").fill("first thoughts");
+  await modal.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(postedComment(modal, "first thoughts").first()).toBeVisible();
+  await expect(modal.getByText("(edited)")).toHaveCount(0);
+
+  await modal.getByRole("button", { name: "Edit" }).click();
+  await modal.getByPlaceholder("Edit your comment").fill("second thoughts");
+  await modal.getByRole("button", { name: "Save" }).click();
+
+  await expect(modal.getByText("second thoughts")).toBeVisible();
+  await expect(modal.getByText("first thoughts")).toHaveCount(0);
+  const editedMarker = modal.getByText("(edited)");
+  await expect(editedMarker).toBeVisible();
+  await expect(editedMarker).toHaveAttribute("title", /^Edited /);
+
+  await modal.getByRole("button", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Yes" }).click();
+
+  await expect(modal.getByText("second thoughts")).toHaveCount(0);
+  await expect(
+    modal.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+});
+
+test("replies to a comment, collapses the thread, and permalinks to a reply", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await actAs(page, /Alice Test/i);
+
+  const modal = await openSession(page, THREAD_SESSION);
+  await modal.getByPlaceholder("Add a comment").fill("the opening question");
+  await modal.getByRole("button", { name: "Comment", exact: true }).click();
+  const parent = postedComment(modal, "the opening question").first();
+  await expect(parent).toBeVisible();
+
+  await openReplyForm(modal);
+  await submitReply(modal, "the threaded answer");
+  const reply = postedComment(modal, "the threaded answer").first();
+  await expect(reply).toBeVisible();
+
+  await toggleUntil(
+    modal.getByRole("button", { name: "Collapse comment" }).first(),
+    () => parent.isHidden()
+  );
+  await expect(reply).toBeHidden();
+  await expect(
+    modal.getByRole("link", { name: "Alice Test" }).first()
+  ).toBeVisible();
+
+  await toggleUntil(
+    modal.getByRole("button", { name: "Expand comment" }).first(),
+    () => parent.isVisible()
+  );
+
+  // Each comment's timestamp links to that comment alone, parent and reply
+  // getting distinct targets. Both have to be on the page before comparing:
+  // with only the parent rendered, first and last are the same link.
+  const timestamps = modal.getByRole("link", { name: /^\d/ });
+  await expect(timestamps).toHaveCount(2);
+  const parentPermalink = await timestamps.first().getAttribute("href");
+  const permalink = await timestamps.last().getAttribute("href");
+  expect(permalink).toMatch(/#comment-/);
+  expect(permalink).not.toBe(parentPermalink);
+
+  // Following a permalink in place must not add a history entry: dismissing
+  // the modal goes back, and would otherwise only undo the hash.
+  await modal.getByRole("link", { name: /^\d/ }).last().click();
+  await expect(page).toHaveURL(/#comment-/);
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByRole("dialog", { name: "Session details" })
+  ).toBeHidden();
+
+  await page.goto(permalink!);
+  await expect(
+    page
+      .getByRole("dialog", { name: "Session details" })
+      .getByText("the threaded answer")
+      .first()
+  ).toBeVisible();
+});
+
+test("keeps replies readable when their parent is deleted", async ({
+  page,
+  browser,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await actAs(page, /Alice Test/i);
+
+  const modal = await openSession(page, TOMBSTONE_SESSION);
+  await modal.getByPlaceholder("Add a comment").fill("a doomed parent");
+  await modal.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(postedComment(modal, "a doomed parent").first()).toBeVisible();
+
+  // Someone else replies, so deleting the parent can't simply remove it. A
+  // second context, not a second page: pages share the identity cookie.
+  const bobContext = await browser.newContext();
+  const bob = await bobContext.newPage();
+  await login(bob);
+  await bob.goto("/Conference-Gamma");
+  await actAs(bob, /Bob Test/i);
+  const bobModal = await openSession(bob, TOMBSTONE_SESSION);
+  await openReplyForm(bobModal);
+  await submitReply(bobModal, "a surviving reply");
+  await expect(
+    postedComment(bobModal, "a surviving reply").first()
+  ).toBeVisible();
+  await bobContext.close();
+
+  // Her open modal fetched its comments before Bob replied; reloading shows
+  // his reply arrived through the endpoint before she deletes the parent.
+  await page.reload();
+  const reopened = page.getByRole("dialog", { name: "Session details" });
+  await expect(reopened.getByText("a doomed parent").first()).toBeVisible();
+  await expect(reopened.getByText("a surviving reply").first()).toBeVisible();
+
+  await reopened.getByRole("button", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Yes" }).click();
+
+  await expect(reopened.getByText("a doomed parent")).toHaveCount(0);
+  await expect(reopened.getByText("Comment deleted")).toBeVisible();
+  await expect(reopened.getByText("a surviving reply")).toBeVisible();
+});
+
+test("likes a comment and shows who liked it", async ({ page, browser }) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await actAs(page, /Alice Test/i);
+
+  const modal = await openSession(page, LIKE_SESSION);
+  await modal.getByPlaceholder("Add a comment").fill("a likeable comment");
+  await modal.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(
+    postedComment(modal, "a likeable comment").first()
+  ).toBeVisible();
+
+  const like = modal.getByRole("button", { name: "Like", exact: true });
+  const liked = modal.getByRole("button", { name: "Liked", exact: true });
+  await like.click();
+  await expect(liked).toBeVisible();
+  await expect(modal.getByRole("button", { name: "1 like" })).toBeVisible();
+
+  // A second context, not a second page: pages share the identity cookie.
+  const bobContext = await browser.newContext();
+  const bob = await bobContext.newPage();
+  await login(bob);
+  await bob.goto("/Conference-Gamma");
+  await actAs(bob, /Bob Test/i);
+  const bobModal = await openSession(bob, LIKE_SESSION);
+  await bobModal.getByRole("button", { name: "Like", exact: true }).click();
+  await expect(bobModal.getByRole("button", { name: "2 likes" })).toBeVisible();
+  await bobContext.close();
+
+  await page.reload();
+  const reopened = page.getByRole("dialog", { name: "Session details" });
+  // Hovering previews the likers, newest first, without opening anything.
+  const count = reopened.getByRole("button", { name: "2 likes" });
+  const tooltip = page.getByRole("tooltip");
+  await expect(tooltip).toHaveCSS("opacity", "0");
+  await count.hover();
+  await expect(tooltip).toHaveCSS("opacity", "1");
+  await expect(tooltip).toHaveText(/^Bob TestAlice Test$/);
+
+  await count.click();
+  const likers = page.getByRole("dialog", { name: "Liked by" });
+  await expect(likers.getByRole("link", { name: "Alice Test" })).toBeVisible();
+  await expect(likers.getByRole("link", { name: "Bob Test" })).toBeVisible();
+  // One avatar per liker — an uploaded image or the initials fallback, both
+  // decorative and so hidden from the accessibility tree.
+  await expect(likers.locator("li [aria-hidden='true']")).toHaveCount(2);
+  await likers.getByRole("button", { name: "Close" }).click();
+  // The pointer never left the count, but the click dismissed its preview.
+  await expect(tooltip).toHaveCSS("opacity", "0");
+
+  await reopened.getByRole("button", { name: "Liked", exact: true }).click();
+  await expect(
+    reopened.getByRole("button", { name: "Like", exact: true })
+  ).toBeVisible();
+  await expect(reopened.getByRole("button", { name: "1 like" })).toBeVisible();
+});
+
+test("asks visitors without a name to select one before commenting", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+
+  const modal = await openSession(page, CLOSING_SESSION);
+
+  await expect(
+    modal.getByText("Select your name to leave a comment.")
+  ).toBeVisible();
+  await expect(modal.getByPlaceholder("Add a comment")).toHaveCount(0);
+});
+
+test("nests sibling replies under the comment they answer", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await actAs(page, /Alice Test/i);
+
+  const modal = await openSession(page, SIBLINGS_SESSION);
+  await modal.getByPlaceholder("Add a comment").fill("Who else is coming?");
+  await modal.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(
+    postedComment(modal, "Who else is coming?").first()
+  ).toBeVisible();
+
+  // Posting closes the reply form (onDone), so each reply waits for the
+  // previous one to actually render before reopening the form.
+  await openReplyForm(modal);
+  await submitReply(modal, "I'd like to join.");
+  await expect(postedComment(modal, "I'd like to join.").first()).toBeVisible();
+  await openReplyForm(modal);
+  await submitReply(modal, "So would I.");
+  await expect(postedComment(modal, "So would I.").first()).toBeVisible();
+
+  // Both hang off the same parent, so collapsing it takes them together.
+  await toggleUntil(
+    modal.getByRole("button", { name: "Collapse comment" }).first(),
+    () => postedComment(modal, "Who else is coming?").isHidden()
+  );
+  await expect(postedComment(modal, "I'd like to join.")).toBeHidden();
+  await expect(postedComment(modal, "So would I.")).toBeHidden();
+});

--- a/tests/integration/comment-routes.test.ts
+++ b/tests/integration/comment-routes.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { GET as sessionComments } from "@/app/api/session/[sessionId]/comments/route";
+
+describe("comment read endpoints", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("serves a session's comments", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const session = await createSession(event.id);
+    await getRepositories().sessionComments.create({
+      subjectId: session.id,
+      authorId: guest.id,
+      body: "See you there",
+      createdTime: new Date(),
+    });
+
+    const res = await sessionComments(
+      new Request(`http://test/api/session/${session.id}/comments`),
+      { params: Promise.resolve({ sessionId: session.id }) }
+    );
+
+    expect(res.status).toBe(200);
+    const comments = (await res.json()) as { body: string }[];
+    expect(comments.map((c) => c.body)).toEqual(["See you there"]);
+  });
+
+  // Without this a typo'd or deleted id is indistinguishable from a session
+  // nobody has commented on yet.
+  it("answers 404 for a session that does not exist", async () => {
+    const res = await sessionComments(
+      new Request("http://test/api/session/nope/comments"),
+      { params: Promise.resolve({ sessionId: "nope" }) }
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -44,13 +44,13 @@ vi.mock("next/cache", () => ({
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
+  createDay,
   createEvent,
   createGuest,
   createLocation,
-  createDay,
-  slotStart,
   createProposal,
   createSession,
+  slotStart,
 } from "../helpers/factories";
 import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
 import { getRepositories } from "@/db/container";
@@ -86,7 +86,7 @@ const OUT_OF_SCOPE_PREFIXES = ["admin/", "auth/"];
 const OUT_OF_SCOPE_EXACT = new Set(["health"]);
 
 // Read-only surfaces are exempt from the invariant per CONTRIBUTING.md.
-const READ_ONLY = new Set(["rsvps", "votes"]);
+const READ_ONLY = new Set(["rsvps", "votes", "session/[sessionId]/comments"]);
 
 type Verifier = () => Promise<void>;
 

--- a/tests/integration/session-comment-likes.test.ts
+++ b/tests/integration/session-comment-likes.test.ts
@@ -1,0 +1,241 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetTestDb, setupTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
+import {
+  createSessionComment as createComment,
+  deleteComment,
+  toggleCommentLike,
+} from "@/app/(site)/[eventSlug]/comment-actions";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+function act(guestId: string): void {
+  cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guestId));
+}
+
+async function setup() {
+  const event = await createEvent({ phase: "scheduling" });
+  const guest = await createGuest({ eventId: event.id });
+  const session = await createSession(event.id);
+  act(guest.id);
+  await createComment({
+    sessionId: session.id,
+    body: "worth liking",
+  });
+  const [comment] = await getRepositories().sessionComments.list(session.id);
+  return { event, guest, session, comment };
+}
+
+async function likesOn(sessionId: string, commentId: string) {
+  const comments = await getRepositories().sessionComments.list(sessionId);
+  return comments.find((c) => c.id === commentId)!.likes;
+}
+
+describe("session comment likes", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("starts with no likes", async () => {
+    const { session, comment } = await setup();
+
+    expect(await likesOn(session.id, comment.id)).toEqual([]);
+  });
+
+  it("records who liked the comment", async () => {
+    const { guest, session, comment } = await setup();
+
+    const result = await toggleCommentLike({
+      commentId: comment.id,
+    });
+
+    expect(result).toEqual({ success: true, liked: true });
+    expect(await likesOn(session.id, comment.id)).toEqual([
+      { id: guest.id, name: guest.name, avatarUrl: null },
+    ]);
+  });
+
+  it("carries each liker's avatar, so it can be shown next to their name", async () => {
+    const { guest, session, comment } = await setup();
+    await getRepositories().guests.updateProfile(
+      guest.id,
+      {
+        name: guest.name,
+        aboutMe: null,
+        avatarUrl: "/uploads/avatar.webp",
+        pronouns: null,
+        basedIn: null,
+        prompts: null,
+        languages: null,
+        contacts: null,
+      },
+      new Date()
+    );
+
+    await toggleCommentLike({ commentId: comment.id });
+
+    expect(await likesOn(session.id, comment.id)).toEqual([
+      { id: guest.id, name: guest.name, avatarUrl: "/uploads/avatar.webp" },
+    ]);
+  });
+
+  it("takes the like back when pressed again", async () => {
+    const { session, comment } = await setup();
+    await toggleCommentLike({ commentId: comment.id });
+
+    const result = await toggleCommentLike({
+      commentId: comment.id,
+    });
+
+    expect(result).toEqual({ success: true, liked: false });
+    expect(await likesOn(session.id, comment.id)).toEqual([]);
+  });
+
+  it("keeps every guest's like, oldest first", async () => {
+    const { event, guest, session, comment } = await setup();
+    const other = await createGuest({ eventId: event.id });
+
+    await toggleCommentLike({ commentId: comment.id });
+    act(other.id);
+    await toggleCommentLike({ commentId: comment.id });
+
+    expect(await likesOn(session.id, comment.id)).toEqual([
+      { id: guest.id, name: guest.name, avatarUrl: null },
+      { id: other.id, name: other.name, avatarUrl: null },
+    ]);
+  });
+
+  it("keeps the pressing order for likes that land in the same millisecond", async () => {
+    const { session, comment } = await setup();
+    const guests = [
+      await createGuest({ eventId: session.eventId }),
+      await createGuest({ eventId: session.eventId }),
+    ];
+    // Press in descending id order, so a tiebreak on the (random) guest id
+    // would hand back the reverse of the order they were pressed in.
+    const likers = guests.sort((a, b) => (a.id < b.id ? 1 : -1));
+    const sameMillisecond = new Date();
+
+    for (const liker of likers) {
+      await getRepositories().comments.toggleLike({
+        commentId: comment.id,
+        guestId: liker.id,
+        createdTime: sameMillisecond,
+      });
+    }
+
+    expect(await likesOn(session.id, comment.id)).toEqual(
+      likers.map((liker) => ({
+        id: liker.id,
+        name: liker.name,
+        avatarUrl: null,
+      }))
+    );
+  });
+
+  it("refuses to like without a selected name", async () => {
+    const { session, comment } = await setup();
+    cookieJar.clear();
+
+    const result = await toggleCommentLike({
+      commentId: comment.id,
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await likesOn(session.id, comment.id)).toEqual([]);
+  });
+
+  it("refuses to like as a protected guest without a verified session", async () => {
+    const { guest, session, comment } = await setup();
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+
+    const result = await toggleCommentLike({
+      commentId: comment.id,
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await likesOn(session.id, comment.id)).toEqual([]);
+  });
+
+  it("refuses to like a comment that does not exist", async () => {
+    await setup();
+
+    const result = await toggleCommentLike({
+      commentId: "does-not-exist",
+    });
+
+    expect(result).toHaveProperty("error");
+  });
+
+  it("refuses to like a deleted comment kept as a tombstone", async () => {
+    const { event, guest, session, comment } = await setup();
+    const other = await createGuest({ eventId: event.id });
+    act(other.id);
+    await createComment({
+      sessionId: session.id,
+      parentId: comment.id,
+      body: "a surviving reply",
+    });
+    act(guest.id);
+    await deleteComment({ commentId: comment.id });
+
+    const result = await toggleCommentLike({
+      commentId: comment.id,
+    });
+
+    expect(result).toHaveProperty("error");
+  });
+
+  it("discards the likes of a comment deleted into a tombstone", async () => {
+    const { event, guest, session, comment } = await setup();
+    const other = await createGuest({ eventId: event.id });
+    act(other.id);
+    await createComment({
+      sessionId: session.id,
+      parentId: comment.id,
+      body: "a surviving reply",
+    });
+    await toggleCommentLike({ commentId: comment.id });
+    expect(await likesOn(session.id, comment.id)).toHaveLength(1);
+
+    act(guest.id);
+    await deleteComment({ commentId: comment.id });
+
+    expect(await likesOn(session.id, comment.id)).toEqual([]);
+  });
+
+  it("discards the likes of a comment removed outright", async () => {
+    const { session, comment } = await setup();
+    await toggleCommentLike({ commentId: comment.id });
+
+    await deleteComment({ commentId: comment.id });
+
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+});

--- a/tests/integration/session-comments.test.ts
+++ b/tests/integration/session-comments.test.ts
@@ -1,0 +1,560 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { afterTasks } = vi.hoisted(() => ({
+  afterTasks: [] as Promise<unknown>[],
+}));
+
+vi.mock("next/server", () => ({
+  after: (task: () => unknown) => {
+    afterTasks.push(Promise.resolve(task()));
+  },
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createProposal,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import {
+  GUEST_COOKIE_NAME,
+  openGuestValue,
+  verifiedGuestValue,
+} from "../helpers/guest-cookie";
+import {
+  createProposalComment,
+  createSessionComment as createComment,
+  deleteComment,
+  updateComment,
+} from "@/app/(site)/[eventSlug]/comment-actions";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function setup() {
+  const event = await createEvent({ phase: "scheduling" });
+  const guest = await createGuest({ eventId: event.id });
+  const session = await createSession(event.id);
+  return { event, guest, session };
+}
+
+function act(guestId: string): void {
+  cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guestId));
+}
+
+describe("session comments", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    afterTasks.length = 0;
+  });
+
+  it("stores a comment and reads it back with its author and time", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    const before = new Date();
+
+    const result = await createComment({
+      sessionId: session.id,
+      body: "See you there",
+    });
+
+    expect(result).toEqual({ success: true });
+    const comments = await getRepositories().sessionComments.list(session.id);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].body).toBe("See you there");
+    expect(comments[0].author).toEqual({ id: guest.id, name: guest.name });
+    expect(comments[0].createdTime.getTime()).toBeGreaterThanOrEqual(
+      before.getTime() - 1000
+    );
+  });
+
+  it("lists comments oldest first", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+
+    await createComment({
+      sessionId: session.id,
+      body: "first",
+    });
+    await createComment({
+      sessionId: session.id,
+      body: "second",
+    });
+
+    const comments = await getRepositories().sessionComments.list(session.id);
+    expect(comments.map((c) => c.body)).toEqual(["first", "second"]);
+  });
+
+  it("lists comments posted in the same millisecond in the order they were posted", async () => {
+    const { guest, session } = await setup();
+    const { sessionComments } = getRepositories();
+    const sameMillisecond = new Date();
+    const bodies = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th"];
+
+    for (const body of bodies) {
+      await sessionComments.create({
+        subjectId: session.id,
+        authorId: guest.id,
+        body,
+        createdTime: sameMillisecond,
+      });
+    }
+
+    // Comment ids are random, so a tiebreak on the id would shuffle these.
+    expect((await sessionComments.list(session.id)).map((c) => c.body)).toEqual(
+      bodies
+    );
+  });
+
+  it("keeps each session's comments separate", async () => {
+    const { event, guest, session } = await setup();
+    const other = await createSession(event.id);
+    act(guest.id);
+
+    await createComment({
+      sessionId: session.id,
+      body: "on the first",
+    });
+
+    expect(await getRepositories().sessionComments.list(other.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("keeps sessions' and proposals' comments separate", async () => {
+    const { event, guest, session } = await setup();
+    const proposal = await createProposal(event.id, []);
+    act(guest.id);
+
+    await createComment({
+      sessionId: session.id,
+      body: "on the session",
+    });
+    await createProposalComment({
+      proposalId: proposal.id,
+      eventSlug: event.slug,
+      body: "on the proposal",
+    });
+
+    expect(
+      (await getRepositories().sessionComments.list(session.id)).map(
+        (c) => c.body
+      )
+    ).toEqual(["on the session"]);
+    expect(
+      (await getRepositories().proposalComments.list(proposal.id)).map(
+        (c) => c.body
+      )
+    ).toEqual(["on the proposal"]);
+  });
+
+  it("refuses to comment without a selected name", async () => {
+    const { session } = await setup();
+
+    const result = await createComment({
+      sessionId: session.id,
+      body: "anonymous",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().sessionComments.list(session.id)
+    ).toHaveLength(0);
+  });
+
+  it("refuses to comment as a protected guest without a verified session", async () => {
+    const { guest, session } = await setup();
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    act(guest.id);
+
+    const result = await createComment({
+      sessionId: session.id,
+      body: "impersonated",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().sessionComments.list(session.id)
+    ).toHaveLength(0);
+  });
+
+  it("allows a verified protected guest to comment", async () => {
+    const { guest, session } = await setup();
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guest.id));
+
+    const result = await createComment({
+      sessionId: session.id,
+      body: "verified",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(
+      await getRepositories().sessionComments.list(session.id)
+    ).toHaveLength(1);
+  });
+
+  it("rejects an empty comment", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+
+    const result = await createComment({
+      sessionId: session.id,
+      body: "   ",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().sessionComments.list(session.id)
+    ).toHaveLength(0);
+  });
+
+  it("rejects a comment on an unknown session", async () => {
+    const { guest } = await setup();
+    act(guest.id);
+
+    const result = await createComment({
+      sessionId: "does-not-exist",
+      body: "hello",
+    });
+
+    expect(result).toHaveProperty("error");
+  });
+
+  it("removes a session's comments when the session is deleted", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "doomed",
+    });
+
+    await getRepositories().sessions.delete(session.id);
+
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+});
+
+async function onlyComment(sessionId: string) {
+  const comments = await getRepositories().sessionComments.list(sessionId);
+  expect(comments).toHaveLength(1);
+  return comments[0];
+}
+
+describe("editing a session comment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("replaces the body and records when it was edited", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "original",
+    });
+    const before = await onlyComment(session.id);
+    expect(before.editedTime).toBeNull();
+
+    const result = await updateComment({
+      commentId: before.id,
+      body: "revised",
+    });
+
+    expect(result).toEqual({ success: true });
+    const after = await onlyComment(session.id);
+    expect(after.body).toBe("revised");
+    expect(after.editedTime).toBeInstanceOf(Date);
+    expect(after.createdTime).toEqual(before.createdTime);
+  });
+
+  it("refuses to edit someone else's comment", async () => {
+    const { event, guest, session } = await setup();
+    const other = await createGuest({ eventId: event.id });
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "mine",
+    });
+    const comment = await onlyComment(session.id);
+
+    act(other.id);
+    const result = await updateComment({
+      commentId: comment.id,
+      body: "hijacked",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(session.id)).body).toBe("mine");
+  });
+
+  it("rejects an empty edit", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "mine",
+    });
+    const comment = await onlyComment(session.id);
+
+    const result = await updateComment({
+      commentId: comment.id,
+      body: "  ",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(session.id)).body).toBe("mine");
+  });
+});
+
+describe("deleting a session comment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("removes a childless comment outright", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "never mind",
+    });
+    const comment = await onlyComment(session.id);
+
+    const result = await deleteComment({
+      commentId: comment.id,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+
+  it("leaves a tombstone when the comment has replies", async () => {
+    const { event, guest, session } = await setup();
+    const other = await createGuest({ eventId: event.id });
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "the question",
+    });
+    const parent = await onlyComment(session.id);
+    act(other.id);
+    await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "the answer",
+    });
+
+    act(guest.id);
+    await deleteComment({ commentId: parent.id });
+
+    const comments = await getRepositories().sessionComments.list(session.id);
+    expect(comments).toHaveLength(2);
+    const tombstone = comments.find((c) => c.id === parent.id)!;
+    expect(tombstone.deleted).toBe(true);
+    expect(tombstone.body).toBe("");
+    expect(tombstone.author).toBeNull();
+    const reply = comments.find((c) => c.id !== parent.id)!;
+    expect(reply.body).toBe("the answer");
+    expect(reply.parentId).toBe(parent.id);
+  });
+
+  it("clears a tombstone once its last reply goes", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "parent",
+    });
+    const parent = await onlyComment(session.id);
+    await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "child",
+    });
+    const child = (
+      await getRepositories().sessionComments.list(session.id)
+    ).find((c) => c.id !== parent.id)!;
+
+    await deleteComment({ commentId: parent.id });
+    await deleteComment({ commentId: child.id });
+
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+
+  it("refuses to delete someone else's comment", async () => {
+    const { event, guest, session } = await setup();
+    const other = await createGuest({ eventId: event.id });
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "mine",
+    });
+    const comment = await onlyComment(session.id);
+
+    act(other.id);
+    const result = await deleteComment({
+      commentId: comment.id,
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(session.id)).body).toBe("mine");
+  });
+
+  it("refuses to edit a tombstone", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "parent",
+    });
+    const parent = await onlyComment(session.id);
+    await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "child",
+    });
+    await deleteComment({ commentId: parent.id });
+
+    const result = await updateComment({
+      commentId: parent.id,
+      body: "back from the dead",
+    });
+
+    expect(result).toHaveProperty("error");
+  });
+});
+
+describe("threaded session replies", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("records the parent of a reply", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "top level",
+    });
+    const parent = await onlyComment(session.id);
+
+    await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "a reply",
+    });
+
+    const comments = await getRepositories().sessionComments.list(session.id);
+    expect(comments.map((c) => c.parentId)).toEqual([null, parent.id]);
+  });
+
+  it("rejects a reply to a comment on another session", async () => {
+    const { event, guest, session } = await setup();
+    const elsewhere = await createSession(event.id);
+    act(guest.id);
+    await createComment({
+      sessionId: elsewhere.id,
+      body: "top level elsewhere",
+    });
+    const parent = await onlyComment(elsewhere.id);
+
+    const result = await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "misfiled reply",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+
+  it("rejects a reply to a comment left on a proposal", async () => {
+    const { event, guest, session } = await setup();
+    const proposal = await createProposal(event.id, []);
+    act(guest.id);
+    await createProposalComment({
+      proposalId: proposal.id,
+      eventSlug: event.slug,
+      body: "top level on a proposal",
+    });
+    const parent = (
+      await getRepositories().proposalComments.list(proposal.id)
+    )[0];
+
+    const result = await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "misfiled reply",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+
+  it("deletes a whole thread with its session", async () => {
+    const { guest, session } = await setup();
+    act(guest.id);
+    await createComment({
+      sessionId: session.id,
+      body: "top level",
+    });
+    const parent = await onlyComment(session.id);
+    await createComment({
+      sessionId: session.id,
+      parentId: parent.id,
+      body: "a reply",
+    });
+
+    await getRepositories().sessions.delete(session.id);
+
+    expect(await getRepositories().sessionComments.list(session.id)).toEqual(
+      []
+    );
+  });
+});


### PR DESCRIPTION
A session's details get the comment section proposals already had. The
session modal opens by pushing the URL locally, without an RSC roundtrip,
so its comments load through /api/session/[sessionId]/comments instead of
arriving as server props.

fixes schellingboard/schellingboard#461

<!-- jip:pushed-commit=d4fbc7c14c6131510d8b7361a024d05d4801e6a2 -->