### PR TITLE
fix: mark pass-through images unoptimized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Room photos shipped with the demo data no longer make Next warn that the image loader ignores the
+  requested width. The custom loader hands anything outside `/media/` back unchanged, so those
+  `<Image>`s now declare `unoptimized` instead of asking for a srcset of identical URLs
 - Releases are made by CI instead of by hand on a laptop: pushing a `vX.Y.Z` tag builds the image,
   runs the E2E suite against it, and only then publishes it to Docker Hub and opens the GitHub
   release. Whether the release takes over `:latest` is worked out from the repository's tags instead

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -7,6 +7,7 @@ import { getNumSlots, getNowOffsetPx } from "@/utils/slots";
 import { useKioskMode } from "./kiosk";
 import { useContext } from "react";
 import Image from "next/image";
+import { isUnoptimized } from "@/utils/image-loader";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { Tooltip } from "./tooltip";
 import { DateTime } from "luxon";
@@ -125,6 +126,7 @@ export function DayGrid(props: {
                 <Image
                   src={loc.imageUrl}
                   alt={loc.name}
+                  unoptimized={isUnoptimized(loc.imageUrl)}
                   className="w-full aspect-[4/3]"
                   style={{ maxHeight: 200 }}
                   width={500}

--- a/app/admin/locations-manager.tsx
+++ b/app/admin/locations-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Image from "next/image";
+import { isUnoptimized } from "@/utils/image-loader";
 import clsx from "clsx";
 import { Input } from "@/app/input";
 import type { Location } from "@/db/repositories/interfaces";
@@ -290,6 +291,7 @@ function LocationForm({
           <Image
             src={location.imageUrl}
             alt={`Current image of ${location.name}`}
+            unoptimized={isUnoptimized(location.imageUrl)}
             width={160}
             height={120}
             className="rounded border border-line-subtle"
@@ -451,6 +453,7 @@ function LocationRow({
           <Image
             src={location.imageUrl}
             alt={location.name}
+            unoptimized={isUnoptimized(location.imageUrl)}
             width={80}
             height={60}
             className="rounded border border-line-subtle shrink-0"

--- a/tests/unit/image-loader.test.ts
+++ b/tests/unit/image-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import loader from "@/utils/image-loader";
+import loader, { isUnoptimized } from "@/utils/image-loader";
 
 // Next's built-in optimizer cannot fetch /media: it builds its upstream
 // request with no headers at all, so the proxy sees no site-auth cookie and
@@ -37,5 +37,19 @@ describe("image loader", () => {
     ]) {
       expect(loader({ src, width: 384 })).toBe(src);
     }
+  });
+});
+
+// Next warns in dev when a loader returns the src unchanged ("has a 'loader'
+// property that does not implement width") and would emit a srcset of
+// identical URLs, so every <Image> whose src can miss the media routes has to
+// declare itself unoptimized.
+describe("isUnoptimized", () => {
+  it("is false for media, which the media routes resize", () => {
+    expect(isUnoptimized("/media/locations/l1.jpg?v=123")).toBe(false);
+  });
+
+  it("is true for build assets, which this loader passes through", () => {
+    expect(isUnoptimized("/locations/loc-main-hall.jpg")).toBe(true);
   });
 });

--- a/utils/image-loader.js
+++ b/utils/image-loader.js
@@ -22,11 +22,23 @@
 const DEFAULT_QUALITY = 75;
 
 /**
+ * Whether <Image> must render `src` with `unoptimized`. Everything this loader
+ * hands back unchanged has to: Next warns in dev that the loader ignores the
+ * requested width, and builds a srcset of identical URLs.
+ *
+ * @param {string} src
+ * @returns {boolean}
+ */
+export function isUnoptimized(src) {
+  return !src.startsWith("/media/");
+}
+
+/**
  * @param {import("next/image").ImageLoaderProps} props
  * @returns {string}
  */
 export default function imageLoader({ src, width, quality }) {
-  if (!src.startsWith("/media/")) return src;
+  if (isUnoptimized(src)) return src;
 
   // Stored media URLs already carry a ?v= cache-buster.
   const separator = src.includes("?") ? "&" : "?";


### PR DESCRIPTION
The custom loader hands anything outside /media/ back unchanged, so Next
warned that it ignores the requested width and built a srcset of identical
URLs for the seeded room photos.

<!-- jip:pushed-commit=92e8134eaddbe6134d913ae1bb555dfa5f0ff600 -->