### PR TITLE
fix: put uploaded images behind site auth, off the image optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **A cap on how much login mail one attendee can be sent**: asking for a login code, or for a link to set a password,
   sends mail to the address on file, and nothing limited how often. At most 20 such mails a day now go to any one
   attendee
+- **Uploaded pictures now need the site password too**: profile photos, room photos and the venue map were handed to
+  anyone who asked for them by address, with no authentication required. A photo's address ends in a long random code
+  nobody could guess, so this mattered only for the venue map, which sits at a fixed address. The reason for this was
+  that, surprisingly, it's the default way Next.js handles images. See the note _"If the src image requires authentication,
+  consider using the unoptimized property to disable Image Optimization."_
+  [here](https://nextjs.org/docs/app/api-reference/components/image).
 
 ### Internal
 

--- a/app/media/avatars/[filename]/route.ts
+++ b/app/media/avatars/[filename]/route.ts
@@ -1,22 +1,35 @@
-// Serves user-uploaded location images from SB_UPLOADS_DIR. URLs carry a
-// ?v= cache-buster set on upload, so responses can be cached aggressively.
+// Serves user-uploaded avatars from SB_UPLOADS_DIR. URLs carry a ?v=
+// cache-buster set on upload, and ?w= the width next/image asked for (see
+// utils/image-loader.js), so responses can be cached aggressively.
 import { NextRequest, NextResponse } from "next/server";
-import { getImageRepositories } from "@/utils/images";
+import { getImageRepositories, requestedWidth } from "@/utils/images";
+import { MEDIA_CACHE_CONTROL, requireMediaAuth } from "@/utils/media-auth";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ filename: string }> }
 ) {
-  const { filename } = await params;
+  const unauthorized = await requireMediaAuth(request);
+  if (unauthorized) return unauthorized;
 
-  const image = await getImageRepositories().avatars.read(filename);
+  const { filename } = await params;
+  const width = requestedWidth(request.nextUrl.searchParams);
+  if (width === false) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+
+  const avatars = getImageRepositories().avatars;
+  const image =
+    width === null
+      ? await avatars.read(filename)
+      : await avatars.readSized(filename, width);
   if (!image) {
     return new NextResponse("Not Found", { status: 404 });
   }
   return new NextResponse(new Uint8Array(image.data), {
     headers: {
       "Content-Type": image.contentType,
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cache-Control": MEDIA_CACHE_CONTROL,
     },
   });
 }

--- a/app/media/locations/[filename]/route.ts
+++ b/app/media/locations/[filename]/route.ts
@@ -1,21 +1,35 @@
+// Serves admin-uploaded location images from SB_UPLOADS_DIR. URLs carry a ?v=
+// cache-buster set on upload, and ?w= the width next/image asked for (see
+// utils/image-loader.js), so responses can be cached aggressively.
 import { NextRequest, NextResponse } from "next/server";
-import { getImageRepositories } from "@/utils/images";
+import { getImageRepositories, requestedWidth } from "@/utils/images";
+import { MEDIA_CACHE_CONTROL, requireMediaAuth } from "@/utils/media-auth";
 
-// Serves admin-uploaded location images from SB_UPLOADS_DIR. URLs carry a
-// ?v= cache-buster set on upload, so responses can be cached aggressively.
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ filename: string }> }
 ) {
+  const unauthorized = await requireMediaAuth(request);
+  if (unauthorized) return unauthorized;
+
   const { filename } = await params;
-  const image = await getImageRepositories().locations.read(filename);
+  const width = requestedWidth(request.nextUrl.searchParams);
+  if (width === false) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+
+  const locations = getImageRepositories().locations;
+  const image =
+    width === null
+      ? await locations.read(filename)
+      : await locations.readSized(filename, width);
   if (!image) {
     return new NextResponse("Not Found", { status: 404 });
   }
   return new NextResponse(new Uint8Array(image.data), {
     headers: {
       "Content-Type": image.contentType,
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cache-Control": MEDIA_CACHE_CONTROL,
     },
   });
 }

--- a/app/media/site/[filename]/route.ts
+++ b/app/media/site/[filename]/route.ts
@@ -1,12 +1,23 @@
-import { NextRequest, NextResponse } from "next/server";
-import { readMapImage } from "@/utils/map-image";
-
 // Serves the admin-uploaded site map from SB_UPLOADS_DIR. URLs carry a ?v=
 // cache-buster set on upload, so responses can be cached aggressively.
+//
+// No ?w= handling, unlike the other two media routes: the map is an image of
+// unknown dimensions shown at full width in a modal, so it is rendered
+// `unoptimized` (see MapModal) and never asks for a rendition.
+import { NextRequest, NextResponse } from "next/server";
+import { readMapImage } from "@/utils/map-image";
+import {
+  MEDIA_CACHE_CONTROL,
+  requireMediaAuth,
+} from "@/utils/media-auth";
+
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ filename: string }> }
 ) {
+  const unauthorized = await requireMediaAuth(request);
+  if (unauthorized) return unauthorized;
+
   const { filename } = await params;
   const image = await readMapImage(filename);
   if (!image) {
@@ -15,7 +26,7 @@ export async function GET(
   return new NextResponse(new Uint8Array(image.data), {
     headers: {
       "Content-Type": image.contentType,
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cache-Control": MEDIA_CACHE_CONTROL,
     },
   });
 }

--- a/next.config.js
+++ b/next.config.js
@@ -28,19 +28,18 @@ const nextConfig = {
     ];
   },
   images: {
-    localPatterns: [
-      // Location uploads carry a ?v=<timestamp> cache-buster; omitting `search`
-      // allows any query string for these paths.
-      { pathname: "/media/**" },
-      // Other local/public assets (e.g. /map.png) without a query string.
-      { pathname: "/**", search: "" },
-    ],
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "res.cloudinary.com",
-      },
-    ],
+    // Media can't go through the built-in optimizer once /media requires a
+    // cookie: the optimizer fetches the source with a request carrying no
+    // headers at all, so the proxy bounces it and it 400s even for a caller
+    // who is logged in. This loader sends /media straight to the media routes,
+    // which resize and check auth themselves. See utils/image-loader.js .
+    //
+    // Naming any custom loader also switches the optimizer off app-wide —
+    // /_next/image then 404s — which is why no localPatterns/remotePatterns
+    // are configured here: they only ever gated that endpoint, and nothing
+    // reaches it now.
+    loader: "custom",
+    loaderFile: "./utils/image-loader.js",
   },
   env: {
     NEXT_PUBLIC_APP_VERSION:

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ import {
   requireAdminAuthApi,
   requireAuth,
 } from "./utils/auth";
+import { requireMediaAuth } from "./utils/media-auth";
 
 // Only requireAdminAuthApi may grant ADMIN_VERIFIED_HEADER (and only ever
 // sets it to "1"); every other forwarded request must have any
@@ -53,6 +54,13 @@ export async function proxy(request: NextRequest) {
     return requireAdminAuthApi(request);
   }
 
+  // Uploaded images are shown to attendees and previewed in the admin UI, so
+  // either cookie opens them; the route handlers apply the same rule again.
+  if (pathname.startsWith("/media/")) {
+    const mediaResponse = await requireMediaAuth(request);
+    return mediaResponse ?? forwardWithoutAdminHeader(request);
+  }
+
   // Check authentication for all other routes
   const authResponse = await requireAuth(request);
   if (authResponse) {
@@ -65,12 +73,20 @@ export async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - public assets (images, etc.)
+     * Everything except an explicit list of what must stay public:
+     * - _next/static — build output, no user data
+     * - _next/image  — dead under the custom loader (it 404s, see
+     *                  next.config.js), and build assets either way
+     * - the three icons app/layout.tsx loads, which the login page needs
+     *   before anyone has a cookie
+     * - locations/  — the seeded room photos in public/, which the admin UI
+     *   renders with the admin cookie alone (uploads live under /media)
+     *
+     * This deliberately does NOT exempt paths by file extension. It used to,
+     * and since media filenames are `<id>.<jpg|png|webp>` that exempted every
+     * uploaded avatar, location image and site map from auth entirely — see
+     * matcher's own test at tests/unit/proxy-matcher.test.ts.
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:jpg|jpeg|gif|png|svg|ico|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|icon.svg|apple-touch-icon.png|locations/).*)",
   ],
 };

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -3,6 +3,7 @@ import sharp from "sharp";
 import { test, expect } from "./helpers/fixtures";
 import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto } from "./helpers/auth";
+import { expectImageLoaded } from "./helpers/images";
 import { selectUser } from "./helpers/user";
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
@@ -1668,6 +1669,10 @@ test.describe("Admin UI locations", () => {
     await gotoLocations(page);
     const region = page.getByRole("region", { name: "Locations" });
 
+    // A seeded room photo, which ships in public/ rather than the uploads
+    // volume — the other way an image can reach this page.
+    await expectImageLoaded(region.getByRole("img", { name: "Main Hall" }));
+
     const name = `E2E Photo Room ${uniqueSuffix()}`;
     await region.getByRole("button", { name: "New location" }).click();
     await region.getByLabel("Name", { exact: true }).fill(name);
@@ -1693,7 +1698,9 @@ test.describe("Admin UI locations", () => {
     await region.getByRole("button", { name: "Add location" }).click();
     const row = region.getByRole("listitem").filter({ hasText: name });
     await expect(row).toBeVisible();
-    await expect(row.getByRole("img", { name })).toBeVisible();
+    // Loaded, not just present: this page runs on the admin cookie alone, so
+    // an image gated on the site cookie would show up here as a broken box.
+    await expectImageLoaded(row.getByRole("img", { name }));
 
     await deleteLocation(page, name);
   });

--- a/tests/e2e/helpers/images.ts
+++ b/tests/e2e/helpers/images.ts
@@ -1,0 +1,13 @@
+import { Locator, expect } from "@playwright/test";
+
+/**
+ * Asserts the image actually decoded, not merely that its element is on the
+ * page: a 401 or 404 leaves a broken <img> that still has a box, so
+ * `toBeVisible()` passes for an image nobody can see.
+ */
+export async function expectImageLoaded(image: Locator): Promise<void> {
+  await expect(image).toBeVisible();
+  await expect
+    .poll(() => image.evaluate((img: HTMLImageElement) => img.naturalWidth))
+    .toBeGreaterThan(0);
+}

--- a/tests/e2e/profile-photo.spec.ts
+++ b/tests/e2e/profile-photo.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
+import { expectImageLoaded } from "./helpers/images";
 
 // Charlie Test is seeded with an uploaded photo and no other spec edits their
 // profile, so this never races profile.spec.ts, which resets Alice's avatar.
@@ -19,6 +20,9 @@ test("shows the photo big enough to recognise someone, without clicking", async 
   ).toBeVisible();
 
   const photo = profile.getByAltText(`Profile avatar of ${GUEST}`);
+  // The box below says nothing about whether the bytes arrived: uploads are
+  // served by /media, which authenticates the request itself.
+  await expectImageLoaded(photo);
   const box = (await photo.boundingBox())!;
   expect(box.width).toBeGreaterThanOrEqual(240);
   // Stored avatars are square crops, so an unsquare box means a stretched face.

--- a/tests/integration/media-routes.test.ts
+++ b/tests/integration/media-routes.test.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import sharp from "sharp";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  ADMIN_COOKIE_NAME,
+  AUTH_COOKIE_NAME,
+  createAdminAuthCookie,
+  createAuthCookie,
+} from "@/utils/auth";
+import { GET as avatarGET } from "@/app/media/avatars/[filename]/route";
+import { GET as locationGET } from "@/app/media/locations/[filename]/route";
+import { GET as siteGET } from "@/app/media/site/[filename]/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+let uploadsDir: string;
+
+/** Writes a square test image and returns its filename. */
+async function writeImage(
+  dir: string,
+  name: string,
+  size: number
+): Promise<string> {
+  const target = path.join(uploadsDir, dir);
+  await fs.mkdir(target, { recursive: true });
+  await sharp({
+    create: {
+      width: size,
+      height: size,
+      channels: 3,
+      background: { r: 10, g: 120, b: 200 },
+    },
+  })
+    .webp()
+    .toFile(path.join(target, name));
+  return name;
+}
+
+function req(url: string, authed = true): NextRequest {
+  const request = new NextRequest(`http://test${url}`);
+  if (authed) request.cookies.set(AUTH_COOKIE_NAME, siteCookieValue);
+  return request;
+}
+
+let siteCookieValue: string;
+
+const params = (filename: string) => ({
+  params: Promise.resolve({ filename }),
+});
+
+describe("media routes", () => {
+  beforeEach(async () => {
+    uploadsDir = await fs.mkdtemp(path.join(os.tmpdir(), "media-test-"));
+    vi.stubEnv("SB_UPLOADS_DIR", uploadsDir);
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    vi.stubEnv("SITE_PASSWORD", "site-pw");
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    siteCookieValue = (await createAuthCookie()).value;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(uploadsDir, { recursive: true, force: true });
+  });
+
+  // The map is stored under its own fixed name, not a generated id.
+  describe.each([
+    ["avatars", avatarGET, "probe.webp"],
+    ["locations", locationGET, "probe.webp"],
+    ["site", siteGET, "map.webp"],
+  ] as const)("/media/%s", (dir, GET, file) => {
+    it("refuses a request with no site-auth cookie", async () => {
+      const name = await writeImage(dir, file, 300);
+      const res = await GET(req(`/media/${dir}/${name}`, false), params(name));
+      expect(res.status).toBe(401);
+      expect(res.headers.get("content-type")).not.toMatch(/^image\//);
+    });
+
+    it("refuses a forged site-auth cookie", async () => {
+      const name = await writeImage(dir, file, 300);
+      const request = new NextRequest(`http://test/media/${dir}/${name}`);
+      request.cookies.set(AUTH_COOKIE_NAME, "not.a.real.signature");
+      const res = await GET(request, params(name));
+      expect(res.status).toBe(401);
+    });
+
+    it("serves the image to a site-authenticated caller", async () => {
+      const name = await writeImage(dir, file, 300);
+      const res = await GET(req(`/media/${dir}/${name}`), params(name));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/webp");
+      expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0);
+    });
+
+    // The admin UI is reachable with the admin cookie alone (see
+    // tests/e2e/admin.spec.ts), and it previews the very images it uploads.
+    it("serves the image to an admin with no site-auth cookie", async () => {
+      const name = await writeImage(dir, file, 300);
+      const request = new NextRequest(`http://test/media/${dir}/${name}`);
+      request.cookies.set(
+        ADMIN_COOKIE_NAME,
+        (await createAdminAuthCookie()).value
+      );
+      const res = await GET(request, params(name));
+      expect(res.status).toBe(200);
+    });
+
+    it("404s a missing file rather than leaking the difference", async () => {
+      const res = await GET(
+        req(`/media/${dir}/nothing.webp`),
+        params("nothing.webp")
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects a traversing filename", async () => {
+      const res = await GET(
+        req(`/media/${dir}/..%2F..%2Fetc%2Fpasswd`),
+        params("../../etc/passwd")
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // The built-in optimizer can't fetch these (its upstream request carries no
+  // cookies, so the proxy bounces it), so the handlers resize themselves and
+  // the loader asks for a width. See utils/image-loader.js.
+  describe("resizing", () => {
+    it("serves a smaller rendition for a requested width", async () => {
+      const name = await writeImage("avatars", "big.webp", 1024);
+      const res = await avatarGET(
+        req(`/media/avatars/${name}?w=128`),
+        params(name)
+      );
+      expect(res.status).toBe(200);
+      const meta = await sharp(Buffer.from(await res.arrayBuffer())).metadata();
+      expect(meta.width).toBe(128);
+    });
+
+    it("never upscales past the stored size", async () => {
+      const name = await writeImage("avatars", "small.webp", 200);
+      const res = await avatarGET(
+        req(`/media/avatars/${name}?w=640`),
+        params(name)
+      );
+      const meta = await sharp(Buffer.from(await res.arrayBuffer())).metadata();
+      expect(meta.width).toBe(200);
+    });
+
+    it("serves the original when no width is asked for", async () => {
+      const name = await writeImage("avatars", "big.webp", 1024);
+      const res = await avatarGET(req(`/media/avatars/${name}`), params(name));
+      const meta = await sharp(Buffer.from(await res.arrayBuffer())).metadata();
+      expect(meta.width).toBe(1024);
+    });
+
+    // An open width parameter is a CPU-burn oracle: one URL per width, each
+    // missing the rendition cache and costing a full decode plus resize.
+    it("rejects a width outside the allowed set", async () => {
+      const name = await writeImage("avatars", "big.webp", 1024);
+      for (const w of ["127", "999", "-1", "0", "abc", "1e9"]) {
+        const res = await avatarGET(
+          req(`/media/avatars/${name}?w=${w}`),
+          params(name)
+        );
+        expect(res.status, `w=${w} must be refused`).toBe(400);
+      }
+    });
+
+    it("caches a rendition so the second request doesn't resize again", async () => {
+      const name = await writeImage("avatars", "big.webp", 1024);
+      const url = `/media/avatars/${name}?w=256`;
+      await avatarGET(req(url), params(name));
+
+      const cached = await fs.readdir(path.join(uploadsDir, "avatars"));
+      expect(cached).toContain("big.256.webp");
+
+      // Replacing the cached file with a differently shaped image is the only
+      // way to tell a cache hit from a second resize: both answer 256 wide.
+      await sharp({
+        create: {
+          width: 256,
+          height: 64,
+          channels: 3,
+          background: { r: 1, g: 2, b: 3 },
+        },
+      })
+        .webp()
+        .toFile(path.join(uploadsDir, "avatars", "big.256.webp"));
+
+      const res = await avatarGET(req(url), params(name));
+      const meta = await sharp(Buffer.from(await res.arrayBuffer())).metadata();
+      expect(meta.height).toBe(64);
+    });
+  });
+});

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { ADMIN_VERIFIED_HEADER, createAdminAuthCookie } from "@/utils/auth";
+import {
+  ADMIN_VERIFIED_HEADER,
+  createAdminAuthCookie,
+  createAuthCookie,
+} from "@/utils/auth";
 import { throughProxy } from "../helpers/through-proxy";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
@@ -94,5 +98,37 @@ describe("proxy: /api/admin/* auth", () => {
     const admin = await createAdminAuthCookie();
     const result = await throughProxy("/api/admin/create-guest", {}, [admin]);
     if (!result.ok) throw new Error("expected proxy to forward the request");
+  });
+});
+
+// Uploaded images are shown to attendees, who hold the site cookie, and
+// previewed in the admin UI, which is independent of site auth — so either
+// cookie opens them. The route handlers apply the same rule (see
+// utils/media-auth.ts and tests/integration/media-routes.test.ts).
+describe("proxy: /media auth", () => {
+  beforeEach(() => {
+    vi.stubEnv("SITE_PASSWORD", "site-pw");
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("forwards a request carrying the site cookie", async () => {
+    const site = await createAuthCookie();
+    const result = await throughProxy("/media/avatars/abc.webp", {}, [site]);
+    if (!result.ok) throw new Error("expected proxy to forward the request");
+  });
+
+  it("forwards a request carrying only the admin cookie", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy("/media/locations/abc.webp", {}, [admin]);
+    if (!result.ok) throw new Error("expected proxy to forward the request");
+  });
+
+  it("answers 401 rather than redirecting an unauthenticated image request", async () => {
+    const result = await throughProxy("/media/site/map.webp", {}, []);
+    if (result.ok) throw new Error("expected proxy to reject the request");
+    expect(result.response.status).toBe(401);
+    expect(result.response.headers.get("location")).toBeNull();
   });
 });

--- a/tests/unit/image-loader.test.ts
+++ b/tests/unit/image-loader.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import loader from "@/utils/image-loader";
+
+// Next's built-in optimizer cannot fetch /media: it builds its upstream
+// request with no headers at all, so the proxy sees no site-auth cookie and
+// bounces it. This loader therefore points media at the media routes
+// themselves, which resize and check auth, and leaves everything else on the
+// default path.
+
+describe("image loader", () => {
+  it("asks the media route for the width, keeping the cache-buster", () => {
+    expect(loader({ src: "/media/avatars/a1.webp?v=123", width: 128 })).toBe(
+      "/media/avatars/a1.webp?v=123&w=128&q=75"
+    );
+  });
+
+  it("starts the query when the source carries none", () => {
+    expect(loader({ src: "/media/site/map.webp", width: 640 })).toBe(
+      "/media/site/map.webp?w=640&q=75"
+    );
+  });
+
+  it("passes an explicit quality through", () => {
+    expect(
+      loader({ src: "/media/locations/l1.jpg", width: 256, quality: 90 })
+    ).toBe("/media/locations/l1.jpg?w=256&q=90");
+  });
+
+  // Configuring any custom loader makes Next answer /_next/image with a 404
+  // (next-server.js: `imagesConfig.loader !== 'default'` → render404), so a
+  // URL pointing there would be a broken image, not an optimized one.
+  it("never routes anything to the built-in optimizer", () => {
+    for (const src of [
+      "/locations/loc-room-a.jpg",
+      "/mediafoo/x.webp",
+      "https://res.cloudinary.com/x/y.jpg",
+    ]) {
+      expect(loader({ src, width: 384 })).toBe(src);
+    }
+  });
+});

--- a/tests/unit/proxy-matcher.test.ts
+++ b/tests/unit/proxy-matcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { config } from "@/proxy";
+
+// tests/integration/proxy.test.ts calls proxy() directly, so it never
+// exercises config.matcher — and a path the matcher excludes never reaches
+// proxy() at all. That blind spot is what let every uploaded image be served
+// unauthenticated: the matcher excluded any path ending in an image extension,
+// and media filenames are <id>.<jpg|png|webp>.
+
+const matches = (pathname: string): boolean =>
+  new RegExp(`^${config.matcher[0]}$`).test(pathname);
+
+describe("proxy matcher", () => {
+  it("covers uploaded media, whatever the extension", () => {
+    for (const path of [
+      "/media/avatars/abc123.webp",
+      "/media/avatars/abc123.png",
+      "/media/avatars/abc123.jpg",
+      "/media/locations/xyz789.webp",
+      "/media/site/map.webp",
+      "/media/site/map.png",
+      "/media/site/map.jpg",
+    ]) {
+      expect(matches(path), `${path} must reach the proxy`).toBe(true);
+    }
+  });
+
+  it("covers pages and API routes", () => {
+    for (const path of ["/", "/guests", "/api/votes", "/Conference-Alpha"]) {
+      expect(matches(path), `${path} must reach the proxy`).toBe(true);
+    }
+  });
+
+  // Excluding these is what keeps the login page renderable to someone who
+  // has not logged in yet: the root layout loads all three icons.
+  //
+  // public/locations holds the seeded room photos the sample data points at.
+  // They are build output like any other, and gating them broke the admin UI,
+  // which renders them with the admin cookie alone and no site cookie.
+  it("skips build output and the icons the login page itself loads", () => {
+    for (const path of [
+      "/_next/static/chunks/main.js",
+      "/_next/image",
+      "/favicon.ico",
+      "/icon.svg",
+      "/apple-touch-icon.png",
+      "/locations/loc-room-a.jpg",
+    ]) {
+      expect(matches(path), `${path} must skip the proxy`).toBe(false);
+    }
+  });
+
+  it("no longer exempts a path merely for ending in an image extension", () => {
+    for (const path of ["/secret.png", "/guests/leak.webp", "/x.jpg"]) {
+      expect(matches(path), `${path} must reach the proxy`).toBe(true);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     "db",
+    ".next/dev/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/utils/image-loader.js
+++ b/utils/image-loader.js
@@ -1,0 +1,34 @@
+// Custom next/image loader, wired up as `images.loaderFile` in
+// next.config.js. It has to be a global loader rather than a per-component
+// `loader` prop, because <Image> is a client component and a server component
+// cannot pass it a function.
+//
+// Uploaded media cannot go through Next's built-in optimizer once /media is
+// behind auth. The optimizer fetches the source itself, and that internal
+// request is built by createRequestResponseMocks({ url, method, socket }) with
+// no headers at all — so it carries no cookie, the proxy bounces it to /login,
+// and the optimizer 400s even for a caller who *is* logged in.
+//
+// So media is fetched straight from the media routes, which the browser
+// requests with cookies attached; those routes do the resizing the optimizer
+// would otherwise have done.
+//
+// Everything else is served as stored, unresized: configuring any custom
+// loader makes Next answer /_next/image with a 404 (next-server.js bails on
+// `imagesConfig.loader !== 'default'`), so the optimizer is off for the whole
+// app, not just for media. Only build assets take this path — the seeded room
+// photos under public/locations — and they ship at display size already.
+
+const DEFAULT_QUALITY = 75;
+
+/**
+ * @param {import("next/image").ImageLoaderProps} props
+ * @returns {string}
+ */
+export default function imageLoader({ src, width, quality }) {
+  if (!src.startsWith("/media/")) return src;
+
+  // Stored media URLs already carry a ?v= cache-buster.
+  const separator = src.includes("?") ? "&" : "?";
+  return `${src}${separator}w=${width}&q=${quality || DEFAULT_QUALITY}`;
+}

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -152,16 +152,110 @@ export abstract class BaseImageResourceRepository<
     filename: string
   ): Promise<{ data: Buffer; contentType: string } | undefined> {
     if (!SAFE_FILENAME.test(filename)) return undefined;
+    return this.readStored(filename);
+  }
 
-    filename = path.join(/*turbopackIgnore: true*/ this.dirPath, filename);
+  /**
+   * {@link read} without the SAFE_FILENAME check, for names this class builds
+   * itself. Renditions are `<id>.<width>.<ext>`, which SAFE_FILENAME rejects
+   * (it allows no dot in the stem) — reading them through `read` silently
+   * missed the cache on every request.
+   */
+  private async readStored(
+    filename: string
+  ): Promise<{ data: Buffer; contentType: string } | undefined> {
+    const target = path.join(/*turbopackIgnore: true*/ this.dirPath, filename);
     try {
-      const data = await fs.readFile(filename);
-      const ext = filename.split(".").pop()!;
+      const data = await fs.readFile(target);
+      const ext = target.split(".").pop()!;
       return { data, contentType: CONTENT_TYPES[ext] };
     } catch {
       return undefined;
     }
   }
+
+  /**
+   * {@link read}, downscaled to `width`. Does the job next/image's optimizer
+   * would, because it can't reach these files once /media needs a cookie
+   * (see utils/image-loader.js).
+   *
+   * The rendition is cached beside the original as `<id>.<width>.<ext>`, so
+   * replacing an image drops its renditions too — {@link delete} already
+   * removes everything starting with `<id>.`.
+   */
+  async readSized(
+    filename: string,
+    width: number
+  ): Promise<{ data: Buffer; contentType: string } | undefined> {
+    if (!SAFE_FILENAME.test(filename)) return undefined;
+
+    const [base, ext] = splitExtension(filename);
+    const rendition = `${base}.${width}.${ext}`;
+    const cached = await this.readStored(rendition);
+    if (cached) return cached;
+
+    const original = await this.read(filename);
+    if (!original) return undefined;
+
+    let resized: Buffer;
+    try {
+      const image = sharp(original.data);
+      const { width: sourceWidth } = await image.metadata();
+      // Upscaling invents no detail and only costs bytes.
+      if (sourceWidth <= width) return original;
+      resized = await image
+        .resize(width, null, { withoutEnlargement: true })
+        .toBuffer();
+    } catch {
+      // A stored file sharp can't read is still servable as-is.
+      return original;
+    }
+
+    await this.writeRendition(rendition, resized);
+    return { data: resized, contentType: original.contentType };
+  }
+
+  /**
+   * Writes via a unique temporary name and renames into place, so a second
+   * request for the same rendition can never read a half-written file.
+   */
+  private async writeRendition(name: string, data: Buffer): Promise<void> {
+    const dir = this.dirPath;
+    const target = path.join(/*turbopackIgnore: true*/ dir, name);
+    const temp = `${target}.${crypto.randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(temp, data);
+      await fs.rename(temp, target);
+    } catch {
+      // A failed cache write costs a resize next time, nothing more.
+      await fs.unlink(temp).catch(() => {});
+    }
+  }
+}
+
+/** Splits "a1.webp" into ["a1", "webp"]; the name is SAFE_FILENAME-checked. */
+function splitExtension(filename: string): [string, string] {
+  const dot = filename.lastIndexOf(".");
+  return [filename.slice(0, dot), filename.slice(dot + 1)];
+}
+
+// The widths next/image can ask for: its default imageSizes and deviceSizes.
+// An open width parameter would be a CPU-burn oracle — every distinct value
+// misses the rendition cache and costs a full decode plus resize.
+const ALLOWED_WIDTHS = new Set([
+  16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080, 1200, 1920, 2048,
+  3840,
+]);
+
+/**
+ * The width a media request asks for: null when it asks for none (serve the
+ * original), or false when the value isn't one we generate renditions for.
+ */
+export function requestedWidth(params: URLSearchParams): number | null | false {
+  const raw = params.get("w");
+  if (raw === null) return null;
+  const width = Number(raw);
+  return ALLOWED_WIDTHS.has(width) ? width : false;
 }
 
 const SAFE_FILENAME = /^[A-Za-z0-9_-]+\.(jpg|png|webp)$/;

--- a/utils/media-auth.ts
+++ b/utils/media-auth.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  AUTH_COOKIE_NAME,
+  isAdminAuthenticated,
+  isAuthCookieValid,
+} from "./auth";
+
+/**
+ * The /media gate, applied twice: once in the proxy and again in each route
+ * handler. The second check is what mirrors {@link requireProxyVerifiedAdmin}
+ * for /api/admin — it makes these routes fail *closed* if the proxy ever stops
+ * covering them: a matcher edit, a route moved, a middleware-bypass bug in
+ * Next. All three of those went wrong at once before: the matcher exempted any
+ * path ending in an image extension, media filenames are `<id>.<jpg|png|webp>`,
+ * and the handlers had no check of their own — so every uploaded avatar,
+ * location photo and site map was served without auth.
+ *
+ * Either cookie opens media: attendees hold the site cookie, and the admin UI
+ * — which is independent of site auth (see proxy.ts) — previews the very
+ * images it uploads. Unlike the admin API contract this re-reads the cookies
+ * rather than trusting a proxy-set header, since attendees carry the site
+ * cookie themselves and there is nothing cheaper to check.
+ *
+ * Answers 401 rather than redirecting to /login: an <img> that follows a
+ * redirect to an HTML page renders a broken image either way, and a status the
+ * browser reports is easier to diagnose. Returns null to let the request
+ * through.
+ */
+export async function requireMediaAuth(
+  request: NextRequest
+): Promise<NextResponse | null> {
+  const cookie = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+  if (await isAuthCookieValid(cookie)) return null;
+  if (await isAdminAuthenticated(request)) return null;
+
+  return new NextResponse("Unauthorized", {
+    status: 401,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+// Uploads are immutable at a given URL: every save mints a fresh ?v=. Private
+// so a shared cache can't hand one attendee's avatar to an unauthenticated
+// stranger — the whole point of the gate above.
+export const MEDIA_CACHE_CONTROL = "private, max-age=31536000, immutable";


### PR DESCRIPTION
The proxy matcher exempted every path ending in an image extension, and media
filenames are `<id>.<ext>`, so no uploaded image required a login. How much
that exposed differs per image: an avatar or location photo sits behind a
21-character random id that is not guessable in practice, so it was readable
only by someone who had been handed the address; the site map, stored under the
fixed name `map.<ext>`, was effectively public.

Gating them means giving up Next's optimizer for media: its upstream fetch is
built with no headers at all, so the very check being added bounces it and the
image 400s even for a logged-in caller. A custom next/image loader points media
at the media routes instead, which the browser requests with cookies and which
now resize on demand and check auth themselves.

Naming any custom loader also switches /_next/image off app-wide — it 404s —
so everything else is served as stored. That "everything else" is the seeded
room photos in public/, which the admin UI renders; since the admin UI runs on
the admin cookie alone, they stay outside the gate and /media takes either
cookie.

<!-- jip:pushed-commit=96c8ca7cc67204540683f604ac97457a06737c89 -->