### PR TITLE
ci: release by pushing a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,165 @@
+name: Release
+
+# Everything a release does once its tag exists: build the image, prove it
+# works, publish it to Docker Hub and open the GitHub release. Pushing the tag
+# is the only manual step, and the point of no return — see
+# docs/dev/releasing.md.
+#
+# The docs site rebuilds from the same tag push, in docs.yml. The two are
+# independent: documentation for a version that has no image yet is harmless,
+# and neither should wait on the other.
+on:
+  push:
+    tags:
+      # `v*.*.*` keeps other tags out; the exact version is validated below,
+      # since a glob cannot tell v3.4.2 from v3.4.2-rc1.
+      - "v*.*.*"
+  # Republishing a tag (a Docker Hub outage, a flake in the E2E gate): run this
+  # workflow against the tag, not a branch.
+  workflow_dispatch:
+
+# A release must never race another one for `:latest`.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # create the GitHub release
+
+    # Email tests are opt-in via these vars (unset means skip — see
+    # docs/dev/testing.md § Running tests), but CI must always run them: they
+    # fail loudly here if the vars are missing, rather than silently skip.
+    env:
+      MAILPIT_API_URL: http://localhost:8025
+      SMTP_URL: smtp://localhost:1025
+      SMTP_FROM: Test <mailer-test@test.example>
+      # The version the footer shows and the image is tagged with. Taken from
+      # the tag rather than left to scripts/app-version.js, which asks jj or
+      # `git describe` — neither of which is reliable on a CI checkout.
+      APP_VERSION: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v7.0.1
+        with:
+          # Every tag, because whether this release takes over `:latest`
+          # depends on the ones already published (scripts/release-tags.ts).
+          fetch-depth: 0
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: bunx playwright install --with-deps firefox
+
+      # The E2E suite sends real email to mailpit (see docs/dev/testing.md
+      # § Running tests). Started from the compose file rather than as a service
+      # container so the image pin has one home that Dependabot can update.
+      - name: Start mailpit
+        run: docker compose -f docker-compose.dev.yml up -d --wait mailpit
+
+      - name: Build the image
+        id: build
+        # Captured in its own assignment: inside `echo "image=$(...)"` a failed
+        # build is an empty string the step still exits 0 on, and the release
+        # would fall over a step later with the wrong error.
+        run: |
+          image="$(bash scripts/docker-build.sh)"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      # Before the E2E gate, so a ref that is not a release version (v3.4.2-rc1,
+      # a dispatch against a branch) fails ahead of the ten minutes, not after.
+      - name: Work out which tags to publish
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          refs="$(bun scripts/release-tags.ts "$IMAGE")"
+          printf 'Will publish:\n%s\n' "$refs"
+          {
+            echo 'RELEASE_REFS<<REFS_EOF'
+            echo "$refs"
+            echo REFS_EOF
+          } >> "$GITHUB_ENV"
+
+      # The release gate: the only tier that runs the artifact we ship, against
+      # the very image about to be pushed. See docs/dev/testing.md § Testing the
+      # Docker image.
+      - name: E2E Tests against the image
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: make test-e2e-docker
+
+      # CI retries twice, so a test that only passed on its second attempt would
+      # let the release through with nothing in the log — and a flake here can
+      # be a real fault in the image we are about to publish.
+      - name: Report tests that passed on retry
+        if: always()
+        run: bun scripts/ci-flaky-summary.ts
+
+      # The reports and the traces of failed attempts are the only way to debug
+      # a failure once the runner is gone — and here that failure is holding up
+      # a release. Kept for a green run too: that is where the retried attempts
+      # the step above names are looked at.
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+            playwright-results.json
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Log in to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          printf '%s' "$DOCKERHUB_TOKEN" |
+            docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+
+      - name: Publish the image
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          for ref in $RELEASE_REFS; do
+            docker tag "$IMAGE" "$ref"
+            docker push "$ref"
+          done
+
+      # Last, so a release exists only once its images do. `--latest` follows
+      # the same decision `:latest` did: a patch to an older line is published
+      # without becoming the release GitHub points newcomers at.
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          # Every other step here can simply be repeated; this one cannot, and
+          # re-running the workflow after a publishing failure has to work.
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists — leaving it alone."
+            exit 0
+          fi
+          if printf '%s\n' $RELEASE_REFS | grep -q ':latest$'; then
+            latest=--latest
+          else
+            latest=--latest=false
+          fi
+          cat > "$RUNNER_TEMP/release-notes.md" <<EOF
+          See [changelog]($REPO_URL/blob/$VERSION/CHANGELOG.md).
+
+          Container images on [Docker hub](https://hub.docker.com/r/schellingboard/schellingboard).
+          EOF
+          gh release create "$VERSION" --title "$VERSION" "$latest" \
+            --notes-file "$RUNNER_TEMP/release-notes.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ jj squash --from <commit> --to @ -m "message" -- <path>
 ### Test tiers (short form)
 
 - **E2E** (Playwright): important user workflows only — quality over quantity
-- **E2E against the Docker image** (`make test-e2e-docker`): the same suite against a container. Not part of `make precommit` — run it before a release and after touching the `Dockerfile`, the standalone build, or anything path-, upload- or migration-related. The container runs in UTC, so it catches dates formatted in the ambient time zone; format in the event's zone
+- **E2E against the Docker image** (`make test-e2e-docker`): the same suite against a container. Not part of `make precommit`; the release workflow runs it against the image it is about to publish, so run it by hand after touching the `Dockerfile`, the standalone build, or anything path-, upload- or migration-related — well before a release. The container runs in UTC, so it catches dates formatted in the ambient time zone; format in the event's zone
 - **Integration** (Vitest, real DB): high coverage of business logic via repositories/server actions
 - **Release upgrade** (Vitest, part of `make test`): migrates a released version's seeded database forward and exercises CRUD on it. Add a fixture only when releasing (`make dump-release-db VERSION=vX.Y.Z`), never by hand
 - **Unit** (Vitest): only for complex isolated functions; never duplicate integration-test coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Releases are made by CI instead of by hand on a laptop: pushing a `vX.Y.Z` tag builds the image,
+  runs the E2E suite against it, and only then publishes it to Docker Hub and opens the GitHub
+  release. Whether the release takes over `:latest` is worked out from the repository's tags instead
+  of being remembered, so a patch to an older line can no longer displace a newer one. See
+  [docs/dev/releasing.md](docs/dev/releasing.md)
 - Release-upgrade tests: `make test` now restores an older release's seeded database, migrates it
   forward and exercises CRUD on it, so a migration that only breaks against real data, or a read
   path that assumes a shape only new rows have, fails before it ships. Releasing records the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,9 +295,9 @@ where screenshots live.
 
 ## Releasing a New Version
 
-Finalize the changelog, tag `main`, verify the tagged image with
-`make test-e2e-docker`, push the tag (which publishes the documentation), then
-publish the Docker images. Full checklist:
+Finalize the changelog, tag `main`, push the tag. The rest is CI: it builds the
+image, runs the E2E suite against it, publishes it to Docker Hub and opens the
+GitHub release, while the docs site rebuilds from the same tag. Full checklist:
 [Releasing a new version](docs/dev/releasing.md).
 
 ## Version Control

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,8 @@ services:
     # compares versions against (a digest on its own tells it nothing).
     image: axllent/mailpit:v1.31.0@sha256:c96991d9bef73594c246d89ca81411d4e916f03e76a7d2d72fa2ab5dd3c9ce24
     # CI sets neither variable and hardcodes these defaults in the MAILPIT_API_URL
-    # and SMTP_URL of both workflows — change a default here and change them too.
+    # and SMTP_URL of the ci, ci-e2e and release workflows — change a default
+    # here and change them too.
     ports:
       - "${MAILPIT_SMTP_PORT:-1025}:1025" # SMTP
       - "${MAILPIT_UI_PORT:-8025}:8025" # web UI

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -1,6 +1,14 @@
 # Releasing a New Version
 
-1. **Finalize the changelog** — in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (no `v` prefix in the header), and replace the `[Unreleased]` compare link at the bottom of the file with the new version's, pointing from the previous release's endpoint to the new tag (`vX.Y.Z`). Do _not_ add a fresh `## [Unreleased]` section here — the released tag should carry no empty section, since that is what the documentation site publishes. Step 6 reopens it afterwards.
+Pushing the tag is the whole release: it triggers
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml), which
+builds the image, runs the E2E suite against it, publishes it to Docker Hub and
+opens the GitHub release — and [`docs.yml`](../../.github/workflows/docs.yml),
+which rebuilds the docs site and serves `docs/public/` as of that tag at its
+root. Docs are versioned per minor release, so `v3.2.1` republishes the `3.2`
+documentation.
+
+1. **Finalize the changelog** — in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (no `v` prefix in the header), and replace the `[Unreleased]` compare link at the bottom of the file with the new version's, pointing from the previous release's endpoint to the new tag (`vX.Y.Z`). Do _not_ add a fresh `## [Unreleased]` section here — the released tag should carry no empty section, since that is what the documentation site publishes. Step 4 reopens it afterwards.
 
    **Record the release's database in the same commit**, so future releases are tested against an upgrade from it:
 
@@ -12,81 +20,99 @@
 
    Commit and merge this like any other change.
 
-2. **Tag the resulting commit on `main`, locally for now**:
+2. **Tag the resulting commit on `main` and push the tag** — the point of no
+   return, since it publishes the documentation:
 
    ```bash
-   VERSION=v3.0.0
-   MINOR=${VERSION%.*}   # v3.0
-   MAJOR=${MINOR%.*}     # v3
-
    jj git fetch
-   jj tag set $VERSION -r main@origin
+   jj tag set v3.0.0 -r main@origin
+   jj git push --tag v3.0.0
    # git: git fetch origin main
-   #      git tag $VERSION origin/main
+   #      git tag v3.0.0 origin/main
+   #      git push origin v3.0.0
    ```
 
-3. **Sanity-check the image that will be published** — build it from the tag and
-   run the E2E suite against a container. This is the last chance to catch a
-   fault that exists only in the packaged image (a file the standalone build
-   didn't copy, a path that resolves differently under `/data`, a date rendered
-   in the server's timezone rather than the event's) — no other test tier runs
-   the artifact we actually ship. See
-   [Testing the Docker image](testing.md#testing-the-docker-image).
+   Optionally run `make test-e2e-docker` on the release commit first. The
+   release workflow runs it too, and refuses to publish anything if it fails —
+   running it locally only buys you the chance to fix a failure before the tag
+   is public.
 
-   ```bash
-   jj new $VERSION
-   # git: git checkout $VERSION
-   make test-e2e-docker
-   ```
+3. **Watch the release workflow.** It takes around fifteen minutes, most of it
+   the E2E suite against the image.
 
-   The tag is still local at this point, so a failure costs nothing: fix it on
-   `main`, delete the tag (`jj tag delete $VERSION`, or `git tag -d $VERSION`),
-   and start again from step 1.
+4. **Reopen the changelog** — in a follow-up commit on `main`, add an empty
+   `## [Unreleased]` section above `## [X.Y.Z]` and an `[Unreleased]` compare
+   link from `vX.Y.Z` to `HEAD`.
 
-4. **Push the tag**, which is the point of no return — it publishes the
-   documentation:
+## What the release workflow does
 
-   ```bash
-   jj git push --tag $VERSION
-   # git: git push origin $VERSION
-   ```
+Triggered by a `v*.*.*` tag, in one job, so nothing is published until
+everything before it has passed:
 
-5. **Publish the Docker images** — see below.
+- **Builds the image** through `scripts/docker-build.sh` — the same script
+  `make docker-build` runs — with `APP_VERSION` taken from the tag rather than
+  from `scripts/app-version.js`, which asks `jj` or `git describe` and can't be
+  trusted on a CI checkout.
+- **Runs the E2E suite against that image** (`make test-e2e-docker`, with
+  `IMAGE` naming the image just built, so it is not rebuilt). This is the only
+  tier that runs the artifact we ship, and the last chance to catch a fault that
+  exists only in it — a file the standalone build didn't copy, a path that
+  resolves differently under `/data`, a date rendered in the server's timezone
+  rather than the event's. See
+  [Testing the Docker image](testing.md#testing-the-docker-image). The report
+  and the traces of failed attempts are uploaded as an artifact.
+- **Pushes four tags** to `schellingboard/schellingboard`: the full version,
+  `major.minor`, `major`, and `latest`. `scripts/release-tags.ts` decides the
+  last one from the repository's tags — `:latest` has to keep meaning the newest
+  published release, so a patch cut from an older line (`v3.3.2` released after
+  `v3.4.0`) publishes its own three tags and leaves `:latest` alone.
+- **Creates the GitHub release**, last, so a release exists only once its images
+  do. It is marked as GitHub's "latest" on the same condition as the `:latest`
+  tag.
 
-6. **Reopen the changelog** — in a follow-up commit on `main`, add an empty `## [Unreleased]` section above `## [X.Y.Z]` and an `[Unreleased]` compare link from `vX.Y.Z` to `HEAD`. It comes last because the Docker build derives its version from the nearest tag: a commit on top of the release tag would make `make docker-build` tag the image with a hash instead of `$VERSION`.
+Images are `linux/amd64` only, which is what has always been published.
 
-Pushing the tag publishes the documentation: the docs site rebuilds and
-serves `docs/public/` as of that tag at its root. Docs are versioned per minor
-release, so `v3.2.1` republishes the `3.2` documentation.
+### Repository configuration
 
-## Publishing Docker Images
+The workflow needs two repository secrets:
 
-Image: `schellingboard/schellingboard` on Docker Hub.
+| Secret               | Value                                                                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DOCKERHUB_USERNAME` | The Docker Hub account that can push to `schellingboard/schellingboard`.                                                                                     |
+| `DOCKERHUB_TOKEN`    | A Docker Hub [access token](https://app.docker.com/settings/personal-access-tokens) for that account with **Read & Write** scope — not the account password. |
 
-For a release, push four tags: the full version, `major.minor`, `major`, and `latest`. Skip `latest` when publishing a patch for an older major/minor (i.e. when it wouldn't be the newest release).
+Nothing else: the GitHub release is created with the automatic `GITHUB_TOKEN`,
+which the workflow grants `contents: write`.
+
+### If it fails
+
+Nothing has been published unless the run reached the "Publish the image" step,
+so a failing build or E2E gate leaves Docker Hub and the releases page
+untouched. The tag and the documentation are out, though, and re-cutting a tag
+that people may already have fetched is worse than moving on: fix the problem on
+`main` and release the next patch version.
+
+A failure _after_ the gate — a Docker Hub outage, a flake — is different: the
+tag is fine and only the publishing didn't happen. Re-run the workflow (or
+dispatch it against the tag). Every step in it can be repeated safely.
+
+### Publishing by hand
+
+Only if the workflow itself is unavailable. `scripts/release-tags.ts` prints
+exactly what would be pushed:
 
 ```bash
+VERSION=v3.0.0
+
 docker login
 jj new $VERSION      # git: git checkout $VERSION
 make clean
-make docker-build   # builds and locally tags :$VERSION
-docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:$MINOR
-docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:$MAJOR
-# omit if not the newest release
-docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:latest
-
-docker push schellingboard/schellingboard:$VERSION
-docker push schellingboard/schellingboard:$MINOR
-docker push schellingboard/schellingboard:$MAJOR
-# omit if not the newest release
-docker push schellingboard/schellingboard:latest
+IMAGE="$(APP_VERSION=$VERSION bash scripts/docker-build.sh)"
+for ref in $(bun scripts/release-tags.ts "$IMAGE"); do
+  docker tag "$IMAGE" "$ref"
+  docker push "$ref"
+done
 ```
-
-All four tags are set here rather than by `make docker-build`, which only ever
-tags `:$VERSION`: that target runs on any working tree, and `:latest` has to
-keep meaning the newest published release.
-
-`make docker-build` derives `$VERSION` with `scripts/app-version.js` (the nearest tag, via `jj` or `git`), so the release commit must already be tagged with the exact version (e.g. `v3.0.0`) before running it.
 
 ## Patch Releases
 
@@ -102,8 +128,8 @@ jj bookmark create release/3.2   # git: git switch -c release/3.2 v3.2.0
 
 Commit the fix there (cherry-picking it from `main` if it landed there first),
 then run the steps above against the branch instead of `main`, and merge the
-branch back into `main` so the fix is not lost. Omit the `:latest` Docker tag
-when the patch is not the newest release.
+branch back into `main` so the fix is not lost. Whether the patch takes over
+`:latest` is not a decision to make: the workflow works it out from the tags.
 
 Pushing the branch republishes that version's documentation on its own, without
 a tag — the docs build prefers `release/<major.minor>` over the tag for that

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -183,19 +183,22 @@ bun set-env.ts test bash scripts/e2e-docker.sh tests/e2e/proposals.spec.ts
 ```
 
 It is not part of `make precommit` — it builds an image and takes a few
-minutes. Run it before a release (see [Releasing a New Version](releasing.md))
-and after changing the `Dockerfile`, the standalone build, or anything touching
-paths, uploads or migrations.
+minutes. The release workflow runs it against the image it is about to publish
+and refuses to publish if it fails (see [Releasing a New
+Version](releasing.md)), so the reason to run it by hand is a change to the
+`Dockerfile`, the standalone build, or anything touching paths, uploads or
+migrations — well before a release rather than at one.
 
 What it does, and why each piece is there:
 
 - **Picks a free port** and starts the container on it, then waits for
   `/api/health`.
 - **Builds through `scripts/docker-build.sh`**, the script `make docker-build`
-  runs too — same build arguments, same `:<version>` tag, so the release build
-  is a cache hit of this one and what gets published is what was tested here.
-  The version is the one `scripts/app-version.js` prints, which is also what
-  the footer shows.
+  and the release workflow run too — same build arguments, same `:<version>`
+  tag, so what gets published is what was tested. (In the release workflow the
+  build comes first and is handed here by name in `IMAGE`, so the very image
+  that is pushed is the one the suite ran against.) The version is the one
+  `scripts/app-version.js` prints, which is also what the footer shows.
 - **Bind-mounts `.e2e-docker/`** (gitignored) as `/data`. Seeding runs on the
   host, as usual, and writes to the same SQLite file and uploads directory the
   container reads — so no seeding code has to exist inside the image. The

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Build the image we publish, and print its name.
 #
-# Two callers, one build: `make docker-build` (the release build) and
-# scripts/e2e-docker.sh (the E2E run against the image). Building the same
-# thing is the point — the release build is meant to be a cache hit of the one
-# the suite already ran against, so what gets published is what was tested —
-# and that only holds as long as neither side grows a build flag the other
-# lacks. Keeping the command in one place is what keeps that true.
+# Three callers, one build: the release workflow (which then hands the image to
+# the E2E run and pushes that same image), `make docker-build`, and
+# scripts/e2e-docker.sh when nobody named an image for it. Building the same
+# thing is the point — what gets published has to be what was tested — and that
+# only holds as long as no caller grows a build flag the others lack. Keeping
+# the command in one place is what keeps that true.
 #
 # Only the image reference goes to stdout, so a caller can capture it:
 #
@@ -25,8 +25,8 @@ cd "$(dirname "$0")/.."
 APP_VERSION="${APP_VERSION:-$(bun scripts/app-version.js)}"
 # It is the tag too, so a leftover image says which tree it came from and
 # successive builds don't overwrite each other. Never :latest — that means the
-# newest published release, which the release checklist tags deliberately (see
-# docs/dev/releasing.md).
+# newest published release, and only scripts/release-tags.ts decides who gets
+# it (see docs/dev/releasing.md).
 IMAGE="schellingboard/schellingboard:$APP_VERSION"
 
 docker build --build-arg "APP_VERSION=$APP_VERSION" -t "$IMAGE" . >&2

--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -6,8 +6,9 @@
 # migrations, uploads and the SQLite file on a mounted /data volume. Bugs that
 # only exist there (a file the standalone tracer failed to copy, a path that
 # resolves differently under a different working directory) are invisible to
-# every other test tier, which is why this is a release checklist item — see
-# docs/dev/testing.md § Testing the Docker image.
+# every other test tier, which is why the release workflow runs this against the
+# image it is about to publish — see docs/dev/testing.md § Testing the Docker
+# image.
 #
 # Run through set-env.ts (`make test-e2e-docker`) so the test credentials and
 # the optional mail variables are already in the environment; they are handed
@@ -30,9 +31,10 @@ CONTAINER="schellingboard-e2e-$$"
 # Build from the working tree unless the caller named an image (e.g. to run the
 # suite against a release image that was already built or pulled).
 #
-# Through the same script `make docker-build` runs, so the release build is a
-# cache hit of this one and what gets published is what was tested here. That
-# guarantee is the reason the build command isn't inlined here.
+# Through the same script `make docker-build` and the release workflow run, so
+# what gets published is what was tested here — the workflow goes further and
+# hands us the very image it will push. That guarantee is the reason the build
+# command isn't inlined here.
 if [ -n "${IMAGE:-}" ]; then
   echo "==> Using existing image $IMAGE"
 else

--- a/scripts/release-tags.ts
+++ b/scripts/release-tags.ts
@@ -1,0 +1,78 @@
+// The Docker tags a release publishes, and in particular whether it takes over
+// `:latest`.
+//
+// `:latest` has to keep meaning the newest published release, so a patch cut
+// from an older line (v3.3.2 released after v3.4.0) publishes its own three
+// tags and leaves `:latest` pointing at v3.4.0. That used to be a judgement
+// call in the release checklist; deciding it from the repository's tags is why
+// the release workflow checks out the full tag history.
+//
+// Run as a command with the image the build produced, to get every reference to
+// push — the repository comes from that image, so the name lives only in
+// scripts/docker-build.sh:
+//
+//     bun scripts/release-tags.ts schellingboard/schellingboard:v3.4.2
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { compareVersions } from "./release-dumps";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const RELEASE_VERSION = /^v\d+\.\d+\.\d+$/;
+
+export function releaseTags(
+  version: string,
+  released: readonly string[]
+): string[] {
+  if (!RELEASE_VERSION.test(version)) {
+    throw new Error(`Not a release version: "${version}" (expected vX.Y.Z)`);
+  }
+  const [major, minor] = version.split(".");
+  const tags = [version, `${major}.${minor}`, major];
+
+  // Anything unparseable — a release candidate, a stray marker — is nobody's
+  // published release and must not keep this one off `:latest`.
+  const isNewest = released
+    .filter((tag) => RELEASE_VERSION.test(tag))
+    .every((tag) => compareVersions(tag, version) <= 0);
+  if (isNewest) tags.push("latest");
+
+  return tags;
+}
+
+export function releaseRefs(
+  image: string,
+  released: readonly string[]
+): string[] {
+  // A registry host may carry a port, so the tag is after the last colon —
+  // and only if that colon is in the last path segment.
+  const colon = image.lastIndexOf(":");
+  if (colon === -1 || image.slice(colon).includes("/")) {
+    throw new Error(`Image reference has no tag: "${image}"`);
+  }
+  const repository = image.slice(0, colon);
+  return releaseTags(image.slice(colon + 1), released).map(
+    (tag) => `${repository}:${tag}`
+  );
+}
+
+function releasedVersions(): string[] {
+  return execFileSync("git", ["tag", "--list"], {
+    encoding: "utf8",
+    cwd: repoRoot,
+  })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const image = process.argv[2];
+  if (!image) {
+    console.error("Usage: bun scripts/release-tags.ts <image>");
+    process.exit(1);
+  }
+  for (const ref of releaseRefs(image, releasedVersions())) console.log(ref);
+}

--- a/tests/unit/release-tags.test.ts
+++ b/tests/unit/release-tags.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { releaseTags, releaseRefs } from "@/scripts/release-tags";
+
+describe("releaseTags", () => {
+  it("publishes the version, its minor and its major line", () => {
+    expect(releaseTags("v3.4.2", ["v3.4.2"])).toEqual([
+      "v3.4.2",
+      "v3.4",
+      "v3",
+      "latest",
+    ]);
+  });
+
+  it("takes over :latest when nothing newer is released", () => {
+    expect(releaseTags("v3.4.2", ["v3.3.1", "v3.4.0", "v3.4.2"])).toContain(
+      "latest"
+    );
+  });
+
+  it("leaves :latest alone for a patch to an older minor", () => {
+    expect(releaseTags("v3.3.2", ["v3.3.1", "v3.4.2", "v3.3.2"])).toEqual([
+      "v3.3.2",
+      "v3.3",
+      "v3",
+    ]);
+  });
+
+  it("leaves :latest alone for a patch to an older major", () => {
+    expect(releaseTags("v2.9.1", ["v2.9.0", "v3.0.0"])).not.toContain("latest");
+  });
+
+  it("compares versions numerically, not as strings", () => {
+    expect(releaseTags("v3.10.0", ["v3.9.0", "v3.10.0"])).toContain("latest");
+  });
+
+  it("works when the tag being released is not in the list yet", () => {
+    expect(releaseTags("v4.0.0", ["v3.4.2"])).toContain("latest");
+  });
+
+  it("ignores tags that are not releases", () => {
+    expect(releaseTags("v3.4.2", ["v3.5.0-rc1", "wip", "v3.4.2"])).toContain(
+      "latest"
+    );
+  });
+
+  it("rejects a tag that is not a release version", () => {
+    expect(() => releaseTags("v3.4", [])).toThrow(/v3\.4/);
+    expect(() => releaseTags("v3.5.0-rc1", [])).toThrow(/rc1/);
+  });
+});
+
+describe("releaseRefs", () => {
+  it("keeps the repository of the image that was built", () => {
+    expect(
+      releaseRefs("schellingboard/schellingboard:v3.4.2", ["v3.4.2"])
+    ).toEqual([
+      "schellingboard/schellingboard:v3.4.2",
+      "schellingboard/schellingboard:v3.4",
+      "schellingboard/schellingboard:v3",
+      "schellingboard/schellingboard:latest",
+    ]);
+  });
+
+  it("keeps a registry host's own port out of the version", () => {
+    expect(releaseRefs("registry.example:5000/sb:v1.0.0", ["v1.0.0"])).toEqual([
+      "registry.example:5000/sb:v1.0.0",
+      "registry.example:5000/sb:v1.0",
+      "registry.example:5000/sb:v1",
+      "registry.example:5000/sb:latest",
+    ]);
+  });
+
+  it("rejects an image reference with no tag", () => {
+    expect(() => releaseRefs("schellingboard/schellingboard", [])).toThrow(
+      /tag/
+    );
+  });
+});


### PR DESCRIPTION
Building the image and pushing four tags to Docker Hub was done by hand on a
laptop, which is both a chore and a place to slip: :latest could be handed to a
patch from an older line. Now a vX.Y.Z tag builds the image, runs the E2E suite
against it, and only then publishes and opens the GitHub release.
scripts/release-tags.ts works out from the repository's tags whether the
release takes over :latest, so that is no longer remembered.

fixes schellingboard/schellingboard#694

<!-- jip:pushed-commit=7ad4c517d680a79f1ff86cb6c3ac26f6520124d5 -->