### PR TITLE
test: stop the comment-likes E2E test running out of budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- The E2E test for comment likes is marked slow and waits for the reloaded modal's like count before
+  asserting that the hover preview is hidden. Two identities, a second browser context and a reload
+  ran it just over the 30s default, and the tooltip assertion failed on an element that had not
+  rendered yet
 - Every server action that isn't a login or logout checks the site-auth cookie itself. Next only
   dispatches an action on the route that defines it, so one on a protected page was already
   unreachable without site auth — but that is a framework detail, not a control this codebase owns.

--- a/tests/e2e/session-comments.spec.ts
+++ b/tests/e2e/session-comments.spec.ts
@@ -209,6 +209,11 @@ test("keeps replies readable when their parent is deleted", async ({
 });
 
 test("likes a comment and shows who liked it", async ({ page, browser }) => {
+  // Two identities, each a real logout-then-login round trip, plus a second
+  // browser context and a reload, add up to just over the 30s default once
+  // parallel workers compete for the server.
+  test.slow();
+
   await login(page);
   await page.goto("/Conference-Gamma");
   await actAs(page, /Alice Test/i);
@@ -241,6 +246,9 @@ test("likes a comment and shows who liked it", async ({ page, browser }) => {
   const reopened = page.getByRole("dialog", { name: "Session details" });
   // Hovering previews the likers, newest first, without opening anything.
   const count = reopened.getByRole("button", { name: "2 likes" });
+  // The reloaded modal fetches its comments, so wait for the count before
+  // asserting on the preview: an absent tooltip would satisfy nothing.
+  await expect(count).toBeVisible();
   const tooltip = page.getByRole("tooltip");
   await expect(tooltip).toHaveCSS("opacity", "0");
   await count.hover();


### PR DESCRIPTION
Two logout-then-login round trips, a second browser context and a reload put it
just past the 30s default, and the tooltip assertion ran against a modal whose
comments had not come back yet.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=02d61d3498c8411a706f6b6583f7b5b8caa52fa7 -->