### PR TITLE
fix: check auth inside three server actions, require a name to create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Proposing a session or booking one now asks who you are first**: "Add Proposal" is greyed out until you pick your
+  name, the way voting already was, and both forms ask for a name instead of opening. Before, either could be submitted
+  with no name chosen at all, leaving an entry nobody was recorded as having created
 - **What a room offers is easier to find**: room names on the schedule grid that have a description now carry an ⓘ,
   and tapping or hovering the name opens it. Before, the description only appeared when a mouse happened to rest on
   the name, with nothing to suggest it was there, and on a phone it was cut off at the edge of the screen

--- a/app/(site)/[eventSlug]/add-session/page.tsx
+++ b/app/(site)/[eventSlug]/add-session/page.tsx
@@ -3,5 +3,5 @@ import { renderSessionForm } from "../session-form-page";
 export default async function AddSession(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
-  return renderSessionForm(props);
+  return renderSessionForm(props, "adding a session");
 }

--- a/app/(site)/[eventSlug]/clash-actions.ts
+++ b/app/(site)/[eventSlug]/clash-actions.ts
@@ -2,6 +2,7 @@
 
 import { getRepositories } from "@/db/container";
 import type { Session } from "@/db/repositories/interfaces";
+import { requireVerifiedGuest } from "@/utils/action-auth";
 import { getStartTimePlusBreak } from "@/utils/utils";
 import { newEmptySession, sessionsOverlap } from "../session_utils";
 
@@ -26,6 +27,9 @@ export async function detectHostClashes(input: {
   end: string; // ISO — candidate session end
   excludeSessionId?: string | null;
 }): Promise<HostClash[]> {
+  // Site auth is shared with every attendee, so it can't be the gate on a
+  // reply that reports when another guest is privately busy.
+  await requireVerifiedGuest("checking host availability");
   const { eventId, hostIds, start, end, excludeSessionId } = input;
   if (hostIds.length === 0) return [];
 

--- a/app/(site)/[eventSlug]/edit-session/page.tsx
+++ b/app/(site)/[eventSlug]/edit-session/page.tsx
@@ -3,5 +3,5 @@ import { renderSessionForm } from "../session-form-page";
 export default async function EditSession(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
-  return renderSessionForm(props);
+  return renderSessionForm(props, "editing a session");
 }

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,5 +1,5 @@
 import { cookies } from "next/headers";
-import { BackLink } from "@/app/components/back-link";
+import { PageNotice } from "@/app/components/page-notice";
 import { getRepositories } from "@/db/container";
 import { SessionProposalForm } from "@/app/(site)/[eventSlug]/session-proposal-form";
 import {
@@ -10,10 +10,12 @@ import { notFound } from "next/navigation";
 
 function CantEdit(props: { eventSlug: string; children: React.ReactNode }) {
   return (
-    <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
-      <BackLink href={`/${props.eventSlug}/proposals`}>Proposals</BackLink>
-      <p className="text-fg-muted">{props.children}</p>
-    </div>
+    <PageNotice
+      backHref={`/${props.eventSlug}/proposals`}
+      backLabel="Proposals"
+    >
+      {props.children}
+    </PageNotice>
   );
 }
 

--- a/app/(site)/[eventSlug]/proposals/actions.ts
+++ b/app/(site)/[eventSlug]/proposals/actions.ts
@@ -12,8 +12,7 @@ import {
 } from "@/model/session";
 import { serverNow } from "@/utils/dev-clock-server";
 import {
-  actingUserIsVerified,
-  NAME_PROTECTED_ERROR,
+  unverifiedUserMessage,
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
 
@@ -23,8 +22,14 @@ export async function createProposal(
 export async function createProposal(
   input: unknown
 ): Promise<{ error: string | z.core.$ZodIssue[] } | { success: true }> {
-  if (!(await actingUserIsVerified(await cookies()))) {
-    return { error: NAME_PROTECTED_ERROR };
+  // Creating needs a name actually selected, not merely one that isn't being
+  // falsely claimed: a proposal is attributed to its hosts, so an anonymous
+  // caller has no identity to attribute it to.
+  const cookieStore = await cookies();
+  if (!(await verifiedCurrentUser(cookieStore))) {
+    return {
+      error: await unverifiedUserMessage(cookieStore, "creating a proposal"),
+    };
   }
 
   const parseResult = await sessionProposalSchema.safeParseAsync(input);

--- a/app/(site)/[eventSlug]/proposals/new/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/new/page.tsx
@@ -1,4 +1,10 @@
+import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
+import { PageNotice } from "@/app/components/page-notice";
 import { SessionProposalForm } from "../../session-proposal-form";
 
 export default async function NewProposalPage({
@@ -13,6 +19,15 @@ export default async function NewProposalPage({
 
   if (!event) {
     return <div>Event not found</div>;
+  }
+
+  const cookieStore = await cookies();
+  if (!(await verifiedCurrentUser(cookieStore))) {
+    return (
+      <PageNotice backHref={`/${eventSlug}/proposals`} backLabel="Proposals">
+        {await unverifiedUserMessage(cookieStore, "creating a proposal")}
+      </PageNotice>
+    );
   }
 
   const guests = await repos.guests.list();

--- a/app/(site)/[eventSlug]/proposals/proposal-action-bar.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-action-bar.tsx
@@ -31,6 +31,12 @@ export function ProposalActionBar({
   const localZone = useLocalZone();
   const votingEnabled = !!currentUserId && inVotingPhase(event, now);
 
+  // A proposal is attributed to its hosts, so it can't be created anonymously.
+  const proposingEnabled = !!currentUserId && !inSchedPhase(event, now);
+  const proposingDisabledText = inSchedPhase(event, now)
+    ? "Proposal and voting phases are over"
+    : "Select a user first";
+
   let votingDisabledText = "";
   if (inSchedPhase(event, now)) {
     votingDisabledText = `The voting phase is over`;
@@ -46,14 +52,14 @@ export function ProposalActionBar({
   return (
     <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center mb-6">
       <HoverTooltip
-        text="Proposal and voting phases are over"
-        visible={inSchedPhase(event, now)}
+        text={proposingDisabledText}
+        visible={!proposingEnabled}
         unavailable
       >
         <Link
-          href={`/${eventSlug}/proposals/new`}
+          href={proposingEnabled ? `/${eventSlug}/proposals/new` : "#"}
           className={`bg-brand hover:bg-brand-hover transition-colors text-on-brand px-4 py-2 rounded-md flex items-center gap-2 ${
-            inSchedPhase(event, now) ? "opacity-50 cursor-not-allowed" : ""
+            proposingEnabled ? "" : "opacity-50 cursor-not-allowed"
           }`}
         >
           <PlusIcon className="h-5 w-5" />

--- a/app/(site)/[eventSlug]/session-actions.ts
+++ b/app/(site)/[eventSlug]/session-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { requireSiteAuth } from "@/utils/action-auth";
 
 // Sessions are mutated through the /api/{add,update,delete}-session route
 // handlers, but we also need to purge the client-side Router Cache.
@@ -9,9 +10,7 @@ import { revalidatePath } from "next/cache";
 // The session list is fetched in the shared [eventSlug] layout, so we
 // revalidate the layout: this invalidates it and every page beneath it.
 //
-// revalidatePath is synchronous, but a "use server" action must be async to be
-// callable from the client, hence the eslint exception.
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function revalidateEvent(eventSlug: string) {
+  await requireSiteAuth();
   revalidatePath(`/${eventSlug}`, "layout");
 }

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -1,20 +1,38 @@
 import { Suspense } from "react";
 import { cookies } from "next/headers";
-import { verifiedCurrentUser } from "@/utils/acting-guest";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
 
+import { PageNotice } from "@/app/components/page-notice";
 import { SessionForm } from "./session-form";
 import { getRepositories } from "@/db/container";
 
-export async function renderSessionForm(props: {
-  params: Promise<{ eventSlug: string }>;
-}) {
+export async function renderSessionForm(
+  props: {
+    params: Promise<{ eventSlug: string }>;
+  },
+  // Completes "before …" in the message shown when no name is selected.
+  task: string
+) {
   const { eventSlug } = await props.params;
-  const currentUser = await verifiedCurrentUser(await cookies());
+  const cookieStore = await cookies();
+  const currentUser = await verifiedCurrentUser(cookieStore);
   const repos = getRepositories();
 
   const event = await repos.events.findBySlug(eventSlug);
   if (!event) {
     return <div>Event not found</div>;
+  }
+
+  // A session is attributed to its hosts, so it can't be booked anonymously.
+  if (!currentUser) {
+    return (
+      <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
+        {await unverifiedUserMessage(cookieStore, task)}
+      </PageNotice>
+    );
   }
 
   const [days, sessions, guests, locations, allProposals] = await Promise.all([
@@ -25,8 +43,8 @@ export async function renderSessionForm(props: {
     repos.sessionProposals.listByEvent(event.id),
   ]);
 
-  const currentUserProposals = allProposals.filter(
-    (p) => currentUser && p.hosts.some((h) => h.id === currentUser)
+  const currentUserProposals = allProposals.filter((p) =>
+    p.hosts.some((h) => h.id === currentUser)
   );
   const hostlessProposals = allProposals.filter((p) => p.hosts.length === 0);
   const proposals = currentUserProposals.concat(hostlessProposals);

--- a/app/(site)/guests/edit/page.tsx
+++ b/app/(site)/guests/edit/page.tsx
@@ -1,5 +1,5 @@
 import { cookies } from "next/headers";
-import { BackLink } from "@/app/components/back-link";
+import { PageNotice } from "@/app/components/page-notice";
 import { getRepositories } from "@/db/container";
 import { sanitizeGuest } from "@/utils/guests";
 import {
@@ -14,12 +14,9 @@ export default async function EditProfilePage() {
 
   if (!currentUser) {
     return (
-      <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
-        <BackLink href="/guests">Attendees</BackLink>
-        <p className="text-fg-muted">
-          {await unverifiedUserMessage(cookieStore, "editing your profile")}
-        </p>
-      </div>
+      <PageNotice backHref="/guests" backLabel="Attendees">
+        {await unverifiedUserMessage(cookieStore, "editing your profile")}
+      </PageNotice>
     );
   }
 

--- a/app/(site)/guests/profile-activity.ts
+++ b/app/(site)/guests/profile-activity.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { getRepositories } from "@/db/container";
+import { requireSiteAuth } from "@/utils/action-auth";
 import { eventNameToSlug } from "@/utils/utils";
 
 /** A session or proposal on a profile, ready to link to. */
@@ -24,6 +25,7 @@ export type ProfileActivity = {
 export async function listProfileActivity(
   guestId: string
 ): Promise<ProfileActivity> {
+  await requireSiteAuth();
   const repos = getRepositories();
   const [hostedSessions, proposals, events] = await Promise.all([
     repos.sessions.listHostedByGuest(guestId),

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -1,5 +1,5 @@
 import { cookies } from "next/headers";
-import { BackLink } from "@/app/components/back-link";
+import { PageNotice } from "@/app/components/page-notice";
 import { getRepositories } from "@/db/container";
 import {
   unverifiedUserMessage,
@@ -20,12 +20,9 @@ export default async function SettingsPage() {
   if (!currentUser) {
     return (
       <div className="flex flex-col gap-8">
-        <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
-          <BackLink href="/guests">Attendees</BackLink>
-          <p className="text-fg-muted">
-            {await unverifiedUserMessage(cookieStore, "changing your settings")}
-          </p>
-        </div>
+        <PageNotice backHref="/guests" backLabel="Attendees">
+          {await unverifiedUserMessage(cookieStore, "changing your settings")}
+        </PageNotice>
         <AppearanceSettings />
       </div>
     );

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -4,8 +4,7 @@ import { inSchedPhase } from "@/app/(site)/utils/events";
 import { requestNow } from "@/utils/dev-clock";
 import { notifyCohostsAdded } from "@/utils/notifications";
 import {
-  actingUserIsVerified,
-  guestProtectionError,
+  unverifiedUserMessage,
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
 import { sessionBookingWindowError } from "@/utils/day-window";
@@ -16,8 +15,15 @@ import type { SessionParams } from "../session-form-utils";
 export const dynamic = "force-dynamic"; // defaults to auto
 
 export async function POST(req: NextRequest) {
-  if (!(await actingUserIsVerified(req.cookies))) {
-    return guestProtectionError();
+  // Creating needs a name actually selected, not merely one that isn't being
+  // falsely claimed: a session is attributed to its hosts, so an anonymous
+  // caller has no identity to attribute it to.
+  const actingGuestId = await verifiedCurrentUser(req.cookies);
+  if (!actingGuestId) {
+    return Response.json(
+      { error: await unverifiedUserMessage(req.cookies, "adding a session") },
+      { status: 403 }
+    );
   }
   const params = (await req.json()) as SessionParams;
   const repos = getRepositories();
@@ -100,9 +106,7 @@ export async function POST(req: NextRequest) {
     await notifyCohostsAdded({
       session,
       previousHostIds: [],
-      // Verified so notifications can't attribute the change to a protected
-      // guest someone merely claims to be.
-      changedById: await verifiedCurrentUser(req.cookies),
+      changedById: actingGuestId,
     });
     return Response.json({ success: true });
   } else {

--- a/app/components/page-notice.tsx
+++ b/app/components/page-notice.tsx
@@ -1,0 +1,19 @@
+import { BackLink } from "./back-link";
+
+/** A page standing in for content the visitor can't have, saying why. */
+export function PageNotice({
+  backHref,
+  backLabel,
+  children,
+}: {
+  backHref: string;
+  backLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
+      <BackLink href={backHref}>{backLabel}</BackLink>
+      <p className="text-fg-muted">{children}</p>
+    </div>
+  );
+}

--- a/tests/e2e/add-session.spec.ts
+++ b/tests/e2e/add-session.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./helpers/fixtures";
 import { uniqueSuffix } from "./helpers/unique";
 import { login } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
 import { dismissToast, toast } from "./helpers/toast";
 
 test("a newly added session appears on the overview and can be opened", async ({
@@ -10,6 +11,7 @@ test("a newly added session appears on the overview and can be opened", async ({
 
   await page.goto("/Conference-Gamma");
   await expect(page.getByRole("button", { name: "Grid" })).toBeVisible();
+  await selectUser(page, /Alice Test/i);
 
   // Reach the form the way a real user does: click a free "+" slot in the grid.
   // We don't care which slot, so take the first.
@@ -23,16 +25,7 @@ test("a newly added session appears on the overview and can be opened", async ({
   const sessionTitle = `Yak shaving ${uniqueSuffix()}`;
   await page.getByRole("textbox").first().fill(sessionTitle);
 
-  // Add a host via the combobox (a host is required to enable Submit).
-  const hostsSection = page
-    .locator("div")
-    .filter({ hasText: /^Hosts/ })
-    .first();
-  await hostsSection.getByRole("button").first().click();
-  await page.keyboard.type("Alice Test");
-  await page.getByRole("option", { name: /Alice Test/i }).click();
-  await page.keyboard.press("Escape");
-
+  // A host is required to enable Submit; the selected user is prefilled as one.
   const submit = page.getByRole("button", { name: "Submit" });
   await expect(submit).toBeEnabled();
   await submit.click();

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -3,6 +3,7 @@ import sharp from "sharp";
 import { test, expect } from "./helpers/fixtures";
 import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
 
@@ -1245,7 +1246,9 @@ test.describe("Admin UI proposals", () => {
 
   test("deletes a proposal via named confirm", async ({ page }) => {
     // Create a fresh proposal so we never permanently delete seeded data
-    await loginAndGoto(page, "/Conference-Alpha/proposals/new");
+    await loginAndGoto(page, "/Conference-Alpha/proposals");
+    await selectUser(page, /Bob Test/i);
+    await page.getByRole("link", { name: /Add Proposal/i }).click();
     const title = `E2E Delete Test ${uniqueSuffix()}`;
     await page.getByLabel("Title").fill(title);
     await Promise.all([

--- a/tests/e2e/phases.spec.ts
+++ b/tests/e2e/phases.spec.ts
@@ -50,11 +50,13 @@ test("voting phase: proposing and voting are open, scheduling is not", async ({
   await page.goto("/Conference-Beta");
   await expect(page).toHaveURL(/\/Conference-Beta\/proposals$/);
 
+  // Proposing needs a name selected, so pick one before asking whether the
+  // phase allows it — otherwise this asserts the identity gate, not the phase.
+  await selectUser(page, /Alice Test/i);
   await expect(
     page.getByRole("link", { name: /Add Proposal/i })
   ).not.toHaveClass(/cursor-not-allowed/);
 
-  await selectUser(page, /Alice Test/i);
   const row = page.getByRole("row", {
     name: /Conference Beta Lightning Talks/,
   });

--- a/tests/e2e/proposals.spec.ts
+++ b/tests/e2e/proposals.spec.ts
@@ -6,7 +6,9 @@ import { selectUser } from "./helpers/user";
 test("should auto-focus the title input for new proposals", async ({
   page,
 }) => {
-  await loginAndGoto(page, "/Conference-Alpha/proposals/new");
+  await loginAndGoto(page, "/Conference-Alpha/proposals");
+  await selectUser(page, /Bob Test/i);
+  await page.getByRole("link", { name: /Add Proposal/i }).click();
   await expect(page.getByLabel("Title")).toBeFocused();
 });
 
@@ -17,6 +19,7 @@ test("should create a new session proposal, edit it, and add hosts", async ({
 
   // Go to proposals list first (optional, helps ensure baseline loaded)
   await page.goto("/Conference-Alpha/proposals");
+  await selectUser(page, /Bob Test/i);
   // Generate a unique title to avoid collisions between runs
   const proposalTitle = `Playwright Test Proposal ${uniqueSuffix()}`;
   await expect(page.getByText(proposalTitle).first()).toHaveCount(0); // ensure not present
@@ -60,14 +63,12 @@ test("should create a new session proposal, edit it, and add hosts", async ({
     page.getByRole("heading", { name: /Edit Session Proposal/i })
   ).toBeVisible();
 
-  // Click the hosts combobox to open it (it opens on focus) and type directly
+  // Bob is already a host: creating a proposal prefills the selected user, and
+  // the combobox is a toggle, so picking him again would remove him. Add Alice
+  // alongside him instead.
   await page.getByLabel("Host(s)").click();
   await page.keyboard.type("Alice Test");
   await page.getByRole("option", { name: /Alice Test/i }).click();
-
-  // Add second host - dropdown stays open in multi-select mode, just type
-  await page.keyboard.type("Bob Test");
-  await page.getByRole("option", { name: /Bob Test/i }).click();
 
   // Close the still-open hosts dropdown so it doesn't overlay Submit
   await page.keyboard.press("Escape");
@@ -86,6 +87,7 @@ test("should create a new session proposal, edit it, and add hosts", async ({
 test("should delete a proposal from its edit page", async ({ page }) => {
   await login(page);
   await page.goto("/Conference-Alpha/proposals");
+  await selectUser(page, /Bob Test/i);
 
   // Create a throwaway proposal so seeded data stays untouched
   const proposalTitle = `Playwright Delete Proposal ${uniqueSuffix()}`;

--- a/tests/e2e/scheduling.spec.ts
+++ b/tests/e2e/scheduling.spec.ts
@@ -148,6 +148,7 @@ test("a day running past midnight says so, and its late slots name the day", asy
 }) => {
   await login(page);
   await page.goto("/Conference-Gamma");
+  await selectUser(page, /Alice Test/i);
   await page.getByRole("link", { name: "Add session" }).first().click();
   await expect(
     page.getByRole("heading", { name: /Add a session/i })
@@ -178,6 +179,7 @@ test("occupied start times are not offered in the same location but are in other
 }) => {
   await login(page);
   await page.goto("/Conference-Gamma");
+  await selectUser(page, /Alice Test/i);
   await page.getByRole("link", { name: "Add session" }).first().click();
   await expect(
     page.getByRole("heading", { name: /Add a session/i })

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -103,19 +103,16 @@ test("votes from two users persist independently across reloads", async ({
   await login(page);
   await page.goto("/Conference-Beta/proposals");
 
-  // Create a throwaway proposal hosted by Bob Test, before selecting a user
-  // (a selected user would be prefilled as host, and hosts get no voting
-  // buttons on their own proposals). The host matters: the quick-voting test
-  // in this file votes as Bob in a parallel worker, and quick voting never
-  // offers proposals the current user hosts, so no other test can add votes
-  // to this proposal.
+  // Create a throwaway proposal as Bob Test, who is prefilled as its host.
+  // The host matters twice over: hosts get no voting buttons on their own
+  // proposals, so the voters below must be someone else; and the quick-voting
+  // test in this file votes as Bob in a parallel worker, where quick voting
+  // never offers proposals the current user hosts, so no other test can add
+  // votes to this proposal.
+  await selectUser(page, /Bob Test/i);
   const title = `E2E Vote Target ${uniqueSuffix()}`;
   await page.getByRole("link", { name: /Add Proposal/i }).click();
   await page.getByLabel("Title").fill(title);
-  await page.getByLabel("Host(s)").click();
-  await page.keyboard.type("Bob Test");
-  await page.getByRole("option", { name: /Bob Test/i }).click();
-  await page.keyboard.press("Escape");
   await Promise.all([
     page.waitForURL(/\/Conference-Beta\/proposals$/),
     page.getByRole("button", { name: /Submit/i }).click(),

--- a/tests/integration/action-site-auth.test.ts
+++ b/tests/integration/action-site-auth.test.ts
@@ -1,0 +1,261 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+const revalidatePath = vi.fn();
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => {
+    revalidatePath(...args);
+  },
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createDay,
+  slotStart,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import {
+  GUEST_COOKIE_NAME,
+  openGuestValue,
+  verifiedGuestValue,
+} from "../helpers/guest-cookie";
+import { AUTH_COOKIE_NAME, createAuthCookie } from "@/utils/auth";
+import { listProfileActivity } from "@/app/(site)/guests/profile-activity";
+import { detectHostClashes } from "@/app/(site)/[eventSlug]/clash-actions";
+import { revalidateEvent } from "@/app/(site)/[eventSlug]/session-actions";
+import { createProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function siteAuthenticate(): Promise<void> {
+  cookieJar.set(AUTH_COOKIE_NAME, (await createAuthCookie()).value);
+}
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
+
+const T = (h: number) => new Date(Date.UTC(2030, 0, 1, h, 0, 0));
+
+describe("server actions require site auth", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    revalidatePath.mockClear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    vi.stubEnv("SITE_PASSWORD", "site-pw");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("listProfileActivity refuses a caller with no site-auth cookie", async () => {
+    const guest = await createGuest();
+    await expect(listProfileActivity(guest.id)).rejects.toThrow();
+  });
+
+  it("listProfileActivity answers a site-authenticated caller", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [guest.id],
+      startTime: T(10),
+      endTime: T(11),
+    });
+    await siteAuthenticate();
+
+    const activity = await listProfileActivity(guest.id);
+    expect(activity.hosting.map((s) => s.title)).toEqual(["Their talk"]);
+  });
+
+  it("revalidateEvent refuses a caller with no site-auth cookie", async () => {
+    await expect(revalidateEvent("some-event")).rejects.toThrow();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("revalidateEvent works for a site-authenticated caller", async () => {
+    await siteAuthenticate();
+    await revalidateEvent("some-event");
+    expect(revalidatePath).toHaveBeenCalledWith("/some-event", "layout");
+  });
+
+  it("detectHostClashes refuses a caller with no site-auth cookie", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    await expect(
+      detectHostClashes({
+        eventId: event.id,
+        hostIds: [host.id],
+        start: T(10).toISOString(),
+        end: T(11).toISOString(),
+      })
+    ).rejects.toThrow();
+  });
+
+  // The `busy` clash kind exists to keep a host's private RSVPs off the
+  // client, so site auth alone is too weak a gate: it is shared with every
+  // attendee. The caller must be acting as a guest in their own right.
+  it("detectHostClashes refuses a site-authenticated caller with no name selected", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    await siteAuthenticate();
+
+    await expect(
+      detectHostClashes({
+        eventId: event.id,
+        hostIds: [host.id],
+        start: T(10).toISOString(),
+        end: T(11).toISOString(),
+      })
+    ).rejects.toThrow();
+  });
+
+  it("detectHostClashes refuses a caller claiming a protected guest without a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const caller = await createGuest({ eventId: event.id });
+    await protectGuest(caller.id);
+    await siteAuthenticate();
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(caller.id));
+
+    await expect(
+      detectHostClashes({
+        eventId: event.id,
+        hostIds: [host.id],
+        start: T(10).toISOString(),
+        end: T(11).toISOString(),
+      })
+    ).rejects.toThrow();
+  });
+
+  it("detectHostClashes answers a verified guest", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const caller = await createGuest({ eventId: event.id });
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [host.id],
+      startTime: T(10),
+      endTime: T(11),
+    });
+    await siteAuthenticate();
+    cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(caller.id));
+
+    const clashes = await detectHostClashes({
+      eventId: event.id,
+      hostIds: [host.id],
+      start: T(10).toISOString(),
+      end: T(11).toISOString(),
+    });
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].kind).toBe("hosting");
+  });
+});
+
+// Creation only checked that the guest cookie wasn't falsely claiming a
+// protected name, which an absent cookie passes — nothing is claimed, so
+// nothing is verified. Creating now requires a name to actually be selected.
+describe("creation requires a selected name", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    vi.stubEnv("SITE_PASSWORD", "site-pw");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("createProposal refuses a caller with no name selected", async () => {
+    const event = await createEvent({ phase: "proposal" });
+    const guest = await createGuest({ eventId: event.id });
+    await siteAuthenticate();
+
+    const result = await createProposal({
+      eventId: event.id,
+      eventSlug: "test-event",
+      title: "T",
+      hostIds: [guest.id],
+    });
+
+    expect(result).toHaveProperty("error");
+    expect(
+      await getRepositories().sessionProposals.listByHost(guest.id)
+    ).toEqual([]);
+  });
+
+  it("createProposal accepts a caller with a name selected", async () => {
+    const event = await createEvent({ phase: "proposal" });
+    const guest = await createGuest({ eventId: event.id });
+    await siteAuthenticate();
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+
+    const result = await createProposal({
+      eventId: event.id,
+      eventSlug: "test-event",
+      title: "T",
+      hostIds: [guest.id],
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("add-session refuses a caller with no name selected", async () => {
+    const { POST } = await import("@/app/api/add-session/route");
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      new NextRequest("http://test/api/add-session", {
+        method: "POST",
+        body: JSON.stringify({
+          title: "T",
+          description: "",
+          closed: false,
+          hosts: [guest],
+          location,
+          dayId: day.id,
+          startTime: slotStart(day, 60),
+          duration: 60,
+        }),
+      })
+    );
+
+    expect(res.status).toBe(403);
+    expect(
+      await getRepositories().sessions.listHostedByGuest(guest.id)
+    ).toEqual([]);
+  });
+});

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -45,9 +45,13 @@ function makeReq(
   payload: unknown,
   opts?: { editorGuestId?: string; verified?: boolean }
 ): NextRequest {
+  // Creating requires a name to be selected, so default to the payload's
+  // first host: the ordinary case of a host booking their own session.
+  const actingGuestId =
+    opts?.editorGuestId ?? (payload as SessionParams).hosts?.[0]?.id;
   const cookies: string[] = [];
-  if (opts?.editorGuestId)
-    cookies.push(`${GUEST_COOKIE_NAME}=${openGuestValue(opts.editorGuestId)}`);
+  if (actingGuestId)
+    cookies.push(`${GUEST_COOKIE_NAME}=${openGuestValue(actingGuestId)}`);
   return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
@@ -378,10 +382,17 @@ describe("POST /api/add-session", () => {
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
+    // The payload has no host to fall back to, so name the acting guest
+    // explicitly — otherwise the request is refused for having no name
+    // selected and never reaches the no-hosts check.
     const res = await POST(
-      makeReq({ ...buildPayload(guest, location, day), hosts: [] })
+      makeReq(
+        { ...buildPayload(guest, location, day), hosts: [] },
+        { editorGuestId: guest.id }
+      )
     );
     expect(res.ok).toBe(false);
+    expect(res.status).not.toBe(403);
   });
 
   it("rejects session with missing location id", async () => {
@@ -502,10 +513,14 @@ describe("POST /api/add-session", () => {
 
   // Route does not guard req.json() — parse errors surface as a thrown SyntaxError
   it("malformed JSON causes a SyntaxError", async () => {
+    const guest = await createGuest();
     const req = new NextRequest("http://test/api/add-session", {
       method: "POST",
       body: "not json",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        cookie: `${GUEST_COOKIE_NAME}=${openGuestValue(guest.id)}`,
+      },
     });
     await expect(POST(req)).rejects.toThrow(SyntaxError);
   });

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -43,9 +43,13 @@ async function protectGuest(guestId: string): Promise<void> {
 }
 
 function makeAddReq(payload: unknown): NextRequest {
+  // Creating requires a name to be selected; these fixtures only seed a
+  // session, so act as its first host.
+  const hostId = (payload as SessionParams).hosts[0].id;
   return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
+    headers: { cookie: `${GUEST_COOKIE_NAME}=${openGuestValue(hostId)}` },
   });
 }
 
@@ -264,10 +268,12 @@ describe("POST /api/delete-session", () => {
   it("rejects a protected host without a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    await protectGuest(host.id);
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
+    // Protect only once the fixture exists: creating needs a selected name
+    // too, so a protected host can't seed one with an open cookie.
+    await protectGuest(host.id);
 
     const res = await POST(makeDeleteReq(id, { editorGuestId: host.id }));
     expect(res.status).toBe(403);
@@ -279,10 +285,12 @@ describe("POST /api/delete-session", () => {
   it("accepts a protected host with a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    await protectGuest(host.id);
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
+    // Protect only once the fixture exists: creating needs a selected name
+    // too, so a protected host can't seed one with an open cookie.
+    await protectGuest(host.id);
 
     const res = await POST(await makeDeleteReqWithAuthCookie(id, host.id));
     expect(res.ok).toBe(true);

--- a/tests/integration/host-clashes.test.ts
+++ b/tests/integration/host-clashes.test.ts
@@ -1,16 +1,53 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { detectHostClashes } from "@/app/(site)/[eventSlug]/clash-actions";
+import { AUTH_COOKIE_NAME, createAuthCookie } from "@/utils/auth";
+import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
 
 // A host's own hosted sessions are public, so a clash may name them; the
 // sessions a host merely RSVP'd to are private, so a clash must only report
 // that they are "busy" at that time — never which session.
 describe("detectHostClashes", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  // Clash detection reports when a host is privately busy, so it needs both
+  // site auth and a guest the caller may act as; these tests are about what
+  // it then discloses. See action-site-auth.test.ts for the gate itself.
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    cookieJar.set(AUTH_COOKIE_NAME, (await createAuthCookie()).value);
+    cookieJar.set(
+      GUEST_COOKIE_NAME,
+      openGuestValue((await createGuest({ name: "Organiser" })).id)
+    );
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
   const T = (h: number, m = 0) => new Date(Date.UTC(2030, 0, 1, h, m, 0));
 

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -5,10 +5,15 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+const cookieJar = new Map<string, string>();
+
 vi.mock("next/headers", () => ({
   cookies: () =>
     Promise.resolve({
-      get: () => undefined,
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
     }),
 }));
 
@@ -33,16 +38,26 @@ import { POST as addVote } from "@/app/api/add-vote/route";
 import { POST as addSession } from "@/app/api/add-session/route";
 import { POST as toggleRsvp } from "@/app/api/toggle-rsvp/route";
 import { createProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
+import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
 
 // Server-side phase gating mirrors the UI: voting only during the voting
 // phase, session creation only during the scheduling phase, and proposal
 // creation during the proposal *and* voting phases (the UI's "Add Proposal"
 // button is disabled only once scheduling starts).
 
-function makeReq(url: string, payload: unknown): NextRequest {
+// `actingGuestId` selects a name, which creating requires: these tests are
+// about the phase gate, so they must get past the identity gate first.
+function makeReq(
+  url: string,
+  payload: unknown,
+  actingGuestId?: string
+): NextRequest {
   return new NextRequest(url, {
     method: "POST",
     body: JSON.stringify(payload),
+    headers: actingGuestId
+      ? { cookie: `${GUEST_COOKIE_NAME}=${openGuestValue(actingGuestId)}` }
+      : undefined,
   });
 }
 
@@ -81,13 +96,17 @@ async function addSessionIn(phase: "proposal" | "voting" | "scheduling") {
     startTime: slotStart(day, 60),
     duration: 60,
   };
-  const res = await addSession(makeReq("http://test/api/add-session", payload));
+  const res = await addSession(
+    makeReq("http://test/api/add-session", payload, guest.id)
+  );
   const sessions = await getRepositories().sessions.listByEvent(event.id);
   return { res, sessions };
 }
 
 async function proposeIn(phase: "proposal" | "voting" | "scheduling") {
   const event = await createEvent({ phase });
+  const guest = await createGuest({ eventId: event.id });
+  cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
   const fd = {
     eventId: event.id,
     eventSlug: "test-event",
@@ -124,7 +143,10 @@ async function toggleRsvpIn(
 
 describe("server-side phase gating", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+  });
 
   it("rejects voting during the proposal phase", async () => {
     const { res, votes } = await voteOnProposalIn("proposal");

--- a/tests/integration/proposals.test.ts
+++ b/tests/integration/proposals.test.ts
@@ -63,9 +63,15 @@ function errorFields(result: object): string[] {
 
 describe("createProposal", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => {
+  beforeEach(async () => {
     resetTestDb();
     cookieJar.clear();
+    // Creating requires a name to be selected. Tests that care about *which*
+    // name overwrite this; the rest just need to be past the identity gate.
+    cookieJar.set(
+      GUEST_COOKIE_NAME,
+      openGuestValue((await createGuest({ name: "Proposer" })).id)
+    );
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
   });
   afterEach(() => vi.unstubAllEnvs());

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -44,9 +44,13 @@ async function protectGuest(guestId: string): Promise<void> {
 }
 
 function makeAddReq(payload: unknown): NextRequest {
+  // Creating requires a name to be selected; these fixtures only seed a
+  // session, so act as its first host.
+  const hostId = (payload as SessionParams).hosts[0].id;
   return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
+    headers: { cookie: `${GUEST_COOKIE_NAME}=${openGuestValue(hostId)}` },
   });
 }
 
@@ -622,10 +626,12 @@ describe("POST /api/update-session", () => {
   it("rejects a protected host without a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    await protectGuest(host.id);
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
+    // Protect only once the fixture exists: creating needs a selected name
+    // too, so a protected host can't seed one with an open cookie.
+    await protectGuest(host.id);
 
     const res = await POST(
       makeUpdateReq(
@@ -642,10 +648,12 @@ describe("POST /api/update-session", () => {
   it("accepts a protected host with a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    await protectGuest(host.id);
     const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
+    // Protect only once the fixture exists: creating needs a selected name
+    // too, so a protected host can't seed one with an open cookie.
+    await protectGuest(host.id);
 
     const res = await POST(
       await makeUpdateReqWithAuthCookie(

--- a/utils/acting-guest.ts
+++ b/utils/acting-guest.ts
@@ -114,19 +114,3 @@ export async function unverifiedUserMessage(
   }
   return `You need to select who you are before ${task}. Pick your name via the “Select your name” chip in the header at the top of the page.`;
 }
-
-/**
- * True unless the guest cookie claims a protected guest without a verified
- * proof. Unlike verifiedCurrentUser, an absent cookie doesn't fail this
- * check — there's no protected identity being claimed, so there's nothing to
- * verify. For creation endpoints, which have no existing object to check
- * ownership against.
- */
-export async function actingUserIsVerified(
-  cookieStore: ReadonlyCookies
-): Promise<boolean> {
-  const value = cookieStore.get(GUEST_COOKIE_NAME)?.value;
-  const parsed = await readGuestCookie(value);
-  if (!parsed) return true;
-  return isVerifiedAsGuest(parsed.guestId, value);
-}

--- a/utils/action-auth.ts
+++ b/utils/action-auth.ts
@@ -1,0 +1,42 @@
+import { cookies } from "next/headers";
+import { AUTH_COOKIE_NAME, isAuthCookieValid } from "./auth";
+import { unverifiedUserMessage, verifiedCurrentUser } from "./acting-guest";
+
+// The action-layer analogue of requireAuth (utils/auth.ts), which takes a
+// NextRequest and so can't be reached from a server action. Kept out of
+// utils/auth.ts so the proxy's bundle doesn't pull in next/headers.
+//
+// Server actions are dispatched per route, so an action defined on a
+// protected page is already unreachable without site auth — but that is a
+// Next implementation detail, not a control this codebase owns. These
+// helpers make every non-login action fail closed on its own.
+
+export const NOT_AUTHENTICATED_ERROR = "Not authenticated";
+
+/**
+ * Throws unless the caller carries a valid site-auth cookie. Throws rather
+ * than returning a result an action could forget to check: an unauthenticated
+ * caller is never a state the UI renders, so there is nothing to report.
+ */
+export async function requireSiteAuth(): Promise<void> {
+  const value = (await cookies()).get(AUTH_COOKIE_NAME)?.value;
+  if (!(await isAuthCookieValid(value))) {
+    throw new Error(NOT_AUTHENTICATED_ERROR);
+  }
+}
+
+/**
+ * Site auth plus a guest the caller may actually act as, returning that
+ * guest's id. For actions that disclose one guest's data to another:
+ * SITE_PASSWORD is one secret shared with every attendee, so it separates the
+ * event from the open web and nothing finer.
+ */
+export async function requireVerifiedGuest(task: string): Promise<string> {
+  await requireSiteAuth();
+  const cookieStore = await cookies();
+  const guestId = await verifiedCurrentUser(cookieStore);
+  if (!guestId) {
+    throw new Error(await unverifiedUserMessage(cookieStore, task));
+  }
+  return guestId;
+}


### PR DESCRIPTION
listProfileActivity, detectHostClashes and revalidateEvent had no check of
their own. None was reachable without the site password — the proxy guards
every route they live on — so this is defence in depth, not a live bypass.
The second layer they leaned on, Next's per-route action scoping, is an
implementation detail rather than a control we own, so each action now fails
closed by itself.

detectHostClashes takes requireVerifiedGuest rather than plain site auth,
since `busy` clashes are derived from RSVPs, which are otherwise kept off the
client. Between attendees that is a speed bump rather than a boundary: an
"open" cookie naming any unprotected — or non-existent — guest satisfies it,
and protecting a name does not help, because protection governs who may act
as you, not who may read about you.

Creating a session or proposal went through actingUserIsVerified, which
returns true when there is no guest cookie at all — nothing is claimed, so
nothing is verified. Both are attributed to their hosts, so both now require
a name to actually be selected.

<!-- jip:pushed-commit=5cc1360b170b214d454690463f3799744c2f61a2 -->