### PR TITLE
test: make CI report E2E tests that only passed on retry

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -76,3 +76,25 @@ jobs:
 
       - name: E2E Tests
         run: make test-e2e
+
+      # CI retries twice, so a test that only passed on its second attempt
+      # leaves a green check and no trace in the log. Name those explicitly —
+      # a warning annotation each, plus a table in the job summary.
+      - name: Report tests that passed on retry
+        if: always()
+        run: bun scripts/ci-flaky-summary.ts
+
+      # The reports and the traces of failed attempts (trace: on-first-retry)
+      # are the only way to debug a failure once the runner is gone.
+      # See docs/dev/testing.md § Flaky tests on CI.
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+            playwright-results.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ package-lock.json
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+# JSON report, written by the CI reporter (see playwright.config.ts)
+/playwright-results.json
 
 /tests/test-data.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   report plus traces of what failed; `scripts/e2e-flake-report.ts` aggregates those into a report
   ranking flaky tests by failure rate and grouping them by error signature. See
   [docs/dev/testing.md § Flake hunting](docs/dev/testing.md#flake-hunting)
+- CI names the E2E tests that only passed on retry — a warning annotation and a job-summary table
+  from `scripts/ci-flaky-summary.ts`, plus Playwright's `github` reporter putting each failed
+  attempt next to the line that failed — and uploads the Playwright reports plus the traces of
+  failed attempts as an artifact. Before, retries turned a flake into a plain green check with
+  nothing kept to debug it. See
+  [docs/dev/testing.md § Flaky tests on CI](docs/dev/testing.md#flaky-tests-on-ci)
 - Throwaway names in E2E tests carry the worker's process id and a counter, not just `Date.now()`:
   two parallel workers can land in the same millisecond, and the duplicate name would surface as an
   unreproducible locator failure somewhere else entirely

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ clean:
 	rm -rf .next
 	rm -f next-env.d.ts
 	rm -f data.db data.test.db
-	rm -rf playwright-report test-results .e2e-docker
+	rm -rf playwright-report test-results playwright-results.json .e2e-docker
 	rm -f tsconfig.tsbuildinfo
 	rm -rf www-site
 	rm -rf uploads uploads-test

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -223,6 +223,28 @@ If the mail variables are set in `.env.test.local`, start mailpit (`make
 mailpit`) before a hunt — otherwise the email specs fail identically in every
 run and clutter the report as persistent failures.
 
+## Flaky tests on CI
+
+CI runs the suite with `retries: 2`, so a test that fails once and passes on the
+next attempt leaves a green check. The E2E workflow makes that visible instead:
+
+- **Error annotations** — Playwright's own `github` reporter annotates every
+  failed attempt with its error message and location, flaky tests included. So
+  a green run can carry red annotations: they are a failed attempt, not a
+  failed run.
+- **Warning annotations** — `scripts/ci-flaky-summary.ts` reads the JSON report
+  and emits one `::warning` per test Playwright classified as flaky, plus a
+  table in the job summary — the part the reporter cannot do, and the one that
+  survives being scrolled past.
+- **The `playwright-report` artifact** (14 days) holds the html report, the JSON
+  report and `test-results/` — including the trace of the failed attempt, since
+  `trace: on-first-retry` records exactly that one. Download it, unzip it and
+  open the trace with `bun x playwright show-trace <path>`.
+
+A flaky warning is a test that failed for a reason; treat it as a bug to be
+diagnosed from that trace, not as noise. Retries stay at 2 until the suite is
+stable — the aim is to measure flakiness, not to start failing on it.
+
 ## E2E conventions
 
 - Imitate human behavior — click visible elements, navigate naturally

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -95,8 +95,20 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters
+   * On CI the run is only worth as much as the record it leaves behind: the
+   * JSON report is what scripts/ci-flaky-summary.ts reads to name the tests
+   * that passed on retry, and the html report is uploaded as an artifact
+   * (`open: never` — nothing can open a browser there anyway). `github` puts
+   * each failed attempt next to the line that failed — for flaky tests too, so
+   * a green run can carry red annotations. */
+  reporter: process.env.CI
+    ? [
+        ["html", { open: "never" }],
+        ["json", { outputFile: "playwright-results.json" }],
+        ["github"],
+      ]
+    : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/scripts/ci-flaky-summary.ts
+++ b/scripts/ci-flaky-summary.ts
@@ -1,0 +1,131 @@
+/**
+ * Report the tests a CI run only passed on retry, which a green check would
+ * otherwise hide (CI runs with retries).
+ *
+ *   bun scripts/ci-flaky-summary.ts [playwright-results.json]
+ *
+ * Writes a warning annotation per flaky test to stdout — GitHub Actions reads
+ * those off the log — and a table to the job summary. Always exits 0: the
+ * point is a greppable record, not a new gate.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  collectSpecs,
+  specFile,
+  specTitle,
+  type JsonReport,
+} from "./playwright-json";
+
+interface FlakyTest {
+  file: string;
+  line?: number;
+  title: string;
+  attempts: number;
+}
+
+/**
+ * Playwright reports spec files relative to `rootDir` — the common root of the
+ * test directories, `tests/e2e/`, not the repository. GitHub resolves an
+ * annotation's `file=` against the workspace, so rebase it there. A report
+ * from another checkout (`rootDir` outside this one) keeps its own path;
+ * a wrong guess would be worse than the raw one.
+ */
+function repoRelative(file: string, rootDir?: string): string {
+  if (!rootDir) return file;
+  const relative = path.relative(process.cwd(), path.resolve(rootDir, file));
+  return relative && !relative.startsWith("..") && !path.isAbsolute(relative)
+    ? relative
+    : file;
+}
+
+function flakyTests(report: JsonReport): FlakyTest[] {
+  const rootDir = report.config?.rootDir;
+  const out: FlakyTest[] = [];
+  for (const collected of collectSpecs(report.suites ?? [])) {
+    for (const test of collected.spec.tests ?? []) {
+      if (test.status !== "flaky") continue;
+      out.push({
+        file: repoRelative(specFile(collected), rootDir),
+        line: collected.spec.line,
+        title: specTitle(collected),
+        attempts: test.results?.length ?? 0,
+      });
+    }
+  }
+  return out;
+}
+
+// https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+function escapeCommandData(value: string): string {
+  return value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+// Property values are parsed off a comma-separated, colon-terminated list, so
+// they need those two escaped on top of the data escapes.
+function escapeCommandProperty(value: string): string {
+  return escapeCommandData(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
+}
+
+function formatAnnotations(flaky: FlakyTest[]): string[] {
+  return flaky.map((test) => {
+    const location = test.line ? `,line=${test.line}` : "";
+    const attempt = test.attempts
+      ? ` (passed on attempt ${test.attempts})`
+      : "";
+    return (
+      `::warning file=${escapeCommandProperty(test.file)}${location}::` +
+      escapeCommandData(`flaky: ${test.title}${attempt}`)
+    );
+  });
+}
+
+function formatSummary(flaky: FlakyTest[]): string {
+  if (flaky.length === 0) return "";
+  const lines = [
+    `### Flaky tests (${flaky.length})`,
+    "",
+    "Passed only on retry. Open the `playwright-report` artifact — the trace of" +
+      " the failed attempt is in it (see docs/dev/testing.md § Flaky tests on CI).",
+    "",
+    "| Test | Where | Attempts |",
+    "| --- | --- | --- |",
+  ];
+  for (const test of flaky) {
+    const where = test.line ? `${test.file}:${test.line}` : test.file;
+    lines.push(
+      `| ${test.title.replace(/\|/g, "\\|")} | \`${where}\` | ${test.attempts || "?"} |`
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const file = process.argv[2] ?? "playwright-results.json";
+  let report: JsonReport;
+  try {
+    report = JSON.parse(fs.readFileSync(file, "utf8")) as JsonReport;
+  } catch (error) {
+    // A run that died before writing the report is already reported as a
+    // failure by the test step; do not add a second, confusing one.
+    console.log(`No usable ${file} (${String(error)}) — skipping flake check.`);
+    return;
+  }
+
+  const flaky = flakyTests(report);
+  if (flaky.length === 0) {
+    console.log("No tests passed on retry.");
+    return;
+  }
+  for (const line of formatAnnotations(flaky)) console.log(line);
+
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) fs.appendFileSync(summaryFile, formatSummary(flaky));
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  main();
+}
+
+export { flakyTests, formatAnnotations, formatSummary };
+export type { FlakyTest };

--- a/scripts/e2e-flake-report.ts
+++ b/scripts/e2e-flake-report.ts
@@ -10,47 +10,14 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import {
+  collectSpecs,
+  specFile,
+  specTitle,
+  type JsonReport,
+} from "./playwright-json";
 
-// Only the parts of the Playwright JSON reporter's output this report reads.
-// Everything is optional: a run killed mid-suite still writes a file.
-interface JsonError {
-  message?: string;
-}
-interface JsonAttachment {
-  name?: string;
-  path?: string;
-}
-interface JsonResult {
-  status?: string;
-  duration?: number;
-  errors?: JsonError[];
-  error?: JsonError;
-  attachments?: JsonAttachment[];
-}
-interface JsonTest {
-  status?: string;
-  timeout?: number;
-  results?: JsonResult[];
-}
-interface JsonSpec {
-  title?: string;
-  file?: string;
-  tests?: JsonTest[];
-}
-interface JsonSuite {
-  title?: string;
-  file?: string;
-  specs?: JsonSpec[];
-  suites?: JsonSuite[];
-}
-interface JsonStats {
-  duration?: number;
-  unexpected?: number;
-}
-interface JsonReport {
-  suites?: JsonSuite[];
-  errors?: JsonError[];
-  stats?: JsonStats;
+interface HuntReport extends JsonReport {
   // Not Playwright's: set by e2e-flake-hunt.sh when HUNT_KEEP_PASSING=0 threw
   // a green run's per-test data away.
   shrunk?: boolean;
@@ -96,9 +63,9 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 // from a timeout, so flag it before it starts failing.
 const OUTLIER_FRACTION = 0.6;
 
-function readJson(file: string): JsonReport | undefined {
+function readJson(file: string): HuntReport | undefined {
   try {
-    return JSON.parse(fs.readFileSync(file, "utf8")) as JsonReport;
+    return JSON.parse(fs.readFileSync(file, "utf8")) as HuntReport;
   } catch {
     return undefined;
   }
@@ -120,30 +87,11 @@ function normalizeSignature(message: string): string {
     .trim();
 }
 
-function collectSpecs(
-  suites: JsonSuite[],
-  ancestors: string[]
-): { spec: JsonSpec; titlePath: string[] }[] {
-  const out: { spec: JsonSpec; titlePath: string[] }[] = [];
-  for (const suite of suites) {
-    // The file-level suite is titled with the file path itself; describe
-    // blocks below it carry real titles.
-    const title = suite.title && suite.title !== suite.file ? suite.title : "";
-    const nextAncestors = title ? [...ancestors, title] : ancestors;
-    for (const spec of suite.specs ?? []) {
-      out.push({ spec, titlePath: nextAncestors });
-    }
-    out.push(...collectSpecs(suite.suites ?? [], nextAncestors));
-  }
-  return out;
-}
-
 function observationsOf(report: JsonReport): Observation[] {
   const observations: Observation[] = [];
-  for (const { spec, titlePath } of collectSpecs(report.suites ?? [], [])) {
-    const name = [...titlePath, spec.title ?? "(untitled)"].join(" › ");
-    const key = `${spec.file ?? "(unknown file)"} › ${name}`;
-    for (const test of spec.tests ?? []) {
+  for (const collected of collectSpecs(report.suites ?? [])) {
+    const key = `${specFile(collected)} › ${specTitle(collected)}`;
+    for (const test of collected.spec.tests ?? []) {
       const results = test.results ?? [];
       const durationMs = results.reduce((sum, r) => sum + (r.duration ?? 0), 0);
       const failing = results.find(

--- a/scripts/playwright-json.ts
+++ b/scripts/playwright-json.ts
@@ -1,0 +1,84 @@
+/**
+ * The slice of Playwright's JSON reporter output the flake tooling reads, plus
+ * the walk over its nested suites. Shared by scripts/ci-flaky-summary.ts and
+ * scripts/e2e-flake-report.ts, which would otherwise keep two copies of a
+ * shape only Playwright gets to define.
+ *
+ * Every field is optional: a run killed mid-suite still writes a file.
+ */
+
+export interface JsonError {
+  message?: string;
+}
+export interface JsonAttachment {
+  name?: string;
+  path?: string;
+}
+export interface JsonResult {
+  status?: string;
+  duration?: number;
+  errors?: JsonError[];
+  error?: JsonError;
+  attachments?: JsonAttachment[];
+}
+export interface JsonTest {
+  status?: string;
+  timeout?: number;
+  results?: JsonResult[];
+}
+export interface JsonSpec {
+  title?: string;
+  file?: string;
+  line?: number;
+  tests?: JsonTest[];
+}
+export interface JsonSuite {
+  title?: string;
+  file?: string;
+  specs?: JsonSpec[];
+  suites?: JsonSuite[];
+}
+export interface JsonStats {
+  duration?: number;
+  unexpected?: number;
+}
+export interface JsonReport {
+  // Spec paths are relative to this, the common root of the test directories
+  // (tests/e2e), not to the repository.
+  config?: { rootDir?: string };
+  suites?: JsonSuite[];
+  errors?: JsonError[];
+  stats?: JsonStats;
+}
+
+export interface CollectedSpec {
+  spec: JsonSpec;
+  /** Titles of the describe blocks around the spec, outermost first. */
+  titlePath: string[];
+}
+
+/** Flatten the suite tree to its specs, carrying the describe titles along. */
+export function collectSpecs(
+  suites: JsonSuite[],
+  ancestors: string[] = []
+): CollectedSpec[] {
+  const out: CollectedSpec[] = [];
+  for (const suite of suites) {
+    // The file-level suite is titled with the file path itself; describe
+    // blocks below it carry real titles.
+    const title = suite.title && suite.title !== suite.file ? suite.title : "";
+    const titlePath = title ? [...ancestors, title] : ancestors;
+    for (const spec of suite.specs ?? []) out.push({ spec, titlePath });
+    out.push(...collectSpecs(suite.suites ?? [], titlePath));
+  }
+  return out;
+}
+
+/** `describe › describe › test`, the name Playwright itself prints. */
+export function specTitle({ spec, titlePath }: CollectedSpec): string {
+  return [...titlePath, spec.title ?? "(untitled)"].join(" › ");
+}
+
+export function specFile({ spec }: CollectedSpec): string {
+  return spec.file ?? "(unknown file)";
+}

--- a/tests/unit/ci-flaky-summary.test.ts
+++ b/tests/unit/ci-flaky-summary.test.ts
@@ -1,0 +1,120 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  flakyTests,
+  formatAnnotations,
+  formatSummary,
+} from "@/scripts/ci-flaky-summary";
+
+/**
+ * A Playwright JSON report with one steady test and one that flaked, shaped
+ * like the real thing: `config.rootDir` is the test directory and every spec
+ * file is relative to it, not to the repository root.
+ */
+function report() {
+  return {
+    config: { rootDir: path.join(process.cwd(), "tests", "e2e") },
+    stats: { unexpected: 0, flaky: 1 },
+    suites: [
+      {
+        title: "voting.spec.ts",
+        file: "voting.spec.ts",
+        specs: [
+          {
+            title: "steady",
+            file: "voting.spec.ts",
+            line: 10,
+            tests: [{ status: "expected", results: [{ status: "passed" }] }],
+          },
+        ],
+        suites: [
+          {
+            title: "voting",
+            file: "voting.spec.ts",
+            specs: [
+              {
+                title: "wobbly",
+                file: "voting.spec.ts",
+                line: 42,
+                tests: [
+                  {
+                    status: "flaky",
+                    results: [{ status: "failed" }, { status: "passed" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("flakyTests", () => {
+  it("finds tests that only passed on retry, nested suites included", () => {
+    expect(flakyTests(report())).toEqual([
+      {
+        file: "tests/e2e/voting.spec.ts",
+        line: 42,
+        title: "voting › wobbly",
+        attempts: 2,
+      },
+    ]);
+  });
+
+  it("keeps the reported path when the report names no rootDir", () => {
+    const truncated = { suites: report().suites };
+    expect(flakyTests(truncated)[0]?.file).toBe("voting.spec.ts");
+  });
+
+  it("keeps the reported path when rootDir is another checkout", () => {
+    const elsewhere = { ...report(), config: { rootDir: "/somewhere/else" } };
+    expect(flakyTests(elsewhere)[0]?.file).toBe("voting.spec.ts");
+  });
+
+  it("returns nothing for a clean report", () => {
+    expect(flakyTests({ suites: [] })).toEqual([]);
+  });
+
+  it("survives a truncated report", () => {
+    expect(flakyTests({})).toEqual([]);
+  });
+});
+
+describe("formatAnnotations", () => {
+  it("emits one workflow warning command per flaky test", () => {
+    expect(formatAnnotations(flakyTests(report()))).toEqual([
+      "::warning file=tests/e2e/voting.spec.ts,line=42::flaky: voting › wobbly (passed on attempt 2)",
+    ]);
+  });
+
+  it("escapes the characters GitHub reads as command syntax", () => {
+    const lines = formatAnnotations([
+      { file: "a.spec.ts", line: 1, title: "a % b\nc", attempts: 2 },
+    ]);
+    expect(lines[0]).toContain("a %25 b%0Ac");
+  });
+
+  it("escapes the separators GitHub reads inside the file property", () => {
+    const lines = formatAnnotations([
+      { file: "od,d:name.spec.ts", line: 1, title: "t", attempts: 2 },
+    ]);
+    expect(lines[0]).toBe(
+      "::warning file=od%2Cd%3Aname.spec.ts,line=1::flaky: t (passed on attempt 2)"
+    );
+  });
+});
+
+describe("formatSummary", () => {
+  it("is empty when nothing flaked, so the job summary stays clean", () => {
+    expect(formatSummary([])).toBe("");
+  });
+
+  it("tables the flaky tests", () => {
+    const summary = formatSummary(flakyTests(report()));
+    expect(summary).toContain("Flaky tests");
+    expect(summary).toContain("tests/e2e/voting.spec.ts:42");
+    expect(summary).toContain("voting › wobbly");
+  });
+});

--- a/tests/unit/playwright-json.test.ts
+++ b/tests/unit/playwright-json.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { collectSpecs, specFile, specTitle } from "@/scripts/playwright-json";
+
+/** The suite tree Playwright writes for a file with a describe block in it. */
+const suites = [
+  {
+    title: "voting.spec.ts",
+    file: "voting.spec.ts",
+    specs: [{ title: "top level", file: "voting.spec.ts", line: 10 }],
+    suites: [
+      {
+        title: "voting",
+        file: "voting.spec.ts",
+        suites: [
+          {
+            title: "as a guest",
+            file: "voting.spec.ts",
+            specs: [
+              { title: "casts a vote", file: "voting.spec.ts", line: 42 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe("collectSpecs", () => {
+  it("flattens the tree, naming each spec by the describes around it", () => {
+    expect(collectSpecs(suites).map(specTitle)).toEqual([
+      "top level",
+      "voting › as a guest › casts a vote",
+    ]);
+  });
+
+  it("survives a truncated report", () => {
+    expect(collectSpecs([])).toEqual([]);
+    expect(collectSpecs([{ title: "x.spec.ts", file: "x.spec.ts" }])).toEqual(
+      []
+    );
+  });
+});
+
+describe("specTitle / specFile", () => {
+  it("names what a report left unnamed", () => {
+    const collected = { spec: {}, titlePath: ["outer"] };
+    expect(specTitle(collected)).toBe("outer › (untitled)");
+    expect(specFile(collected)).toBe("(unknown file)");
+  });
+});


### PR DESCRIPTION
CI retries twice and uploaded nothing, so a flake became a green check with no
evidence left to debug it. Playwright's github reporter now puts each failed
attempt next to the line that failed, scripts/ci-flaky-summary.ts names the
flaky tests as warning annotations and in the job summary, and the reports plus
the traces of failed attempts are kept as an artifact.

Retries stay at 2 — the aim is to measure flakiness before failing on it.

The report format is now described in one place, scripts/playwright-json.ts:
the flake-hunt report reads the same files and its copy would have to track
Playwright's format in parallel.

<!-- jip:pushed-commit=fc1662f5ca130eea6df1d30a0dfe729f36759cc6 -->