### PR TITLE
docs: reopen the in-app release notes when reopening the changelog

### DIFF
--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -38,6 +38,10 @@ export const SHOWN_RELEASES = 3;
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: "Unreleased",
+    highlights: [],
+  },
+  {
     version: "3.5.0",
     date: "2026-08-30",
     highlights: [

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -44,7 +44,9 @@ documentation.
 
 4. **Reopen the changelog** — in a follow-up commit on `main`, add an empty
    `## [Unreleased]` section above `## [X.Y.Z]` and an `[Unreleased]` compare
-   link from `vX.Y.Z` to `HEAD`.
+   link from `vX.Y.Z` to `HEAD`. **Reopen the in-app notes too** — in
+   `app/release-notes.ts`, add a new first entry with `version: "Unreleased"`
+   and no `date`, above the one just released.
 
 ## What the release workflow does
 

--- a/tests/unit/release-notes.test.ts
+++ b/tests/unit/release-notes.test.ts
@@ -61,7 +61,9 @@ describe("in-app release notes", () => {
   });
 
   it("say something, briefly", () => {
+    // The reopened Unreleased entry starts empty and fills in as changes land.
     for (const note of releaseNotes) {
+      if (note.date === undefined) continue;
       expect(note.highlights.length).toBeGreaterThan(0);
     }
     const highlights = releaseNotes.flatMap((note) => note.highlights);


### PR DESCRIPTION
<!-- jip:pushed-commit=e6a646204fbf07402abaecd4b33b516f5aa50db9 -->