### PR TITLE
perf: eager-load the first room photo on the schedule grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Internal
+
+- The first room photo on the schedule grid is loaded eagerly. It sits above the fold and is usually
+  the page's largest element, so Next warned that the Largest Contentful Paint image was being
+  lazy-loaded
+
 ## [3.5.0] - 2026-08-30
 
 ### Added

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -42,7 +42,8 @@ export function DayGrid(props: {
   const numLocations = includedLocations.length;
   const slotIncrement = useSlotIncrement();
   const numSlots = getNumSlots(day.start, day.end, slotIncrement);
-  const hasImages = includedLocations.some((loc) => loc.imageUrl);
+  const firstImageIndex = includedLocations.findIndex((loc) => loc.imageUrl);
+  const hasImages = firstImageIndex !== -1;
   const date = DateTime.fromJSDate(day.start).setZone(timezone);
 
   // Kiosk mode: a red line across the day at the current time. `now` comes from
@@ -120,13 +121,15 @@ export function DayGrid(props: {
       {hasImages && (
         <>
           <div className="sticky left-0 z-20 bg-surface border-r border-line-subtle" />
-          {includedLocations.map((loc) => (
+          {includedLocations.map((loc, i) => (
             <div key={loc.name} className="border-l border-line-subtle p-1">
               {loc.imageUrl && (
                 <Image
                   src={loc.imageUrl}
                   alt={loc.name}
                   unoptimized={isUnoptimized(loc.imageUrl)}
+                  // Above the fold, so it is usually the LCP element
+                  priority={i === firstImageIndex}
                   className="w-full aspect-[4/3]"
                   style={{ maxHeight: 200 }}
                   width={500}


### PR DESCRIPTION
It sits above the fold and is usually the LCP element, so Next warned
about it being lazy-loaded.

<!-- jip:pushed-commit=8c280b9e23473f8864e7994ae6d81234a8c36aa8 -->