### PR TITLE
fix: keep eslint out of the Playwright output directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   The retry is what makes `trace: on-first-retry` record anything, so a flake now leaves a trace to
   open instead of a bare error message, and a broken test is told apart from a flaky one — without
   letting either through `make precommit`
+- eslint ignores the Playwright output directories. It parsed the trace-viewer bundle inside
+  `playwright-report/`, which ran it out of heap — so `make lint`, and with it `make precommit`,
+  crashed after any local E2E run until the report was deleted. Prettier was unaffected: it skips
+  gitignored files by default, eslint does not
 - Throwaway names in E2E tests carry the worker's process id and a counter, not just `Date.now()`:
   two parallel workers can land in the same millisecond, and the duplicate name would surface as an
   unreproducible locator failure somewhere else entirely

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,10 @@ function dropTsPlugin(configs) {
 export default tseslint.config(
   {
     // `site/` is the generated docs site (see docs/dev/documentation.md);
-    // its JS comes from docmd, not from us.
+    // its JS comes from docmd, not from us. The Playwright output below is
+    // likewise not ours — and the trace viewer bundle inside the html report
+    // is big enough to run eslint out of heap, so an E2E run would otherwise
+    // leave `make lint` crashing until the report is deleted.
     ignores: [
       "tailwind.config.ts",
       ".next/**",
@@ -26,6 +29,11 @@ export default tseslint.config(
       "site/**",
       "coverage/**",
       "docs/dev/attendance-model/.venv/**",
+      "playwright-report/**",
+      "blob-report/**",
+      "test-results/**",
+      ".flake-hunt/**",
+      ".e2e-docker/**",
     ],
   },
   ...dropTsPlugin(coreWebVitals),


### PR DESCRIPTION
Linting the trace-viewer bundle in playwright-report/ ran eslint out of heap, so
`make lint` — and `make precommit` with it — crashed after any local E2E run
until the report was deleted by hand. Prettier never had the problem: it skips
gitignored files by default, eslint does not.

<!-- jip:pushed-commit=6db9cedcd0df1931c5b0a7aff7d864aefe97ac04 -->