### PR TITLE
feat: show recent release notes when the footer's version is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+> **Developers**: Remember to update [`app/release-notes.ts`](app/release-notes.ts)
+> — a sentence or two for the changes an organizer or attendee cares about.
+
 ## [Unreleased]
 
 ### Added
 
+- **What's new, in the app**: clicking the version at the bottom of any page opens a short summary of what
+  the last three releases changed, each with its release date, so it is easy to see whether the site is
+  running something recent. A site running a build made since the last release lists those changes too,
+  as "Unreleased". A link goes on to the full changelog on GitHub
 - **Comments on attendee profiles**: a profile now ends with the same comment section sessions and proposals already
   have — threaded replies, likes, editing and deleting your own comments. Open anyone in the directory to say hi or
   arrange to meet up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,8 @@ Update `CHANGELOG.md` under `[Unreleased]` alongside any user-facing change.
 - Breaking changes: `> **Breaking change**: ...` blockquote at the top of the release
 - Skip internal refactors/tests unless they materially affect the dev workflow — then use `Internal`
 
+The app carries a much shorter version of this: `app/release-notes.ts`, shown when the footer's version is clicked. Highlights are inline markdown, so they take the same **bold** lead phrase as the bullets here. Add yours as the change lands, to the first entry — the undated `"Unreleased"` one, shown like any other, since a deployment built from `main` is running exactly those changes. Finalizing the release only gives that entry its version and date — see [Releasing a new version](docs/dev/releasing.md).
+
 ## Documentation
 
 Two audiences, two places:

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -10,6 +10,10 @@ export function Modal(props: {
   hideClose?: boolean;
   zIndex?: string;
   portal?: boolean; // Explicitly control portaling behavior
+  // Passed rather than merged into the panel's classes: two max-width
+  // utilities on one element are resolved by the stylesheet's order, not the
+  // attribute's, so the wider one wouldn't reliably win.
+  maxWidth?: string;
 }) {
   const {
     open,
@@ -18,6 +22,7 @@ export function Modal(props: {
     hideClose,
     zIndex = "z-10",
     portal = false,
+    maxWidth = "sm:max-w-lg",
   } = props;
   const fakeRef = useRef(null);
 
@@ -53,7 +58,9 @@ export function Modal(props: {
                 leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
               >
-                <Dialog.Panel className="relative mb-10 transform overflow-visible rounded-lg bg-surface-raised px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <Dialog.Panel
+                  className={`relative mb-10 transform overflow-visible rounded-lg bg-surface-raised px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full ${maxWidth} sm:p-6`}
+                >
                   {children}
                   {!hideClose && (
                     <div className="mt-4">

--- a/app/footer.tsx
+++ b/app/footer.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { getAppVersion } from "@/utils/git";
 import { ThemeSelect } from "./theme-select";
+import { WhatsNew } from "./whats-new";
 
 // Flexbox centres each item's *box*, but Montserrat's font box is top-heavy
 // (12px ascent to 3px descent at our 12px size), so the glyphs land 1.5px
@@ -14,16 +14,11 @@ const OPTICAL_CENTRE = "-translate-y-[1.5px]";
 // RSVP views. The bar spans the full — possibly horizontally overflowing —
 // grid width, while the text stays pinned to the visible area.
 export default function Footer({ inline }: { inline?: boolean }) {
-  const appVersion = getAppVersion();
-
   const content = (
     // Wrapping matters on narrow phones: the version can be a long dev string
     // (`a1b2c3d4-dirty`), and three links plus it no longer fit on one line.
     <div className="px-3 flex flex-wrap gap-x-2 gap-y-1 justify-between items-center text-xs text-fg-subtle">
-      <span className={`flex gap-1 ${OPTICAL_CENTRE}`}>
-        <span className="hidden sm:block">Version: </span>
-        {appVersion}
-      </span>
+      <WhatsNew className={OPTICAL_CENTRE} />
       {/* The only control that is on every page, which is why the theme lives
           here: the settings page needs a name to have been picked first. */}
       <ThemeSelect />

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -1,0 +1,74 @@
+// What the footer's version button shows: a few plain sentences per recent
+// release, for an organizer who wants to know what changed without leaving the
+// app. Written by hand rather than derived from CHANGELOG.md, which is
+// exhaustive and far too long to read in a modal.
+//
+// Newest first, and one entry per release: the dates are what tells a reader
+// how old the deployment in front of them is, so a release left out makes the
+// newest one look older than it is. tests/unit/release-notes.test.ts fails
+// until the newest release named in CHANGELOG.md has an entry here.
+//
+// The first entry may be the release being prepared — "Unreleased", with no
+// date, written as the changes land. A deployment built from `main` is running
+// exactly those changes, so it is shown like any other entry; cutting the
+// release turns it into one by giving it its version and date.
+
+export type ReleaseNote = {
+  /**
+   * Without the `v`, as CHANGELOG.md's heading writes it — or "Unreleased"
+   * while the release it belongs to is still being prepared.
+   */
+  version: string;
+  /**
+   * The release date, `YYYY-MM-DD`, as CHANGELOG.md's heading writes it. Unset
+   * on the unreleased entry, and the one thing that marks it as unreleased.
+   */
+  date?: string;
+  /**
+   * Inline markdown, rendered as such — as in CHANGELOG.md, a **bold** phrase
+   * naming what changed, so a reader finds the entry that concerns them
+   * without reading every line. Block markdown (lists, headings) is dropped:
+   * one highlight is one bullet.
+   */
+  highlights: string[];
+};
+
+/** How many of the entries below the modal shows. */
+export const SHOWN_RELEASES = 3;
+
+export const releaseNotes: ReleaseNote[] = [
+  {
+    version: "Unreleased",
+    highlights: [
+      "**Comments on sessions and on attendee profiles**, with threaded replies, likes and editing — the section proposals already had.",
+      "**A session booked into the hours after midnight** lands on the right date, instead of disappearing from the schedule.",
+      "**What a room offers is easier to find**, just click/tap on the room name.",
+      "**Clicking the version** at the bottom of any page says what the last few releases changed.",
+    ],
+  },
+  {
+    version: "3.4.2",
+    date: "2026-08-24",
+    highlights: [
+      "**Sessions can only be booked in the event's own rooms**, so one can no longer end up in another event's room and vanish from the schedule.",
+      "**The session form says why a save was refused**, instead of only that it failed.",
+    ],
+  },
+  {
+    version: "3.4.1",
+    date: "2026-08-21",
+    highlights: [
+      "**Long attendee profiles scroll again**, instead of being cut off at the bottom.",
+    ],
+  },
+  {
+    version: "3.4.0",
+    date: "2026-08-21",
+    highlights: [
+      "**Dark mode**, chosen with the System / Light / Dark switch at the bottom of every page.",
+      "**Attendee profiles open over the directory**, with Prev and Next — or arrow keys and swiping — to read through them.",
+      "**The directory can be sorted** by who updated their profile last, and narrowed to attendees who have filled something in.",
+      "**Hosts see how the vote went** on their own proposal, ending with a rough range for how many people to expect.",
+    ],
+  },
+];

--- a/app/whats-new.tsx
+++ b/app/whats-new.tsx
@@ -1,0 +1,112 @@
+"use client";
+import { useState } from "react";
+import { Dialog } from "@headlessui/react";
+import { DateTime } from "luxon";
+import { Modal } from "./components/modal";
+import { InlineMarkdown } from "./(site)/markdown";
+import { releaseNotes, SHOWN_RELEASES } from "./release-notes";
+import { getAppVersion } from "@/utils/git";
+
+const CHANGELOG_URL =
+  "https://github.com/LWCW-Europe/schellingboard/blob/main/CHANGELOG.md";
+
+// Rendered without a zone, so the date stays the calendar date the release
+// carries in CHANGELOG.md rather than shifting by the reader's offset.
+const formatDate = (date: string) =>
+  DateTime.fromISO(date).toFormat("d LLLL yyyy");
+
+// Bigger than the highlights below it, which carry bold of their own: at the
+// same size the release a bullet belongs to stopped being the thing the eye
+// lands on first.
+function ReleaseHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="border-b border-line-subtle pb-1 text-base font-bold text-fg">
+      {children}
+    </h3>
+  );
+}
+
+function Highlights({ highlights }: { highlights: string[] }) {
+  return (
+    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-fg">
+      {highlights.map((highlight) => (
+        <li key={highlight}>
+          <InlineMarkdown>{highlight}</InlineMarkdown>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The footer's version, which opens what changed in the last few releases —
+ * dates included, since the first thing an organizer wants from it is whether
+ * the deployment in front of them is behind.
+ */
+export function WhatsNew({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+  const appVersion = getAppVersion();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="What's new"
+        // Spelled out for a screen reader: on a narrow phone the "Version:"
+        // label is dropped, leaving a bare number that says nothing on its own.
+        aria-label={`Version ${appVersion} — what's new`}
+        // focus-visible, not focus: closing the modal hands the focus back
+        // here, and a mouse user should not be left with a ring in the footer.
+        className={`flex gap-1 rounded-sm text-link hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent ${className ?? ""}`}
+      >
+        <span className="hidden sm:block">Version: </span>
+        {appVersion}
+      </button>
+      {/* Wider than the default: several releases of highlights, each a
+          sentence long, read badly in a narrow column. Above the fixed nav bar
+          (z-30) and the footer (z-20) too — opened from the footer, the modal
+          would otherwise be the one thing on the page they overlap. */}
+      <Modal
+        open={open}
+        setOpen={setOpen}
+        zIndex="z-50"
+        maxWidth="sm:max-w-2xl"
+      >
+        <Dialog.Title className="text-lg font-semibold text-fg">
+          What&apos;s new
+        </Dialog.Title>
+        <p className="mt-1 text-sm text-fg-subtle">
+          This site is running {appVersion}.
+        </p>
+        <div className="mt-4 space-y-4">
+          {releaseNotes.slice(0, SHOWN_RELEASES).map((release) => (
+            <section key={release.version}>
+              <ReleaseHeading>
+                {release.date
+                  ? `${release.version} — ${formatDate(release.date)}`
+                  : release.version}
+              </ReleaseHeading>
+              {/* Dateless: the release this build is ahead of the last one by,
+                  and this is the only place those changes are announced. */}
+              {!release.date && (
+                <p className="mt-1 text-xs text-fg-subtle">
+                  In this build, but not in a released version yet.
+                </p>
+              )}
+              <Highlights highlights={release.highlights} />
+            </section>
+          ))}
+        </div>
+        <a
+          href={CHANGELOG_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 inline-block text-sm text-link hover:underline"
+        >
+          Full changelog on GitHub
+        </a>
+      </Modal>
+    </>
+  );
+}

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -10,6 +10,8 @@ documentation.
 
 1. **Finalize the changelog** — in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (no `v` prefix in the header), and replace the `[Unreleased]` compare link at the bottom of the file with the new version's, pointing from the previous release's endpoint to the new tag (`vX.Y.Z`). Do _not_ add a fresh `## [Unreleased]` section here — the released tag should carry no empty section, since that is what the documentation site publishes. Step 4 reopens it afterwards.
 
+   **Release the in-app notes in the same commit** — in `app/release-notes.ts`, the first entry of `releaseNotes` is the one being prepared: replace its `version: "Unreleased"` with this version and add the `date`. Nothing else moves. Verify the highlights in fact describe this release; that entry is what the footer's version button has been showing all along, so it is worth re-reading rather than assuming. `make test` fails until the newest release the changelog names has an entry.
+
    **Record the release's database in the same commit**, so future releases are tested against an upgrade from it:
 
    ```bash

--- a/tests/e2e/release-notes.spec.ts
+++ b/tests/e2e/release-notes.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { releaseNotes, SHOWN_RELEASES } from "@/app/release-notes";
+
+// What the notes actually say is the release notes' own business (see
+// tests/unit/release-notes.test.ts); this is about the version in the footer
+// being a way in to them at all.
+test("the footer's version opens the recent release notes", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: /what's new/i }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("heading", { name: "What's new" })
+  ).toBeVisible();
+
+  // The last three entries: each release dated, so the reader can tell how old
+  // this deployment is, and the release being prepared — when there is one —
+  // named as unreleased instead.
+  const shown = releaseNotes.slice(0, SHOWN_RELEASES);
+  const headings = dialog.getByRole("heading", { level: 3 });
+  await expect(headings).toHaveCount(SHOWN_RELEASES);
+  for (const [index, heading] of (await headings.all()).entries()) {
+    await expect(heading).toHaveText(
+      shown[index].date ? /^\d+\.\d+\.\d+ — \d{1,2} \w+ \d{4}$/ : /^Unreleased$/
+    );
+  }
+  await expect(dialog.getByRole("listitem").first()).not.toBeEmpty();
+
+  // Highlights are markdown, so a bold lead phrase arrives as bold text rather
+  // than as asterisks.
+  const highlights = shown.flatMap((note) => note.highlights);
+  await expect(dialog).not.toContainText("**");
+  if (highlights.some((highlight) => highlight.includes("**"))) {
+    await expect(dialog.locator("li strong").first()).toBeVisible();
+  }
+
+  await expect(
+    dialog.getByRole("link", { name: /full changelog/i })
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/LWCW-Europe/schellingboard/blob/main/CHANGELOG.md"
+  );
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});

--- a/tests/unit/release-notes.test.ts
+++ b/tests/unit/release-notes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+import { releaseNotes, SHOWN_RELEASES } from "@/app/release-notes";
+
+/**
+ * The in-app release notes are written by hand, so nothing keeps them in step
+ * with CHANGELOG.md on its own. These checks are that: they turn red the
+ * moment a release is finalized without its note, which is when the omission
+ * is cheapest to fix.
+ */
+
+const CHANGELOG = readFileSync(
+  path.join(__dirname, "../../CHANGELOG.md"),
+  "utf8"
+);
+
+/** Released versions and their dates, from the headings, newest first. */
+const released = [
+  ...CHANGELOG.matchAll(/^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})$/gm),
+].map(([, version, date]) => ({ version, date }));
+
+/** The entries that name a release, i.e. all but an unreleased first one. */
+const dated = releaseNotes.filter((note) => note.date !== undefined);
+
+describe("in-app release notes", () => {
+  it("cover at least the releases the modal shows", () => {
+    expect(releaseNotes.length).toBeGreaterThanOrEqual(SHOWN_RELEASES);
+  });
+
+  it("start at the newest release in the changelog", () => {
+    expect(dated[0].version).toBe(released[0].version);
+  });
+
+  it("name a released version, dated as the changelog dates it", () => {
+    for (const note of dated) {
+      expect(released).toContainEqual({
+        version: note.version,
+        date: note.date,
+      });
+    }
+  });
+
+  it("run newest first", () => {
+    const positions = dated.map((note) =>
+      released.findIndex((release) => release.version === note.version)
+    );
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    expect(new Set(positions).size).toBe(positions.length);
+  });
+
+  it("carry the unreleased entry, if any, first and alone", () => {
+    // Releasing renames that entry and dates it; a second one would mean a
+    // release was cut without the first being renamed.
+    const undated = releaseNotes.filter((note) => note.date === undefined);
+    expect(undated.length).toBeLessThanOrEqual(1);
+    for (const note of undated) {
+      expect(note).toBe(releaseNotes[0]);
+      expect(note.version).toBe("Unreleased");
+    }
+  });
+
+  it("say something, briefly", () => {
+    for (const note of releaseNotes) {
+      expect(note.highlights.length).toBeGreaterThan(0);
+    }
+    const highlights = releaseNotes.flatMap((note) => note.highlights);
+    for (const highlight of highlights) {
+      expect(highlight.trim()).toBe(highlight);
+      expect(highlight).not.toBe("");
+      // A modal an organizer/attendee skims, not the changelog: a highlight that no
+      // longer fits in a sentence belongs in CHANGELOG.md instead.
+      expect(highlight.length).toBeLessThanOrEqual(200);
+    }
+  });
+});


### PR DESCRIPTION
Organizers had no way to tell what a deployment contains, or how old it is,
without finding the changelog on GitHub. The notes are hand-written and kept
apart from CHANGELOG.md, which is far too long and too detailed to read in a
modal; a unit test fails until the newest release named there has an entry, so
the two cannot drift.

fixes schellingboard/schellingboard#787

<!-- jip:pushed-commit=20a0fb9c8e4a20eb033165fa26d743b6a50335d0 -->