### PR TITLE
test: retry a failing E2E test once locally, without letting it pass

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -86,7 +86,7 @@ jobs:
 
       # The reports and the traces of failed attempts (trace: on-first-retry)
       # are the only way to debug a failure once the runner is gone.
-      # See docs/dev/testing.md § Flaky tests on CI.
+      # See docs/dev/testing.md § Flaky tests.
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   from `scripts/ci-flaky-summary.ts`, plus Playwright's `github` reporter putting each failed
   attempt next to the line that failed — and uploads the Playwright reports plus the traces of
   failed attempts as an artifact. Before, retries turned a flake into a plain green check with
-  nothing kept to debug it. See
-  [docs/dev/testing.md § Flaky tests on CI](docs/dev/testing.md#flaky-tests-on-ci)
+  nothing kept to debug it. See [docs/dev/testing.md § Flaky tests](docs/dev/testing.md#flaky-tests)
+- A local E2E run retries a failing test once and still fails if it then passes (`failOnFlakyTests`).
+  The retry is what makes `trace: on-first-retry` record anything, so a flake now leaves a trace to
+  open instead of a bare error message, and a broken test is told apart from a flaky one — without
+  letting either through `make precommit`
 - Throwaway names in E2E tests carry the worker's process id and a counter, not just `Date.now()`:
   two parallel workers can land in the same millisecond, and the duplicate name would surface as an
   unreproducible locator failure somewhere else entirely

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -223,10 +223,28 @@ If the mail variables are set in `.env.test.local`, start mailpit (`make
 mailpit`) before a hunt — otherwise the email specs fail identically in every
 run and clutter the report as persistent failures.
 
-## Flaky tests on CI
+## Flaky tests
 
-CI runs the suite with `retries: 2`, so a test that fails once and passes on the
-next attempt leaves a green check. The E2E workflow makes that visible instead:
+Locally the suite retries a failing test **once**, and a test that then passes
+still fails the run (`failOnFlakyTests`). The retry is not leniency, it is
+evidence: `trace: on-first-retry` records nothing when nothing is retried, so
+without it a local flake left an error message and no way to look into it. Now
+it leaves `test-results/<test>-retry1/trace.zip`, and the terminal ends with a
+`flaky` section naming the test — which also tells you at a glance whether the
+test is flaky or plain broken, since a broken one fails both attempts. Open the
+trace with:
+
+```bash
+bun x playwright show-trace test-results/<test>-retry1/trace.zip
+```
+
+A second local retry would buy only a failure rate out of three, at the price of
+running every genuinely failing test three times while you work — measuring
+rates is what [Flake hunting](#flake-hunting) is for.
+
+CI is the other way round: it retries twice and stays green, because nobody is
+watching a run to interrupt, and a suite that goes red on a known flake gets
+ignored wholesale. So the run records instead of failing:
 
 - **Error annotations** — Playwright's own `github` reporter annotates every
   failed attempt with its error message and location, flaky tests included. So
@@ -242,8 +260,8 @@ next attempt leaves a green check. The E2E workflow makes that visible instead:
   open the trace with `bun x playwright show-trace <path>`.
 
 A flaky warning is a test that failed for a reason; treat it as a bug to be
-diagnosed from that trace, not as noise. Retries stay at 2 until the suite is
-stable — the aim is to measure flakiness, not to start failing on it.
+diagnosed from that trace, not as noise. CI's retries stay at 2 until the suite
+is stable — the aim there is to measure flakiness, not to start failing on it.
 
 ## E2E conventions
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -91,8 +91,15 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* One retry locally, purely for the evidence: `trace: on-first-retry` records
+   * nothing at all when a failure is never retried, so a local flake used to
+   * leave an error message and no way to look into it. The retry also says
+   * whether the test is flaky or broken. It buys no leniency —
+   * `failOnFlakyTests` keeps the run red — so precommit still stops here.
+   * CI retries twice and stays green (see the flaky reporting below); dropping
+   * that before the suite is stable would only make CI red noise. */
+  retries: process.env.CI ? 2 : 1,
+  failOnFlakyTests: !process.env.CI,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters

--- a/scripts/ci-flaky-summary.ts
+++ b/scripts/ci-flaky-summary.ts
@@ -86,7 +86,7 @@ function formatSummary(flaky: FlakyTest[]): string {
     `### Flaky tests (${flaky.length})`,
     "",
     "Passed only on retry. Open the `playwright-report` artifact — the trace of" +
-      " the failed attempt is in it (see docs/dev/testing.md § Flaky tests on CI).",
+      " the failed attempt is in it (see docs/dev/testing.md § Flaky tests).",
     "",
     "| Test | Where | Attempts |",
     "| --- | --- | --- |",

--- a/scripts/e2e-flake-hunt.sh
+++ b/scripts/e2e-flake-hunt.sh
@@ -112,7 +112,7 @@ fi
 PW_ARGS=(--reporter=json --trace=retain-on-failure)
 # Raw failure rates are the point, so no retries — and with one server shared
 # by every run, a retry would re-enter a database the suite has already
-# mutated. (CI=1 in the environment would otherwise switch retries on.)
+# mutated. The config retries in every environment, so this has to say so.
 PW_ARGS+=(--retries=0)
 if [ -n "${E2E_WORKERS:-}" ]; then
   PW_ARGS+=("--workers=$E2E_WORKERS")


### PR DESCRIPTION
`trace: on-first-retry` records nothing when nothing is ever retried, so a local
flake left an error message and no way to look into it. One retry produces the
trace, and tells a flake apart from a breakage — while `failOnFlakyTests` keeps
the run red, so precommit still stops for it.

A second retry would add only a rate out of three, at the cost of running every
genuinely failing test three times while working; measuring rates is what
scripts/e2e-flake-hunt.sh is for. CI keeps its two retries and stays green.

<!-- jip:pushed-commit=b6ebc6db4b119d749c2907551d4b71c47ae6f3f0 -->