### PR TITLE
feat: comment on profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Comments on attendee profiles**: a profile now ends with the same comment section sessions and proposals already
+  have — threaded replies, likes, editing and deleting your own comments. Open anyone in the directory to say hi or
+  arrange to meet up
 - **Comments on sessions**: a session's details now have the same comment section proposals already had — threaded
   replies, likes, editing and deleting your own comments. Open any session in the schedule to discuss times, rooms or
   last-minute changes
@@ -66,6 +69,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Comments live behind a scope-agnostic core (find, edit, like, delete) plus one repository per subject, so
+  proposals, sessions and profiles share a single implementation. Adding a fourth thing to comment on is a join
+  table and one line of wiring, not another copy of the same forty lines
 - `scripts/e2e-flake-hunt.sh` runs the E2E suite N times against one build and keeps every run's JSON
   report plus traces of what failed; `scripts/e2e-flake-report.ts` aggregates those into a report
   ranking flaky tests by failure rate and grouping them by error signature. See

--- a/app/(site)/[eventSlug]/comment-actions.ts
+++ b/app/(site)/[eventSlug]/comment-actions.ts
@@ -10,6 +10,7 @@ import {
   commentDeleteSchema,
   commentLikeSchema,
   commentUpdateSchema,
+  profileCommentSchema,
   proposalCommentSchema,
   sessionCommentSchema,
 } from "@/model/comment";
@@ -46,8 +47,8 @@ function toResult(
 }
 
 // Only surfaces that server-render their comments need cache invalidation —
-// proposals. Sessions reload through their own endpoint, so they pass no slug
-// and nothing is revalidated for them.
+// proposals. Sessions and profiles reload through their own endpoint, so they
+// pass no slug and nothing is revalidated for them.
 function revalidateEvent(eventSlug: string | undefined): void {
   if (eventSlug) {
     revalidatePath(`/${eventSlug}`, "layout");
@@ -152,6 +153,44 @@ export async function createSessionComment(
 
     await getRepositories().sessionComments.create({
       subjectId: sessionId,
+      authorId: guest,
+      parentId,
+      body,
+      createdTime: await serverNow(),
+    });
+    return { success: true };
+  } catch (error) {
+    return toResult(error, "Failed to post comment");
+  }
+}
+
+export async function createProfileComment(
+  comment: z.input<typeof profileCommentSchema>
+): Promise<CommentActionResult>;
+export async function createProfileComment(
+  input: unknown
+): Promise<CommentActionResult> {
+  try {
+    const guest = await requireGuest();
+    const { profileId, parentId, body } = await requireParsed(
+      profileCommentSchema,
+      input
+    );
+
+    // validation
+    if (!(await getRepositories().guests.findById(profileId))) {
+      return { error: "Profile not found" };
+    }
+    if (parentId) {
+      const parentOf =
+        await getRepositories().profileComments.findSubjectId(parentId);
+      if (!parentOf || parentOf !== profileId) {
+        return { error: "The comment being replied to is invalid" };
+      }
+    }
+
+    await getRepositories().profileComments.create({
+      subjectId: profileId,
       authorId: guest,
       parentId,
       body,

--- a/app/(site)/[eventSlug]/comment-likes.tsx
+++ b/app/(site)/[eventSlug]/comment-likes.tsx
@@ -19,7 +19,7 @@ export function CommentLikes({
 }: {
   comment: Pick<Comment, "id" | "likes">;
   // Only the cache invalidation target for pages that server-render their
-  // comments — proposals. Sessions omit it.
+  // comments — proposals. Sessions and profiles omit it.
   eventSlug?: string;
   onChanged: () => void;
 }) {

--- a/app/(site)/[eventSlug]/comments-section.tsx
+++ b/app/(site)/[eventSlug]/comments-section.tsx
@@ -61,12 +61,13 @@ export function CommentsSection({
   changed,
 }: {
   // Only the cache invalidation target for pages that server-render their
-  // comments — proposals. Sessions omit it.
+  // comments — proposals. Sessions and profiles omit it.
   eventSlug?: string;
   timezone: string;
   comments?: LoadedComments;
-  // Scope-specific: proposals and sessions differ in the action called and in
-  // where a permalink points. Everything else about commenting is shared.
+  // Scope-specific: proposals, sessions and profiles differ in the action
+  // called and in where a permalink points. Everything else about commenting
+  // is shared.
   create: (input: CommentCreateInput) => Promise<CommentActionResult>;
   permalinkFor: (commentId: string) => string;
   changed: () => void;

--- a/app/(site)/guests/profile-body.tsx
+++ b/app/(site)/guests/profile-body.tsx
@@ -28,6 +28,7 @@ import {
   ProposalLink,
   SessionLink,
 } from "@/app/(site)/guests/profile-link";
+import { ProfileComments } from "@/app/(site)/guests/profile-comments";
 import type { ProfileActivity } from "@/app/(site)/guests/profile-activity";
 
 /**
@@ -38,12 +39,17 @@ import type { ProfileActivity } from "@/app/(site)/guests/profile-activity";
 export function ProfileBody({
   guest,
   isOwnProfile,
+  isActive,
   activity,
   zoomed,
   onToggleZoom,
 }: {
   guest: Attendee;
   isOwnProfile: boolean;
+  // Only the profile being read carries comments: a swipe mounts its
+  // neighbours for a moment, and their sections must not fire requests of
+  // their own.
+  isActive: boolean;
   activity: ProfileActivity | null;
   zoomed: boolean;
   onToggleZoom: () => void;
@@ -187,6 +193,8 @@ export function ProfileBody({
             />
           </>
         )}
+
+        {isActive && <ProfileComments profileId={guest.id} />}
       </div>
     </div>
   );

--- a/app/(site)/guests/profile-comments.tsx
+++ b/app/(site)/guests/profile-comments.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { createProfileComment } from "@/app/(site)/[eventSlug]/comment-actions";
+import {
+  type CommentCreateInput,
+  CommentsSection,
+} from "@/app/(site)/[eventSlug]/comments-section";
+import { useComments } from "@/app/(site)/[eventSlug]/use-comments";
+
+// The profile modal opens by pushing the URL locally, without an RSC
+// roundtrip, so its comments can't arrive as server props: they load through
+// /api/profile/[profileId]/comments instead, and every mutation reloads them.
+export function ProfileComments({ profileId }: { profileId: string }) {
+  const { comments, changed } = useComments(
+    `/api/profile/${profileId}/comments`
+  );
+
+  const create = useCallback(
+    (input: CommentCreateInput) =>
+      createProfileComment({ profileId, ...input }),
+    [profileId]
+  );
+  const permalinkFor = useCallback(
+    (commentId: string) => `/guests/${profileId}#comment-${commentId}`,
+    [profileId]
+  );
+
+  return (
+    <CommentsSection
+      // A profile spans every event, so there is no event zone to anchor the
+      // timestamps to: they fall back to UTC and carry each reader's own zone
+      // once that is known.
+      timezone="UTC"
+      comments={comments}
+      create={create}
+      permalinkFor={permalinkFor}
+      changed={changed}
+    />
+  );
+}

--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -393,6 +393,7 @@ export function ProfileModal({
                       <ProfileBody
                         guest={attendee}
                         isOwnProfile={currentUserId === attendee.id}
+                        isActive={current}
                         activity={current ? activity : null}
                         zoomed={current && zoomed}
                         onToggleZoom={() =>

--- a/app/api/profile/[profileId]/comments/route.ts
+++ b/app/api/profile/[profileId]/comments/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { getRepositories } from "@/db/container";
+
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response
+// and show stale comments after a reload.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
+// Comments are displayed to everyone in the profile details,
+// similarly to sessions
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ profileId: string }> }
+) {
+  const { profileId } = await params;
+
+  try {
+    const { guests, profileComments } = getRepositories();
+    // Without this an unknown id would answer with an empty thread, which is
+    // indistinguishable from a profile nobody has commented on.
+    if (!(await guests.findById(profileId))) {
+      return NextResponse.json(
+        { error: "Profile not found" },
+        { ...NO_STORE, status: 404 }
+      );
+    }
+    return NextResponse.json(await profileComments.list(profileId), NO_STORE);
+  } catch (error) {
+    console.error("Error fetching comments:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch comments" },
+      { ...NO_STORE, status: 500 }
+    );
+  }
+}

--- a/db/container.ts
+++ b/db/container.ts
@@ -38,6 +38,7 @@ export type Repositories = {
   comments: CommentsRepository;
   proposalComments: SubjectCommentsRepository;
   sessionComments: SubjectCommentsRepository;
+  profileComments: SubjectCommentsRepository;
   days: DaysRepository;
   events: EventsRepository;
   guests: GuestsRepository;
@@ -59,6 +60,7 @@ function buildRepositories(sqlite: Database.Database): Repositories {
     comments: new SqliteCommentsRepository(db),
     proposalComments: sqliteSubjectCommentsRepository(db, "proposal"),
     sessionComments: sqliteSubjectCommentsRepository(db, "session"),
+    profileComments: sqliteSubjectCommentsRepository(db, "profile"),
     days: new SqliteDaysRepository(db),
     events: new SqliteEventsRepository(db),
     guests: new SqliteGuestsRepository(db),

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -677,9 +677,9 @@ export type Comment = {
 
 /**
  * Scope-agnostic comment operations. A comment is attached to exactly one
- * subject — a session proposal or a scheduled session — but finding, editing,
- * liking and deleting work identically for all, so they live here. Attaching
- * comments to a subject is a SubjectCommentsRepository.
+ * subject — a session proposal, a scheduled session or a guest's profile —
+ * but finding, editing, liking and deleting work identically for all, so they
+ * live here. Attaching comments to a subject is a SubjectCommentsRepository.
  */
 export interface CommentsRepository {
   findById(commentId: string): Promise<Comment | undefined>;
@@ -699,9 +699,9 @@ export interface CommentsRepository {
 
 /**
  * Comments attached to one kind of subject. Which kind is fixed by the
- * repository itself — `proposalComments` and `sessionComments` on
- * {@link Repositories} — so `subjectId` below is always a proposal or session
- * id respectively.
+ * repository itself — `proposalComments`, `sessionComments` and
+ * `profileComments` on {@link Repositories} — so `subjectId` below is always a
+ * proposal, session or profile id respectively.
  */
 export interface SubjectCommentsRepository {
   /** All comments on the subject, oldest first, likes included. */

--- a/db/repositories/sqlite/comments.ts
+++ b/db/repositories/sqlite/comments.ts
@@ -253,7 +253,7 @@ type CommentJoin = {
   attach: (tx: Tx, commentId: string, subjectId: string) => void;
 };
 
-const JOINS: Record<"proposal" | "session", CommentJoin> = {
+const JOINS: Record<"proposal" | "session" | "profile", CommentJoin> = {
   proposal: {
     table: schema.proposalComments,
     commentId: schema.proposalComments.commentId,
@@ -270,6 +270,13 @@ const JOINS: Record<"proposal" | "session", CommentJoin> = {
     subjectId: schema.sessionComments.sessionId,
     attach: (tx, commentId, sessionId) =>
       tx.insert(schema.sessionComments).values({ commentId, sessionId }).run(),
+  },
+  profile: {
+    table: schema.profileComments,
+    commentId: schema.profileComments.commentId,
+    subjectId: schema.profileComments.profileId,
+    attach: (tx, commentId, profileId) =>
+      tx.insert(schema.profileComments).values({ commentId, profileId }).run(),
   },
 };
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -337,6 +337,22 @@ export const sessionComments = sqliteTable(
   ]
 );
 
+export const profileComments = sqliteTable(
+  "profile_comments",
+  {
+    commentId: text("comment_id")
+      .notNull()
+      .references(() => comments.id, { onDelete: "cascade" }),
+    profileId: text("profile_id")
+      .notNull()
+      .references(() => guests.id, { onDelete: "cascade" }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.commentId] }),
+    index("profile_comments_profile_idx").on(t.profileId),
+  ]
+);
+
 export const votes = sqliteTable(
   "votes",
   {

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -216,6 +216,10 @@ search and filters intact.
   for larger still. On a wide window it stays beside you as you scroll,
   together with name, pronouns, location and languages.
 
+A profile ends with the same comment section proposals and sessions have — a good place to say hi, find someone to share
+a ride with, or ask something before the event. Everything works as described under
+[Discuss a proposal](#discuss-a-proposal): threaded replies, likes, editing and deleting your own comments.
+
 ## Your profile
 
 After picking your name, open **"Edit profile"** to set your About me,

--- a/drizzle/0027_profile_comments.sql
+++ b/drizzle/0027_profile_comments.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `profile_comments`
+(
+  `comment_id` text PRIMARY KEY NOT NULL,
+  `profile_id` text             NOT NULL,
+  FOREIGN KEY (`comment_id`) REFERENCES `comments` (`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`profile_id`) REFERENCES `guests` (`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `profile_comments_profile_idx` ON `profile_comments` (`profile_id`);

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1417 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "41c8af3c-6971-4c05-8a3f-d89159e824e1",
+  "prevId": "0e054d3e-ab25-408b-9733-1e57e74cd1cf",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_comments": {
+      "name": "profile_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_comments_profile_idx": {
+          "name": "profile_comments_profile_idx",
+          "columns": ["profile_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_comments_comment_id_comments_id_fk": {
+          "name": "profile_comments_comment_id_comments_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_comments_profile_id_guests_id_fk": {
+          "name": "profile_comments_profile_id_guests_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "guests",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1787430579703,
       "tag": "0026_session_comments",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1787509687748,
+      "tag": "0027_profile_comments",
+      "breakpoints": true
     }
   ]
 }

--- a/model/comment.ts
+++ b/model/comment.ts
@@ -23,9 +23,15 @@ export const sessionCommentSchema = z.object({
   body,
 });
 
+export const profileCommentSchema = z.object({
+  profileId: z.string().min(1),
+  parentId: z.string().min(1).optional(),
+  body,
+});
+
 // eventSlug is only the cache invalidation target for pages that
-// server-render their comments — proposals. Sessions fetch theirs
-// client-side and omit it.
+// server-render their comments — proposals. Sessions and profiles fetch
+// theirs client-side and omit it.
 export const commentUpdateSchema = z.object({
   commentId: z.string().min(1),
   eventSlug: z.string().min(1).optional(),

--- a/tests/e2e/profile-comments.spec.ts
+++ b/tests/e2e/profile-comments.spec.ts
@@ -1,0 +1,132 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+import { openReplyForm, postedComment, submitReply } from "./helpers/comments";
+
+// Each test comments on a different seeded guest's profile: the suite runs in
+// parallel against one shared database, so two tests on the same profile
+// would see each other's comments.
+async function openProfile(page: Page, name: string) {
+  await page.getByRole("link", { name }).click();
+  const profile = page.getByRole("dialog", { name });
+  await expect(profile).toBeVisible();
+  return profile;
+}
+
+// selectUser logs out and back in; navigating before that settles aborts the
+// request and drops the selection.
+async function actAs(page: Page, name: RegExp) {
+  await selectUser(page, name);
+  await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
+}
+
+test("posts a comment on a profile and shows it when the profile reopens", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await actAs(page, /Bob Test/i);
+
+  const profile = await openProfile(page, "Alice Test");
+  await expect(
+    profile.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+
+  await profile.getByPlaceholder("Add a comment").fill("see you at the venue");
+  await profile.getByRole("button", { name: "Comment", exact: true }).click();
+
+  await expect(
+    profile.getByRole("heading", { name: "1 comment" })
+  ).toBeVisible();
+  await expect(
+    postedComment(profile, "see you at the venue").first()
+  ).toBeVisible();
+
+  // Comments load through their own endpoint when the profile opens, so
+  // reopening must show them without any refresh.
+  await page.keyboard.press("Escape");
+  await expect(profile).toBeHidden();
+  const reopened = await openProfile(page, "Alice Test");
+  await expect(
+    reopened.getByRole("heading", { name: "1 comment" })
+  ).toBeVisible();
+  await expect(
+    postedComment(reopened, "see you at the venue").first()
+  ).toBeVisible();
+});
+
+test("replies to a profile comment and permalinks to the reply", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await actAs(page, /Alice Test/i);
+
+  const profile = await openProfile(page, "Bob Test");
+  await profile.getByPlaceholder("Add a comment").fill("which airport?");
+  await profile.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(postedComment(profile, "which airport?").first()).toBeVisible();
+
+  await openReplyForm(profile);
+  await submitReply(profile, "whatever is closest to the venue");
+  await expect(
+    postedComment(profile, "closest to the venue").first()
+  ).toBeVisible();
+
+  // Each comment's timestamp links to that comment alone, parent and reply
+  // getting distinct targets. Both have to be on the page before comparing:
+  // with only the parent rendered, first and last are the same link.
+  const timestamps = profile.getByRole("link", { name: /^\d/ });
+  await expect(timestamps).toHaveCount(2);
+  const permalink = await timestamps.last().getAttribute("href");
+  expect(permalink).toMatch(/^\/guests\/[^/?]+#comment-/);
+
+  // The permalink is a real profile URL: opening it cold lands on this
+  // profile with the reply shown (and highlighted).
+  await page.goto(permalink!);
+  const opened = page.getByRole("dialog", { name: "Bob Test" });
+  await expect(opened).toBeVisible();
+  await expect(
+    postedComment(opened, "closest to the venue").first()
+  ).toBeVisible();
+});
+
+// A section that can't reach its endpoint used to sit on a "Loading
+// comments..." skeleton forever (profiles) or claim "0 comments" (sessions),
+// both of which say something untrue about the thread.
+test("says comments could not be loaded rather than showing an empty thread", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await page.route("**/api/profile/*/comments*", (route) =>
+    route.fulfill({ status: 500, body: "{}" })
+  );
+
+  const profile = await openProfile(page, "Yuki Tanaka");
+
+  await expect(
+    profile.getByRole("heading", { name: "Comments could not be loaded" })
+  ).toBeVisible();
+  await expect(
+    profile.getByRole("heading", { name: "0 comments" })
+  ).toHaveCount(0);
+  await expect(
+    profile.getByRole("heading", { name: "Loading comments" })
+  ).toHaveCount(0);
+});
+
+test("asks visitors without a name to select one before commenting", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+
+  const profile = await openProfile(page, "Charlie Test");
+
+  await expect(
+    profile.getByText("Select your name to leave a comment.")
+  ).toBeVisible();
+  await expect(profile.getByPlaceholder("Add a comment")).toHaveCount(0);
+});

--- a/tests/integration/comment-routes.test.ts
+++ b/tests/integration/comment-routes.test.ts
@@ -4,6 +4,7 @@ import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { GET as sessionComments } from "@/app/api/session/[sessionId]/comments/route";
+import { GET as profileComments } from "@/app/api/profile/[profileId]/comments/route";
 
 describe("comment read endpoints", () => {
   beforeAll(() => setupTestDb());
@@ -36,6 +37,35 @@ describe("comment read endpoints", () => {
     const res = await sessionComments(
       new Request("http://test/api/session/nope/comments"),
       { params: Promise.resolve({ sessionId: "nope" }) }
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("serves a profile's comments", async () => {
+    const owner = await createGuest();
+    const commenter = await createGuest();
+    await getRepositories().profileComments.create({
+      subjectId: owner.id,
+      authorId: commenter.id,
+      body: "Nice to meet you",
+      createdTime: new Date(),
+    });
+
+    const res = await profileComments(
+      new Request(`http://test/api/profile/${owner.id}/comments`),
+      { params: Promise.resolve({ profileId: owner.id }) }
+    );
+
+    expect(res.status).toBe(200);
+    const comments = (await res.json()) as { body: string }[];
+    expect(comments.map((c) => c.body)).toEqual(["Nice to meet you"]);
+  });
+
+  it("answers 404 for a profile that does not exist", async () => {
+    const res = await profileComments(
+      new Request("http://test/api/profile/nope/comments"),
+      { params: Promise.resolve({ profileId: "nope" }) }
     );
 
     expect(res.status).toBe(404);

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -86,7 +86,12 @@ const OUT_OF_SCOPE_PREFIXES = ["admin/", "auth/"];
 const OUT_OF_SCOPE_EXACT = new Set(["health"]);
 
 // Read-only surfaces are exempt from the invariant per CONTRIBUTING.md.
-const READ_ONLY = new Set(["rsvps", "votes", "session/[sessionId]/comments"]);
+const READ_ONLY = new Set([
+  "rsvps",
+  "votes",
+  "session/[sessionId]/comments",
+  "profile/[profileId]/comments",
+]);
 
 type Verifier = () => Promise<void>;
 

--- a/tests/integration/profile-comments.test.ts
+++ b/tests/integration/profile-comments.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { afterTasks } = vi.hoisted(() => ({
+  afterTasks: [] as Promise<unknown>[],
+}));
+
+vi.mock("next/server", () => ({
+  after: (task: () => unknown) => {
+    afterTasks.push(Promise.resolve(task()));
+  },
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import {
+  GUEST_COOKIE_NAME,
+  openGuestValue,
+  verifiedGuestValue,
+} from "../helpers/guest-cookie";
+import {
+  createProfileComment as createComment,
+  deleteComment,
+  updateComment,
+} from "@/app/(site)/[eventSlug]/comment-actions";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function setup() {
+  const event = await createEvent({ phase: "scheduling" });
+  const owner = await createGuest({ eventId: event.id });
+  const commenter = await createGuest({ eventId: event.id });
+  return { event, owner, commenter };
+}
+
+function act(guestId: string): void {
+  cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guestId));
+}
+
+describe("profile comments", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    afterTasks.length = 0;
+  });
+
+  it("stores a comment and reads it back with its author and time", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    const before = new Date();
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "Loved your talk",
+    });
+
+    expect(result).toEqual({ success: true });
+    const comments = await getRepositories().profileComments.list(owner.id);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].body).toBe("Loved your talk");
+    expect(comments[0].author).toEqual({
+      id: commenter.id,
+      name: commenter.name,
+    });
+    expect(comments[0].createdTime.getTime()).toBeGreaterThanOrEqual(
+      before.getTime() - 1000
+    );
+  });
+
+  it("lists comments oldest first", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+
+    await createComment({ profileId: owner.id, body: "first" });
+    await createComment({ profileId: owner.id, body: "second" });
+
+    const comments = await getRepositories().profileComments.list(owner.id);
+    expect(comments.map((c) => c.body)).toEqual(["first", "second"]);
+  });
+
+  it("lists comments posted in the same millisecond in the order they were posted", async () => {
+    const { owner } = await setup();
+    const commenter = await createGuest();
+    const { profileComments } = getRepositories();
+    const sameMillisecond = new Date();
+    const bodies = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th"];
+
+    for (const body of bodies) {
+      await profileComments.create({
+        subjectId: owner.id,
+        authorId: commenter.id,
+        body,
+        createdTime: sameMillisecond,
+      });
+    }
+
+    // Comment ids are random, so a tiebreak on the id would shuffle these.
+    expect((await profileComments.list(owner.id)).map((c) => c.body)).toEqual(
+      bodies
+    );
+  });
+
+  it("keeps each profile's comments separate", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+
+    await createComment({ profileId: owner.id, body: "on the first" });
+
+    expect(await getRepositories().profileComments.list(other.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("keeps profiles' and sessions' comments separate", async () => {
+    const { event, commenter, owner } = await setup();
+    const session = await createSession(event.id);
+    act(commenter.id);
+
+    await createComment({ profileId: owner.id, body: "on the profile" });
+    await getRepositories().sessionComments.create({
+      subjectId: session.id,
+      authorId: commenter.id,
+      body: "on the session",
+      createdTime: new Date(),
+    });
+
+    expect(
+      (await getRepositories().profileComments.list(owner.id)).map(
+        (c) => c.body
+      )
+    ).toEqual(["on the profile"]);
+    expect(
+      (await getRepositories().sessionComments.list(session.id)).map(
+        (c) => c.body
+      )
+    ).toEqual(["on the session"]);
+  });
+
+  it("refuses to comment without a selected name", async () => {
+    const { owner } = await setup();
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "anonymous",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().profileComments.list(owner.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("refuses to comment as a protected guest without a verified session", async () => {
+    const { commenter, owner } = await setup();
+    await getRepositories().guests.setAuthProtection(commenter.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    act(commenter.id);
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "impersonated",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().profileComments.list(owner.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("allows a verified protected guest to comment", async () => {
+    const { commenter, owner } = await setup();
+    await getRepositories().guests.setAuthProtection(commenter.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(commenter.id));
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "verified",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(await getRepositories().profileComments.list(owner.id)).toHaveLength(
+      1
+    );
+  });
+
+  it("rejects an empty comment", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+
+    const result = await createComment({
+      profileId: owner.id,
+      body: "   ",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().profileComments.list(owner.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("rejects a comment on an unknown profile", async () => {
+    const { commenter } = await setup();
+    act(commenter.id);
+
+    const result = await createComment({
+      profileId: "does-not-exist",
+      body: "hello",
+    });
+
+    expect(result).toHaveProperty("error");
+  });
+
+  it("removes a profile's comments when the guest is deleted", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "doomed" });
+
+    await getRepositories().guests.delete(owner.id);
+
+    expect(await getRepositories().profileComments.list(owner.id)).toEqual([]);
+  });
+});
+
+async function onlyComment(profileId: string) {
+  const comments = await getRepositories().profileComments.list(profileId);
+  expect(comments).toHaveLength(1);
+  return comments[0];
+}
+
+describe("editing a profile comment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("replaces the body and records when it was edited", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "original" });
+    const before = await onlyComment(owner.id);
+    expect(before.editedTime).toBeNull();
+
+    const result = await updateComment({
+      commentId: before.id,
+      body: "revised",
+    });
+
+    expect(result).toEqual({ success: true });
+    const after = await onlyComment(owner.id);
+    expect(after.body).toBe("revised");
+    expect(after.editedTime).toBeInstanceOf(Date);
+    expect(after.createdTime).toEqual(before.createdTime);
+  });
+
+  it("refuses to edit someone else's comment", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "mine" });
+    const comment = await onlyComment(owner.id);
+
+    act(other.id);
+    const result = await updateComment({
+      commentId: comment.id,
+      body: "hijacked",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(owner.id)).body).toBe("mine");
+  });
+
+  it("rejects an empty edit", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "mine" });
+    const comment = await onlyComment(owner.id);
+
+    const result = await updateComment({
+      commentId: comment.id,
+      body: "  ",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(owner.id)).body).toBe("mine");
+  });
+});
+
+describe("deleting a profile comment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("removes a childless comment outright", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "never mind" });
+    const comment = await onlyComment(owner.id);
+
+    const result = await deleteComment({ commentId: comment.id });
+
+    expect(result).toEqual({ success: true });
+    expect(await getRepositories().profileComments.list(owner.id)).toEqual([]);
+  });
+
+  it("leaves a tombstone when the comment has replies", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "the question" });
+    const parent = await onlyComment(owner.id);
+    act(other.id);
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "the answer",
+    });
+
+    act(commenter.id);
+    await deleteComment({ commentId: parent.id });
+
+    const comments = await getRepositories().profileComments.list(owner.id);
+    expect(comments).toHaveLength(2);
+    const tombstone = comments.find((c) => c.id === parent.id)!;
+    expect(tombstone.deleted).toBe(true);
+    expect(tombstone.body).toBe("");
+    expect(tombstone.author).toBeNull();
+    const reply = comments.find((c) => c.id !== parent.id)!;
+    expect(reply.body).toBe("the answer");
+    expect(reply.parentId).toBe(parent.id);
+  });
+
+  it("clears a tombstone once its last reply goes", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "parent" });
+    const parent = await onlyComment(owner.id);
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "child",
+    });
+    const child = (await getRepositories().profileComments.list(owner.id)).find(
+      (c) => c.id !== parent.id
+    )!;
+
+    await deleteComment({ commentId: parent.id });
+    await deleteComment({ commentId: child.id });
+
+    expect(await getRepositories().profileComments.list(owner.id)).toEqual([]);
+  });
+
+  it("refuses to delete someone else's comment", async () => {
+    const { commenter, owner } = await setup();
+    const other = await createGuest();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "mine" });
+    const comment = await onlyComment(owner.id);
+
+    act(other.id);
+    const result = await deleteComment({ commentId: comment.id });
+
+    expect(result).toHaveProperty("error");
+    expect((await onlyComment(owner.id)).body).toBe("mine");
+  });
+});
+
+describe("threaded profile replies", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  it("records the parent of a reply", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "top level" });
+    const parent = await onlyComment(owner.id);
+
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "a reply",
+    });
+
+    const comments = await getRepositories().profileComments.list(owner.id);
+    expect(comments.map((c) => c.parentId)).toEqual([null, parent.id]);
+  });
+
+  it("rejects a reply to a comment on another profile", async () => {
+    const { commenter, owner } = await setup();
+    const elsewhere = await createGuest();
+    act(commenter.id);
+    await createComment({
+      profileId: elsewhere.id,
+      body: "top level elsewhere",
+    });
+    const parent = await onlyComment(elsewhere.id);
+
+    const result = await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "misfiled reply",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().profileComments.list(owner.id)).toEqual([]);
+  });
+
+  it("rejects a reply to a comment left on a session", async () => {
+    const { event, commenter, owner } = await setup();
+    const session = await createSession(event.id);
+    act(commenter.id);
+    await getRepositories().sessionComments.create({
+      subjectId: session.id,
+      authorId: commenter.id,
+      body: "top level on a session",
+      createdTime: new Date(),
+    });
+    const parent = (
+      await getRepositories().sessionComments.list(session.id)
+    )[0];
+
+    const result = await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "misfiled reply",
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(await getRepositories().profileComments.list(owner.id)).toEqual([]);
+  });
+
+  it("deletes a whole thread with its profile", async () => {
+    const { commenter, owner } = await setup();
+    act(commenter.id);
+    await createComment({ profileId: owner.id, body: "top level" });
+    const parent = await onlyComment(owner.id);
+    await createComment({
+      profileId: owner.id,
+      parentId: parent.id,
+      body: "a reply",
+    });
+
+    await getRepositories().guests.delete(owner.id);
+
+    expect(await getRepositories().profileComments.list(owner.id)).toEqual([]);
+  });
+});


### PR DESCRIPTION
A profile ends with the same comment section proposals and sessions have.
Only the profile being read mounts its comments: a swipe briefly mounts
its neighbours, and their sections must not fire requests of their own.

fixes schellingboard/schellingboard#720

<!-- jip:pushed-commit=38c4cf03bc669c731bcee5a6497ba2c1d0ba9e8a -->