### PR TITLE
feat: database groundwork for 1-on-1 meetings

### DIFF
--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -8,7 +8,7 @@ import {
   RESERVED_EVENT_SLUGS,
 } from "@/utils/utils";
 import { isAdminRequest } from "@/utils/acting-admin";
-import type { Event } from "@/db/repositories/interfaces";
+import type { Event, EventMeetingSettings } from "@/db/repositories/interfaces";
 import type { AdminActionResult } from "./admin-guests";
 import { isEventIconName } from "@/app/event-icons";
 import {
@@ -38,9 +38,11 @@ function parseDate(value: string | undefined): Date | undefined {
   return isNaN(d.getTime()) ? undefined : d;
 }
 
-// Phase dates are deliberately excluded: they are managed only by
-// updateEventPhasesAction. Including the keys here (even as undefined) would
-// make the repository update NULL them out on every basic-info save.
+// Phase dates and the meeting settings are deliberately excluded: they are
+// managed only by updateEventPhasesAction and the admin Meetings section.
+// Excluding them is what keeps a basic-info save from touching them — and for
+// the nullable meeting-hours pair it is required, since events.update tests
+// those with `in` and would NULL them out if the keys were present at all.
 type ParsedEvent = Omit<
   Event,
   | "id"
@@ -51,6 +53,7 @@ type ParsedEvent = Omit<
   | "votingPhaseEnd"
   | "schedulingPhaseStart"
   | "schedulingPhaseEnd"
+  | keyof EventMeetingSettings
 >;
 type ParseResult = { data: ParsedEvent } | { error: string };
 

--- a/db/container.ts
+++ b/db/container.ts
@@ -12,6 +12,9 @@ import { SqliteDaysRepository } from "./repositories/sqlite/days";
 import { SqliteEventsRepository } from "./repositories/sqlite/events";
 import { SqliteGuestsRepository } from "./repositories/sqlite/guests";
 import { SqliteLocationsRepository } from "./repositories/sqlite/locations";
+import { SqliteMeetingAvailabilityRepository } from "./repositories/sqlite/meeting-availability";
+import { SqliteMeetingPointsRepository } from "./repositories/sqlite/meeting-points";
+import { SqliteMeetingsRepository } from "./repositories/sqlite/meetings";
 import { SqliteRsvpsRepository } from "./repositories/sqlite/rsvps";
 import { SqliteSettingsRepository } from "./repositories/sqlite/settings";
 import { SqliteSessionProposalsRepository } from "./repositories/sqlite/session-proposals";
@@ -24,6 +27,9 @@ import type {
   EventsRepository,
   GuestsRepository,
   LocationsRepository,
+  MeetingAvailabilityRepository,
+  MeetingPointsRepository,
+  MeetingsRepository,
   RsvpsRepository,
   SettingsRepository,
   SessionProposalsRepository,
@@ -43,6 +49,9 @@ export type Repositories = {
   events: EventsRepository;
   guests: GuestsRepository;
   locations: LocationsRepository;
+  meetingPoints: MeetingPointsRepository;
+  meetingAvailability: MeetingAvailabilityRepository;
+  meetings: MeetingsRepository;
   sessions: SessionsRepository;
   rsvps: RsvpsRepository;
   settings: SettingsRepository;
@@ -65,6 +74,9 @@ function buildRepositories(sqlite: Database.Database): Repositories {
     events: new SqliteEventsRepository(db),
     guests: new SqliteGuestsRepository(db),
     locations: new SqliteLocationsRepository(db),
+    meetingPoints: new SqliteMeetingPointsRepository(db),
+    meetingAvailability: new SqliteMeetingAvailabilityRepository(db),
+    meetings: new SqliteMeetingsRepository(db),
     sessions: new SqliteSessionsRepository(db),
     rsvps: new SqliteRsvpsRepository(db),
     settings: new SqliteSettingsRepository(db),

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -78,7 +78,32 @@ export type Event = {
   /** When true, a session's capacity (> 0) rejects further RSVPs once reached. */
   rsvpCapacityHardLimit: boolean;
   icon?: string | null;
+  /** Whether attendees can book 1-on-1 meetings with each other. */
+  meetingsEnabled: boolean;
+  meetingSlotMinutes: number;
+  /**
+   * Time-of-day bounds ("HH:mm") for 1-on-1 slots. Undefined means the day's
+   * own window.
+   */
+  meetingDayStart?: string;
+  meetingDayEnd?: string;
+  /** How many unanswered requests one attendee may have outstanding. */
+  maxOpenMeetingRequests: number;
 };
+
+/**
+ * The organizer's 1-on-1 settings. Split out because they are configured from
+ * the admin Meetings section after the event exists, never at creation, so
+ * `create` takes them as optional and falls back to the schema's defaults.
+ */
+export type EventMeetingSettings = Pick<
+  Event,
+  | "meetingsEnabled"
+  | "meetingSlotMinutes"
+  | "meetingDayStart"
+  | "meetingDayEnd"
+  | "maxOpenMeetingRequests"
+>;
 
 export interface EventsRepository {
   list(): Promise<Event[]>;
@@ -90,7 +115,10 @@ export interface EventsRepository {
    * Creates the event with a slug derived from its name. Rejects when another
    * event already has that slug (unique constraint).
    */
-  create(data: Omit<Event, "id" | "slug">): Promise<Event>;
+  create(
+    data: Omit<Event, "id" | "slug" | keyof EventMeetingSettings> &
+      Partial<EventMeetingSettings>
+  ): Promise<Event>;
   update(
     id: string,
     patch: Partial<Omit<Event, "id" | "slug">>
@@ -120,6 +148,10 @@ export type EmailSettings = {
    * commented on.
    */
   commentThread: boolean;
+  /** Someone asked the guest for a 1-on-1 meeting. */
+  meetingRequest: boolean;
+  /** A 1-on-1 the guest asked for was accepted, declined or canceled. */
+  meetingResponse: boolean;
 };
 
 export const DEFAULT_EMAIL_SETTINGS: EmailSettings = {
@@ -130,6 +162,10 @@ export const DEFAULT_EMAIL_SETTINGS: EmailSettings = {
   sessionComment: true,
   profileComment: true,
   commentThread: false,
+  // On by default, unlike the comment-thread digest: this mail is addressed
+  // personally to the guest and is waiting on their answer.
+  meetingRequest: true,
+  meetingResponse: true,
 };
 
 type GuestPrivateInfo = {
@@ -756,6 +792,110 @@ export interface VotesRepository {
     proposalId: string,
     guestIds: string[]
   ): Promise<void>;
+}
+
+// ── Meetings ───────────────────────────────────────────────────────────────────
+
+export type MeetingPoint = {
+  id: string;
+  eventId: string;
+  name: string;
+  description: string;
+  sortIndex: number;
+};
+
+export interface MeetingPointsRepository {
+  /** An event's suggested places to meet, in the organizer's order. */
+  listByEvent(eventId: string): Promise<MeetingPoint[]>;
+  create(data: Omit<MeetingPoint, "id">): Promise<MeetingPoint>;
+  update(
+    id: string,
+    patch: Partial<Omit<MeetingPoint, "id" | "eventId">>
+  ): Promise<MeetingPoint | undefined>;
+  delete(id: string): Promise<void>;
+}
+
+export interface MeetingAvailabilityRepository {
+  /**
+   * The slot starts (ISO) a guest declared for an event, chronologically. An
+   * empty result means they are not bookable — the same state as never having
+   * switched meetings on.
+   */
+  listByGuestAndEvent(guestId: string, eventId: string): Promise<Date[]>;
+  /** Replaces a guest's whole declared set for the event. */
+  replaceForGuest(
+    guestId: string,
+    eventId: string,
+    slotStarts: Date[]
+  ): Promise<void>;
+}
+
+/**
+ * Stored meeting states. "expired" is deliberately absent: a pending request
+ * whose slot has passed is expired by definition, and deriving that on read
+ * needs no scheduler.
+ */
+export type MeetingStatus = "pending" | "accepted" | "declined" | "canceled";
+
+export type Meeting = {
+  id: string;
+  eventId: string;
+  requesterId: string;
+  recipientId: string;
+  /** ISO instants; the slot the requester picked. */
+  slotStart: Date;
+  slotEnd: Date;
+  /** Where to meet, as agreed at request time. Never empty. */
+  meetingPoint: string;
+  message: string;
+  status: MeetingStatus;
+  createdAt: Date;
+  respondedAt?: Date;
+};
+
+export interface MeetingsRepository {
+  findById(id: string): Promise<Meeting | undefined>;
+  /**
+   * Every meeting the guest is part of at the event, in either direction,
+   * ordered by slot. Callers filter by status: the schedule shows pending and
+   * accepted, clash detection only accepted.
+   */
+  listByGuestAndEvent(guestId: string, eventId: string): Promise<Meeting[]>;
+  /**
+   * Requests this guest has sent and not heard back on, for the organizer's
+   * cap. `now` bounds it: a pending request whose slot has passed is expired
+   * by definition, and an expired request is not outstanding.
+   */
+  countOpenByRequester(
+    requesterId: string,
+    eventId: string,
+    now: Date
+  ): Promise<number>;
+  create(
+    data: Omit<Meeting, "id" | "status" | "respondedAt">
+  ): Promise<Meeting>;
+  /**
+   * The cap check and the insert in one transaction, returning null when the
+   * requester is already at `cap`. Two separate awaits leave a window a double
+   * submit walks straight through — the same hazard
+   * {@link RsvpsRepository.createIfUnderCapacity} exists for.
+   */
+  createIfUnderCap(
+    data: Omit<Meeting, "id" | "status" | "respondedAt">,
+    cap: number,
+    now: Date
+  ): Promise<Meeting | null>;
+  /**
+   * Moves the meeting to `status`, but only from one of `from` — undefined
+   * when it is in some other state, which is how a caller learns that someone
+   * (a cancelling requester, a second tab) got there first.
+   */
+  updateStatus(
+    id: string,
+    status: MeetingStatus,
+    respondedAt: Date,
+    from: MeetingStatus[]
+  ): Promise<Meeting | undefined>;
 }
 
 // ── Images ─────────────────────────────────────────────────────────────────────

--- a/db/repositories/sqlite/events.ts
+++ b/db/repositories/sqlite/events.ts
@@ -3,7 +3,11 @@ import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
 import { eventNameToSlug } from "@/utils/utils";
-import type { Event, EventsRepository } from "../interfaces";
+import type {
+  Event,
+  EventMeetingSettings,
+  EventsRepository,
+} from "../interfaces";
 
 type EventRow = typeof schema.events.$inferInsert;
 
@@ -42,6 +46,11 @@ function rowToEvent(row: typeof schema.events.$inferSelect): Event {
     timezone: row.timezone,
     rsvpCapacityHardLimit: row.rsvpCapacityHardLimit,
     icon: row.icon ?? undefined,
+    meetingsEnabled: row.meetingsEnabled,
+    meetingSlotMinutes: row.meetingSlotMinutes,
+    meetingDayStart: row.meetingDayStart ?? undefined,
+    meetingDayEnd: row.meetingDayEnd ?? undefined,
+    maxOpenMeetingRequests: row.maxOpenMeetingRequests,
   };
 }
 
@@ -79,7 +88,10 @@ export class SqliteEventsRepository implements EventsRepository {
     return row ? rowToEvent(row) : undefined;
   }
 
-  async create(data: Omit<Event, "id" | "slug">): Promise<Event> {
+  async create(
+    data: Omit<Event, "id" | "slug" | keyof EventMeetingSettings> &
+      Partial<EventMeetingSettings>
+  ): Promise<Event> {
     const id = nanoid();
     const slug = eventNameToSlug(data.name);
     this.db
@@ -104,9 +116,24 @@ export class SqliteEventsRepository implements EventsRepository {
         timezone: data.timezone,
         rsvpCapacityHardLimit: data.rsvpCapacityHardLimit,
         icon: data.icon ?? null,
+        ...(data.meetingsEnabled !== undefined && {
+          meetingsEnabled: data.meetingsEnabled,
+        }),
+        ...(data.meetingSlotMinutes !== undefined && {
+          meetingSlotMinutes: data.meetingSlotMinutes,
+        }),
+        meetingDayStart: data.meetingDayStart ?? null,
+        meetingDayEnd: data.meetingDayEnd ?? null,
+        ...(data.maxOpenMeetingRequests !== undefined && {
+          maxOpenMeetingRequests: data.maxOpenMeetingRequests,
+        }),
       })
       .run();
-    return { id, slug, ...data };
+    // Read back rather than returning `data`: the meeting settings are
+    // optional, and the caller must see the defaults the schema supplied.
+    const created = await this.findById(id);
+    if (!created) throw new Error("Failed to create event");
+    return created;
   }
 
   async update(
@@ -144,6 +171,16 @@ export class SqliteEventsRepository implements EventsRepository {
     if (patch.rsvpCapacityHardLimit !== undefined)
       set.rsvpCapacityHardLimit = patch.rsvpCapacityHardLimit;
     if ("icon" in patch) set.icon = patch.icon ?? null;
+    if (patch.meetingsEnabled !== undefined)
+      set.meetingsEnabled = patch.meetingsEnabled;
+    if (patch.meetingSlotMinutes !== undefined)
+      set.meetingSlotMinutes = patch.meetingSlotMinutes;
+    if ("meetingDayStart" in patch)
+      set.meetingDayStart = patch.meetingDayStart ?? null;
+    if ("meetingDayEnd" in patch)
+      set.meetingDayEnd = patch.meetingDayEnd ?? null;
+    if (patch.maxOpenMeetingRequests !== undefined)
+      set.maxOpenMeetingRequests = patch.maxOpenMeetingRequests;
 
     this.db
       .update(schema.events)

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -92,6 +92,8 @@ function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
         sessionComment: row.emailOnSessionComment,
         profileComment: row.emailOnProfileComment,
         commentThread: row.emailOnCommentThread,
+        meetingRequest: row.emailOnMeetingRequest,
+        meetingResponse: row.emailOnMeetingResponse,
       },
     },
   };
@@ -491,6 +493,8 @@ export class SqliteGuestsRepository implements GuestsRepository {
         emailOnSessionComment: settings.sessionComment,
         emailOnProfileComment: settings.profileComment,
         emailOnCommentThread: settings.commentThread,
+        emailOnMeetingRequest: settings.meetingRequest,
+        emailOnMeetingResponse: settings.meetingResponse,
       })
       .where(eq(schema.guests.id, id))
       .run();

--- a/db/repositories/sqlite/meeting-availability.ts
+++ b/db/repositories/sqlite/meeting-availability.ts
@@ -1,0 +1,51 @@
+import { and, asc, eq } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import * as schema from "../../schema";
+import type { MeetingAvailabilityRepository } from "../interfaces";
+
+type DB = BetterSQLite3Database<typeof schema>;
+
+export class SqliteMeetingAvailabilityRepository implements MeetingAvailabilityRepository {
+  constructor(private readonly db: DB) {}
+
+  async listByGuestAndEvent(guestId: string, eventId: string): Promise<Date[]> {
+    return this.db
+      .select({ slotStart: schema.meetingAvailability.slotStart })
+      .from(schema.meetingAvailability)
+      .where(
+        and(
+          eq(schema.meetingAvailability.eventId, eventId),
+          eq(schema.meetingAvailability.guestId, guestId)
+        )
+      )
+      .orderBy(asc(schema.meetingAvailability.slotStart))
+      .all()
+      .map((row) => new Date(row.slotStart));
+  }
+
+  // Delete-then-insert in one transaction: the form submits the whole set, so
+  // a partial write would leave a guest bookable at slots they just cleared.
+  async replaceForGuest(
+    guestId: string,
+    eventId: string,
+    slotStarts: Date[]
+  ): Promise<void> {
+    this.db.transaction((tx) => {
+      tx.delete(schema.meetingAvailability)
+        .where(
+          and(
+            eq(schema.meetingAvailability.eventId, eventId),
+            eq(schema.meetingAvailability.guestId, guestId)
+          )
+        )
+        .run();
+      // Serialised here rather than by callers: booking compares a meeting's
+      // slot with these rows as text, so one format has to win.
+      const unique = [...new Set(slotStarts.map((slot) => slot.toISOString()))];
+      if (unique.length === 0) return;
+      tx.insert(schema.meetingAvailability)
+        .values(unique.map((slotStart) => ({ eventId, guestId, slotStart })))
+        .run();
+    });
+  }
+}

--- a/db/repositories/sqlite/meeting-points.ts
+++ b/db/repositories/sqlite/meeting-points.ts
@@ -1,0 +1,72 @@
+import { asc, eq } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { nanoid } from "nanoid";
+import * as schema from "../../schema";
+import type { MeetingPoint, MeetingPointsRepository } from "../interfaces";
+
+type DB = BetterSQLite3Database<typeof schema>;
+
+function rowToPoint(
+  row: typeof schema.meetingPoints.$inferSelect
+): MeetingPoint {
+  return {
+    id: row.id,
+    eventId: row.eventId,
+    name: row.name,
+    description: row.description,
+    sortIndex: row.sortIndex,
+  };
+}
+
+export class SqliteMeetingPointsRepository implements MeetingPointsRepository {
+  constructor(private readonly db: DB) {}
+
+  async listByEvent(eventId: string): Promise<MeetingPoint[]> {
+    return this.db
+      .select()
+      .from(schema.meetingPoints)
+      .where(eq(schema.meetingPoints.eventId, eventId))
+      .orderBy(
+        asc(schema.meetingPoints.sortIndex),
+        asc(schema.meetingPoints.id)
+      )
+      .all()
+      .map(rowToPoint);
+  }
+
+  async create(data: Omit<MeetingPoint, "id">): Promise<MeetingPoint> {
+    const row = { id: nanoid(), ...data };
+    this.db.insert(schema.meetingPoints).values(row).run();
+    return rowToPoint(row);
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<MeetingPoint, "id" | "eventId">>
+  ): Promise<MeetingPoint | undefined> {
+    const values: Partial<typeof schema.meetingPoints.$inferInsert> = {};
+    if (patch.name !== undefined) values.name = patch.name;
+    if (patch.description !== undefined) values.description = patch.description;
+    if (patch.sortIndex !== undefined) values.sortIndex = patch.sortIndex;
+    if (Object.keys(values).length > 0) {
+      this.db
+        .update(schema.meetingPoints)
+        .set(values)
+        .where(eq(schema.meetingPoints.id, id))
+        .run();
+    }
+    const row = this.db
+      .select()
+      .from(schema.meetingPoints)
+      .where(eq(schema.meetingPoints.id, id))
+      .get();
+    return row ? rowToPoint(row) : undefined;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.db
+      .delete(schema.meetingPoints)
+      .where(eq(schema.meetingPoints.id, id))
+      .run();
+  }
+}

--- a/db/repositories/sqlite/meetings.ts
+++ b/db/repositories/sqlite/meetings.ts
@@ -1,0 +1,146 @@
+import { and, asc, count, eq, gt, inArray, or } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { nanoid } from "nanoid";
+import * as schema from "../../schema";
+import type { Meeting, MeetingStatus, MeetingsRepository } from "../interfaces";
+
+type DB = BetterSQLite3Database<typeof schema>;
+
+function rowToMeeting(row: typeof schema.meetings.$inferSelect): Meeting {
+  return {
+    id: row.id,
+    eventId: row.eventId,
+    requesterId: row.requesterId,
+    recipientId: row.recipientId,
+    slotStart: new Date(row.slotStart),
+    slotEnd: new Date(row.slotEnd),
+    meetingPoint: row.meetingPoint,
+    message: row.message,
+    status: row.status,
+    createdAt: new Date(row.createdAt),
+    respondedAt: row.respondedAt ? new Date(row.respondedAt) : undefined,
+  };
+}
+
+// Instants are stored as ISO-8601 in UTC and nowhere else formatted, which is
+// what makes ordering by the text column chronological and what lets a
+// meeting's slot be compared with an availability row's.
+function toRow(data: Omit<Meeting, "id" | "status" | "respondedAt">) {
+  return {
+    id: nanoid(),
+    eventId: data.eventId,
+    requesterId: data.requesterId,
+    recipientId: data.recipientId,
+    slotStart: data.slotStart.toISOString(),
+    slotEnd: data.slotEnd.toISOString(),
+    meetingPoint: data.meetingPoint,
+    message: data.message,
+    status: "pending" as const,
+    createdAt: data.createdAt.toISOString(),
+    respondedAt: null,
+  };
+}
+
+export class SqliteMeetingsRepository implements MeetingsRepository {
+  constructor(private readonly db: DB) {}
+
+  async findById(id: string): Promise<Meeting | undefined> {
+    const row = this.db
+      .select()
+      .from(schema.meetings)
+      .where(eq(schema.meetings.id, id))
+      .get();
+    return row ? rowToMeeting(row) : undefined;
+  }
+
+  async listByGuestAndEvent(
+    guestId: string,
+    eventId: string
+  ): Promise<Meeting[]> {
+    return this.db
+      .select()
+      .from(schema.meetings)
+      .where(
+        and(
+          eq(schema.meetings.eventId, eventId),
+          or(
+            eq(schema.meetings.requesterId, guestId),
+            eq(schema.meetings.recipientId, guestId)
+          )
+        )
+      )
+      .orderBy(asc(schema.meetings.slotStart), asc(schema.meetings.id))
+      .all()
+      .map(rowToMeeting);
+  }
+
+  async countOpenByRequester(
+    requesterId: string,
+    eventId: string,
+    now: Date
+  ): Promise<number> {
+    return this.countOpen(this.db, requesterId, eventId, now);
+  }
+
+  async create(
+    data: Omit<Meeting, "id" | "status" | "respondedAt">
+  ): Promise<Meeting> {
+    const row = toRow(data);
+    this.db.insert(schema.meetings).values(row).run();
+    return rowToMeeting(row);
+  }
+
+  async createIfUnderCap(
+    data: Omit<Meeting, "id" | "status" | "respondedAt">,
+    cap: number,
+    now: Date
+  ): Promise<Meeting | null> {
+    return this.db.transaction((tx) => {
+      if (this.countOpen(tx, data.requesterId, data.eventId, now) >= cap) {
+        return null;
+      }
+      const row = toRow(data);
+      tx.insert(schema.meetings).values(row).run();
+      return rowToMeeting(row);
+    });
+  }
+
+  async updateStatus(
+    id: string,
+    status: MeetingStatus,
+    respondedAt: Date,
+    from: MeetingStatus[]
+  ): Promise<Meeting | undefined> {
+    const result = this.db
+      .update(schema.meetings)
+      .set({ status, respondedAt: respondedAt.toISOString() })
+      .where(
+        and(eq(schema.meetings.id, id), inArray(schema.meetings.status, from))
+      )
+      .run();
+    return result.changes === 0 ? undefined : this.findById(id);
+  }
+
+  // Shared by the plain count and the transactional create, so "outstanding"
+  // means one thing: pending, and not yet in the past.
+  private countOpen(
+    db: DB,
+    requesterId: string,
+    eventId: string,
+    now: Date
+  ): number {
+    const row = db
+      .select({ open: count() })
+      .from(schema.meetings)
+      .where(
+        and(
+          eq(schema.meetings.eventId, eventId),
+          eq(schema.meetings.requesterId, requesterId),
+          eq(schema.meetings.status, "pending"),
+          gt(schema.meetings.slotStart, now.toISOString())
+        )
+      )
+      .get();
+    return row?.open ?? 0;
+  }
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -64,6 +64,16 @@ export const guests = sqliteTable(
     })
       .notNull()
       .default(false),
+    emailOnMeetingRequest: integer("email_on_meeting_request", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(true),
+    emailOnMeetingResponse: integer("email_on_meeting_response", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(true),
     avatarUrl: text("avatar_url"),
     // When the guest last changed a public profile field — their name counts,
     // email settings and credentials don't. NULL for profiles nobody ever
@@ -144,6 +154,17 @@ export const events = sqliteTable(
       .notNull()
       .default(false),
     icon: text("icon"),
+    meetingsEnabled: integer("meetings_enabled", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    meetingSlotMinutes: integer("meeting_slot_minutes").notNull().default(30),
+    // Time-of-day bounds ("HH:mm") for 1-on-1 slots. NULL means the day's own
+    // window, so an organiser who never sets them still gets slots.
+    meetingDayStart: text("meeting_day_start"),
+    meetingDayEnd: text("meeting_day_end"),
+    maxOpenMeetingRequests: integer("max_open_meeting_requests")
+      .notNull()
+      .default(5),
   },
   (table) => [uniqueIndex("events_slug_unique").on(table.slug)]
 );
@@ -377,5 +398,92 @@ export const votes = sqliteTable(
   },
   (t) => [
     uniqueIndex("votes_proposal_guest_unique").on(t.proposalId, t.guestId),
+  ]
+);
+
+// The organizer's suggested places to meet. Never reserved and never a grid
+// column, which is why these aren't `locations`: a pair naming one is saying
+// where to find each other, not claiming it.
+export const meetingPoints = sqliteTable(
+  "meeting_points",
+  {
+    id: text("id").primaryKey(),
+    eventId: text("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description").notNull().default(""),
+    sortIndex: integer("sort_index").notNull().default(0),
+  },
+  (t) => [index("meeting_points_event_idx").on(t.eventId)]
+);
+
+// A slot a guest declared themselves free for. Slots themselves are derived
+// from the event's days and `meetingSlotMinutes` rather than stored, so these
+// rows key on the slot's start instant: narrowing the meeting hours later
+// simply stops offering the rows that fall outside, with nothing to migrate.
+//
+// Only availability is recorded here. Whether the guest is *also* free of
+// sessions at that slot is computed when someone tries to book them, so an
+// RSVP made after this was saved still counts.
+export const meetingAvailability = sqliteTable(
+  "meeting_availability",
+  {
+    eventId: text("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    guestId: text("guest_id")
+      .notNull()
+      .references(() => guests.id, { onDelete: "cascade" }),
+    slotStart: text("slot_start").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.eventId, t.guestId, t.slotStart] }),
+    index("meeting_availability_slot_idx").on(t.eventId, t.slotStart),
+  ]
+);
+
+export const meetings = sqliteTable(
+  "meetings",
+  {
+    id: text("id").primaryKey(),
+    eventId: text("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    requesterId: text("requester_id")
+      .notNull()
+      .references(() => guests.id, { onDelete: "cascade" }),
+    recipientId: text("recipient_id")
+      .notNull()
+      .references(() => guests.id, { onDelete: "cascade" }),
+    slotStart: text("slot_start").notNull(),
+    slotEnd: text("slot_end").notNull(),
+    // Free text, not a `meeting_points` reference: the requester may type their
+    // own, and what the pair agreed on shouldn't change under them when the
+    // organizer renames or removes a suggestion.
+    meetingPoint: text("meeting_point").notNull(),
+    message: text("message").notNull().default(""),
+    // Not "expired": a request whose slot has passed is expired by definition,
+    // so it is derived on read rather than swept by a job the app has no
+    // scheduler to run.
+    status: text("status", {
+      enum: ["pending", "accepted", "declined", "canceled"],
+    })
+      .notNull()
+      .default("pending"),
+    createdAt: text("created_at").notNull(),
+    respondedAt: text("responded_at"),
+  },
+  (t) => [
+    index("meetings_event_requester_idx").on(t.eventId, t.requesterId),
+    index("meetings_event_recipient_idx").on(t.eventId, t.recipientId),
+    // Asking the same person for the same slot twice is a double submit, not a
+    // second option: it would leave them two identical requests to answer.
+    uniqueIndex("meetings_no_duplicate_request").on(
+      t.eventId,
+      t.requesterId,
+      t.recipientId,
+      t.slotStart
+    ),
   ]
 );

--- a/drizzle/0029_meetings.sql
+++ b/drizzle/0029_meetings.sql
@@ -1,0 +1,47 @@
+CREATE TABLE `meeting_availability` (
+	`event_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	`slot_start` text NOT NULL,
+	PRIMARY KEY(`event_id`, `guest_id`, `slot_start`),
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `meeting_availability_slot_idx` ON `meeting_availability` (`event_id`,`slot_start`);--> statement-breakpoint
+CREATE TABLE `meeting_points` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`sort_index` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `meeting_points_event_idx` ON `meeting_points` (`event_id`);--> statement-breakpoint
+CREATE TABLE `meetings` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`requester_id` text NOT NULL,
+	`recipient_id` text NOT NULL,
+	`slot_start` text NOT NULL,
+	`slot_end` text NOT NULL,
+	`meeting_point` text NOT NULL,
+	`message` text DEFAULT '' NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`created_at` text NOT NULL,
+	`responded_at` text,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`requester_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`recipient_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `meetings_event_requester_idx` ON `meetings` (`event_id`,`requester_id`);--> statement-breakpoint
+CREATE INDEX `meetings_event_recipient_idx` ON `meetings` (`event_id`,`recipient_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `meetings_no_duplicate_request` ON `meetings` (`event_id`,`requester_id`,`recipient_id`,`slot_start`);--> statement-breakpoint
+ALTER TABLE `events` ADD `meetings_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `events` ADD `meeting_slot_minutes` integer DEFAULT 30 NOT NULL;--> statement-breakpoint
+ALTER TABLE `events` ADD `meeting_day_start` text;--> statement-breakpoint
+ALTER TABLE `events` ADD `meeting_day_end` text;--> statement-breakpoint
+ALTER TABLE `events` ADD `max_open_meeting_requests` integer DEFAULT 5 NOT NULL;--> statement-breakpoint
+ALTER TABLE `guests` ADD `email_on_meeting_request` integer DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `guests` ADD `email_on_meeting_response` integer DEFAULT true NOT NULL;

--- a/drizzle/meta/0029_snapshot.json
+++ b/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,1744 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2acaeb74-73e0-4cc4-829e-964a054814d0",
+  "prevId": "870cb94a-0ce7-4a7f-b1c6-c7d601b1a9e3",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meetings_enabled": {
+          "name": "meetings_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "meeting_slot_minutes": {
+          "name": "meeting_slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "meeting_day_start": {
+          "name": "meeting_day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_day_end": {
+          "name": "meeting_day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_open_meeting_requests": {
+          "name": "max_open_meeting_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_session_comment": {
+          "name": "email_on_session_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_profile_comment": {
+          "name": "email_on_profile_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_on_meeting_request": {
+          "name": "email_on_meeting_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_meeting_response": {
+          "name": "email_on_meeting_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_availability": {
+      "name": "meeting_availability",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_availability_slot_idx": {
+          "name": "meeting_availability_slot_idx",
+          "columns": ["event_id", "slot_start"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_availability_event_id_events_id_fk": {
+          "name": "meeting_availability_event_id_events_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_availability_guest_id_guests_id_fk": {
+          "name": "meeting_availability_guest_id_guests_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meeting_availability_event_id_guest_id_slot_start_pk": {
+          "columns": ["event_id", "guest_id", "slot_start"],
+          "name": "meeting_availability_event_id_guest_id_slot_start_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_points": {
+      "name": "meeting_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "meeting_points_event_idx": {
+          "name": "meeting_points_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_points_event_id_events_id_fk": {
+          "name": "meeting_points_event_id_events_id_fk",
+          "tableFrom": "meeting_points",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_end": {
+          "name": "slot_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_point": {
+          "name": "meeting_point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meetings_event_requester_idx": {
+          "name": "meetings_event_requester_idx",
+          "columns": ["event_id", "requester_id"],
+          "isUnique": false
+        },
+        "meetings_event_recipient_idx": {
+          "name": "meetings_event_recipient_idx",
+          "columns": ["event_id", "recipient_id"],
+          "isUnique": false
+        },
+        "meetings_no_duplicate_request": {
+          "name": "meetings_no_duplicate_request",
+          "columns": ["event_id", "requester_id", "recipient_id", "slot_start"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "meetings_event_id_events_id_fk": {
+          "name": "meetings_event_id_events_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_requester_id_guests_id_fk": {
+          "name": "meetings_requester_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_recipient_id_guests_id_fk": {
+          "name": "meetings_recipient_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_comments": {
+      "name": "profile_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_comments_profile_idx": {
+          "name": "profile_comments_profile_idx",
+          "columns": ["profile_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_comments_comment_id_comments_id_fk": {
+          "name": "profile_comments_comment_id_comments_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_comments_profile_id_guests_id_fk": {
+          "name": "profile_comments_profile_id_guests_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "guests",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1788001821549,
       "tag": "0028_session_profile_comment_email_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1788252255683,
+      "tag": "0029_meetings",
+      "breakpoints": true
     }
   ]
 }

--- a/model/guest.ts
+++ b/model/guest.ts
@@ -21,6 +21,8 @@ export const emailSettingsSchema = z.object({
   sessionComment: z.boolean(),
   profileComment: z.boolean(),
   commentThread: z.boolean(),
+  meetingRequest: z.boolean(),
+  meetingResponse: z.boolean(),
 });
 
 // Length caps are sanity limits only a malicious user would hit; entry caps

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -162,6 +162,8 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       sessionComment: true,
       profileComment: true,
       commentThread: true,
+      meetingRequest: true,
+      meetingResponse: true,
     });
   },
   "actions/user-auth.ts:requestLoginCodeAction": async () => {

--- a/tests/integration/admin-guests.test.ts
+++ b/tests/integration/admin-guests.test.ts
@@ -39,7 +39,10 @@ import { getRepositories } from "@/db/container";
 import { createAdminAuthCookie } from "@/utils/auth";
 import { testEmail } from "@/emails/test-email";
 import { sendMail } from "@/utils/mailer";
-import { VoteChoice } from "@/db/repositories/interfaces";
+import {
+  DEFAULT_EMAIL_SETTINGS,
+  VoteChoice,
+} from "@/db/repositories/interfaces";
 import {
   createGuestAction,
   updateGuestAction,
@@ -251,15 +254,7 @@ describe("admin guest actions", () => {
       expect(result).toEqual({ ok: true });
       const guest =
         await getRepositories().guests.findByEmail("alice@test.example");
-      expect(guest?.info.emailSettings).toEqual({
-        rsvpChange: true,
-        hostChange: true,
-        cohostAdd: true,
-        proposalComment: true,
-        sessionComment: true,
-        profileComment: true,
-        commentThread: false,
-      });
+      expect(guest?.info.emailSettings).toEqual(DEFAULT_EMAIL_SETTINGS);
     });
   });
 

--- a/tests/integration/meetings-repositories.test.ts
+++ b/tests/integration/meetings-repositories.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
+
+const SLOT_A = new Date("2026-09-12T10:00:00.000Z");
+const SLOT_B = new Date("2026-09-12T10:30:00.000Z");
+const SLOT_C = new Date("2026-09-12T11:00:00.000Z");
+// Before every slot above, so a pending request counts as open unless a test
+// says otherwise.
+const BEFORE_SLOTS = new Date("2026-09-12T09:00:00.000Z");
+const AFTER_SLOTS = new Date("2026-09-12T23:00:00.000Z");
+
+describe("event meeting settings", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("defaults to meetings off, 30-minute slots and no meeting-hours window", async () => {
+    const event = await createEvent();
+
+    expect(event.meetingsEnabled).toBe(false);
+    expect(event.meetingSlotMinutes).toBe(30);
+    expect(event.meetingDayStart).toBeUndefined();
+    expect(event.meetingDayEnd).toBeUndefined();
+    expect(event.maxOpenMeetingRequests).toBe(5);
+  });
+
+  it("round-trips the meeting settings through an update", async () => {
+    const { events } = getRepositories();
+    const event = await createEvent();
+
+    await events.update(event.id, {
+      meetingsEnabled: true,
+      meetingSlotMinutes: 15,
+      meetingDayStart: "10:00",
+      meetingDayEnd: "18:00",
+      maxOpenMeetingRequests: 3,
+    });
+
+    const reloaded = await events.findById(event.id);
+    expect(reloaded?.meetingsEnabled).toBe(true);
+    expect(reloaded?.meetingSlotMinutes).toBe(15);
+    expect(reloaded?.meetingDayStart).toBe("10:00");
+    expect(reloaded?.meetingDayEnd).toBe("18:00");
+    expect(reloaded?.maxOpenMeetingRequests).toBe(3);
+  });
+
+  it("clears a meeting-hours window back to the whole day", async () => {
+    const { events } = getRepositories();
+    const event = await createEvent();
+    await events.update(event.id, {
+      meetingDayStart: "10:00",
+      meetingDayEnd: "18:00",
+    });
+
+    await events.update(event.id, {
+      meetingDayStart: undefined,
+      meetingDayEnd: undefined,
+    });
+
+    const reloaded = await events.findById(event.id);
+    expect(reloaded?.meetingDayStart).toBeUndefined();
+    expect(reloaded?.meetingDayEnd).toBeUndefined();
+  });
+});
+
+describe("meeting points", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("lists an event's points in sort order", async () => {
+    const { meetingPoints } = getRepositories();
+    const event = await createEvent();
+    await meetingPoints.create({
+      eventId: event.id,
+      name: "Library corner",
+      description: "Quiet, two armchairs",
+      sortIndex: 2,
+    });
+    await meetingPoints.create({
+      eventId: event.id,
+      name: "Coffee bar",
+      description: "",
+      sortIndex: 1,
+    });
+
+    const points = await meetingPoints.listByEvent(event.id);
+    expect(points.map((p) => p.name)).toEqual(["Coffee bar", "Library corner"]);
+    expect(points[1].description).toBe("Quiet, two armchairs");
+  });
+
+  it("keeps each event's points to itself", async () => {
+    const { meetingPoints } = getRepositories();
+    const [one, two] = [await createEvent(), await createEvent()];
+    await meetingPoints.create({
+      eventId: one.id,
+      name: "Coffee bar",
+      description: "",
+      sortIndex: 0,
+    });
+
+    expect(await meetingPoints.listByEvent(two.id)).toEqual([]);
+  });
+
+  it("updates and deletes a point", async () => {
+    const { meetingPoints } = getRepositories();
+    const event = await createEvent();
+    const point = await meetingPoints.create({
+      eventId: event.id,
+      name: "Coffee bar",
+      description: "",
+      sortIndex: 0,
+    });
+
+    const updated = await meetingPoints.update(point.id, { name: "Café" });
+    expect(updated?.name).toBe("Café");
+
+    await meetingPoints.delete(point.id);
+    expect(await meetingPoints.listByEvent(event.id)).toEqual([]);
+  });
+
+  it("drops an event's points when the event goes", async () => {
+    const { meetingPoints, events } = getRepositories();
+    const event = await createEvent();
+    await meetingPoints.create({
+      eventId: event.id,
+      name: "Coffee bar",
+      description: "",
+      sortIndex: 0,
+    });
+
+    await events.delete(event.id);
+
+    expect(await meetingPoints.listByEvent(event.id)).toEqual([]);
+  });
+});
+
+describe("meeting availability", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("stores the slots a guest declared, in chronological order", async () => {
+    const { meetingAvailability } = getRepositories();
+    const event = await createEvent();
+    const guest = await createGuest({ eventId: event.id });
+
+    await meetingAvailability.replaceForGuest(guest.id, event.id, [
+      SLOT_C,
+      SLOT_A,
+    ]);
+
+    expect(
+      await meetingAvailability.listByGuestAndEvent(guest.id, event.id)
+    ).toEqual([SLOT_A, SLOT_C]);
+  });
+
+  it("replaces the whole set rather than adding to it", async () => {
+    const { meetingAvailability } = getRepositories();
+    const event = await createEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await meetingAvailability.replaceForGuest(guest.id, event.id, [
+      SLOT_A,
+      SLOT_B,
+    ]);
+
+    await meetingAvailability.replaceForGuest(guest.id, event.id, [SLOT_C]);
+
+    expect(
+      await meetingAvailability.listByGuestAndEvent(guest.id, event.id)
+    ).toEqual([SLOT_C]);
+  });
+
+  it("treats a guest with no declared slots as not bookable", async () => {
+    const { meetingAvailability } = getRepositories();
+    const event = await createEvent();
+    const guest = await createGuest({ eventId: event.id });
+
+    expect(
+      await meetingAvailability.listByGuestAndEvent(guest.id, event.id)
+    ).toEqual([]);
+  });
+
+  it("keeps one guest's availability out of another's", async () => {
+    const { meetingAvailability } = getRepositories();
+    const event = await createEvent();
+    const [one, two] = [
+      await createGuest({ eventId: event.id }),
+      await createGuest({ eventId: event.id }),
+    ];
+    await meetingAvailability.replaceForGuest(one.id, event.id, [SLOT_A]);
+
+    expect(
+      await meetingAvailability.listByGuestAndEvent(two.id, event.id)
+    ).toEqual([]);
+  });
+});
+
+describe("meetings", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  async function pair() {
+    const event = await createEvent();
+    const requester = await createGuest({ eventId: event.id });
+    const recipient = await createGuest({ eventId: event.id });
+    return { event, requester, recipient };
+  }
+
+  it("creates a request as pending, with no response recorded yet", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+
+    const meeting = await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "Would love to talk about the attendance model.",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+
+    expect(meeting.status).toBe("pending");
+    expect(meeting.respondedAt).toBeUndefined();
+    expect(meeting.meetingPoint).toBe("Coffee bar");
+  });
+
+  it("lists a guest's meetings in both directions", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+    await meetings.create({
+      eventId: event.id,
+      requesterId: recipient.id,
+      recipientId: requester.id,
+      slotStart: SLOT_B,
+      slotEnd: SLOT_C,
+      meetingPoint: "Lawn",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+
+    const mine = await meetings.listByGuestAndEvent(requester.id, event.id);
+    expect(mine).toHaveLength(2);
+    expect(mine.map((m) => m.slotStart)).toEqual([SLOT_A, SLOT_B]);
+  });
+
+  it("records who answered and when, on accept", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    const meeting = await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+    const respondedAt = new Date("2026-09-01T09:00:00.000Z");
+
+    const accepted = await meetings.updateStatus(
+      meeting.id,
+      "accepted",
+      respondedAt,
+      ["pending"]
+    );
+
+    expect(accepted?.status).toBe("accepted");
+    expect(accepted?.respondedAt).toEqual(respondedAt);
+  });
+
+  it("counts only a requester's still-open requests, for the cap", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    const other = await createGuest({ eventId: event.id });
+
+    const open = await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+    const answered = await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: other.id,
+      slotStart: SLOT_B,
+      slotEnd: SLOT_C,
+      meetingPoint: "Lawn",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+    await meetings.updateStatus(answered.id, "declined", new Date(), [
+      "pending",
+    ]);
+    // Someone else's pending request must not count against this requester.
+    await meetings.create({
+      eventId: event.id,
+      requesterId: other.id,
+      recipientId: requester.id,
+      slotStart: SLOT_B,
+      slotEnd: SLOT_C,
+      meetingPoint: "Lawn",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+
+    expect(
+      await meetings.countOpenByRequester(requester.id, event.id, BEFORE_SLOTS)
+    ).toBe(1);
+    expect(open.status).toBe("pending");
+  });
+
+  // A request whose slot has passed is expired by definition (it is never
+  // stored as a status), so it is not "outstanding" and must not hold a slot
+  // in the requester's cap for the rest of the event.
+  it("stops counting a pending request once its slot has passed", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+
+    expect(
+      await meetings.countOpenByRequester(requester.id, event.id, BEFORE_SLOTS)
+    ).toBe(1);
+    expect(
+      await meetings.countOpenByRequester(requester.id, event.id, AFTER_SLOTS)
+    ).toBe(0);
+  });
+
+  it("refuses a status change from a state the caller did not expect", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    const meeting = await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+    await meetings.updateStatus(meeting.id, "canceled", new Date(), [
+      "pending",
+    ]);
+
+    // The recipient's accept, in flight while the requester cancelled.
+    const accepted = await meetings.updateStatus(
+      meeting.id,
+      "accepted",
+      new Date(),
+      ["pending"]
+    );
+
+    expect(accepted).toBeUndefined();
+    expect((await meetings.findById(meeting.id))?.status).toBe("canceled");
+  });
+
+  // The cap check and the insert have to be one step: two awaits leave a
+  // window where a double submit puts the requester over the cap.
+  it("creates under the cap and refuses at it, in one step", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    const request = (slotStart: Date, slotEnd: Date) => ({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart,
+      slotEnd,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+
+    const first = await meetings.createIfUnderCap(
+      request(SLOT_A, SLOT_B),
+      1,
+      BEFORE_SLOTS
+    );
+    const second = await meetings.createIfUnderCap(
+      request(SLOT_B, SLOT_C),
+      1,
+      BEFORE_SLOTS
+    );
+
+    expect(first?.status).toBe("pending");
+    expect(second).toBeNull();
+    expect(
+      await meetings.listByGuestAndEvent(requester.id, event.id)
+    ).toHaveLength(1);
+  });
+
+  it("counts only unanswered requests against the cap it enforces", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    const request = (slotStart: Date, slotEnd: Date) => ({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart,
+      slotEnd,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+    const first = await meetings.createIfUnderCap(
+      request(SLOT_A, SLOT_B),
+      1,
+      BEFORE_SLOTS
+    );
+    await meetings.updateStatus(first!.id, "declined", new Date(), ["pending"]);
+
+    const second = await meetings.createIfUnderCap(
+      request(SLOT_B, SLOT_C),
+      1,
+      BEFORE_SLOTS
+    );
+
+    expect(second?.status).toBe("pending");
+  });
+
+  // Asking the same person twice for the same slot is a double submit, not a
+  // second option: two identical requests they would have to answer separately.
+  it("rejects a second request to the same person for the same slot", async () => {
+    const { meetings } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    const request = {
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    };
+    await meetings.create(request);
+
+    await expect(meetings.create(request)).rejects.toThrow();
+  });
+
+  it("drops a guest's meetings when the guest goes", async () => {
+    const { meetings, guests } = getRepositories();
+    const { event, requester, recipient } = await pair();
+    await meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_A,
+      slotEnd: SLOT_B,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date("2026-09-01T08:00:00.000Z"),
+    });
+
+    await guests.delete(recipient.id);
+
+    expect(await meetings.listByGuestAndEvent(requester.id, event.id)).toEqual(
+      []
+    );
+  });
+});
+
+describe("meeting email settings", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  // The schema's column defaults and DEFAULT_EMAIL_SETTINGS declare the same
+  // thing in two places; this is where they are compared, for every key rather
+  // than only the two added here.
+  it("gives a new guest exactly the documented defaults", async () => {
+    const { guests } = getRepositories();
+    const guest = await createGuest();
+
+    const reloaded = await guests.findById(guest.id);
+    expect(reloaded?.info.emailSettings).toEqual(DEFAULT_EMAIL_SETTINGS);
+  });
+
+  it("defaults both meeting emails to on", async () => {
+    const { guests } = getRepositories();
+    const guest = await createGuest();
+
+    const reloaded = await guests.findById(guest.id);
+    expect(reloaded?.info.emailSettings.meetingRequest).toBe(true);
+    expect(reloaded?.info.emailSettings.meetingResponse).toBe(true);
+  });
+
+  it("round-trips a guest switching meeting emails off", async () => {
+    const { guests } = getRepositories();
+    const guest = await createGuest({
+      emailSettings: { meetingRequest: false },
+    });
+
+    const reloaded = await guests.findById(guest.id);
+    expect(reloaded?.info.emailSettings.meetingRequest).toBe(false);
+    expect(reloaded?.info.emailSettings.meetingResponse).toBe(true);
+  });
+});

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -29,6 +29,7 @@ import { siteAuthenticate } from "../helpers/site-auth";
 import { createGuest } from "../helpers/factories";
 import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
 import { getRepositories } from "@/db/container";
+import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
 import { updateProfileAction } from "@/app/actions/profile";
 import { createImageFile } from "@/tests/helpers/utils";
 import fs from "fs";
@@ -67,13 +68,10 @@ describe("updateProfileAction", () => {
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
     expect(updated?.info.emailSettings).toEqual({
+      ...DEFAULT_EMAIL_SETTINGS,
       rsvpChange: false,
       hostChange: false,
       cohostAdd: true,
-      proposalComment: true,
-      sessionComment: true,
-      profileComment: true,
-      commentThread: false,
     });
   });
 

--- a/tests/integration/settings-action.test.ts
+++ b/tests/integration/settings-action.test.ts
@@ -32,7 +32,7 @@ describe("updateEmailSettingsAction", () => {
   it("updates the current user's email settings", async () => {
     const guest = await createGuest({ name: "Guest" });
     cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
-    const result = await updateEmailSettingsAction({
+    const settings = {
       rsvpChange: false,
       hostChange: false,
       cohostAdd: true,
@@ -40,18 +40,13 @@ describe("updateEmailSettingsAction", () => {
       sessionComment: false,
       profileComment: true,
       commentThread: true,
-    });
+      meetingRequest: false,
+      meetingResponse: true,
+    };
+    const result = await updateEmailSettingsAction(settings);
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
-    expect(updated?.info.emailSettings).toEqual({
-      rsvpChange: false,
-      hostChange: false,
-      cohostAdd: true,
-      proposalComment: false,
-      sessionComment: false,
-      profileComment: true,
-      commentThread: true,
-    });
+    expect(updated?.info.emailSettings).toEqual(settings);
   });
 
   it("fails when no user is selected", async () => {
@@ -64,6 +59,8 @@ describe("updateEmailSettingsAction", () => {
       sessionComment: false,
       profileComment: false,
       commentThread: false,
+      meetingRequest: false,
+      meetingResponse: false,
     });
     expect(result).toEqual({ ok: false, error: "No user is logged in" });
     const unchanged = await getRepositories().guests.findById(guest.id);

--- a/tests/integration/user-auth-enforcement.test.ts
+++ b/tests/integration/user-auth-enforcement.test.ts
@@ -282,6 +282,8 @@ describe("write enforcement for protected guests", () => {
         sessionComment: false,
         profileComment: false,
         commentThread: false,
+        meetingRequest: false,
+        meetingResponse: false,
       });
       expect(settingsResult.ok).toBe(false);
     });

--- a/tests/unit/event-phases.test.ts
+++ b/tests/unit/event-phases.test.ts
@@ -25,6 +25,9 @@ function makeEvent(overrides: Partial<Event>): Event {
     slotIncrementMinutes: 30,
     timezone: "UTC",
     rsvpCapacityHardLimit: false,
+    meetingsEnabled: false,
+    meetingSlotMinutes: 30,
+    maxOpenMeetingRequests: 5,
     ...overrides,
   };
 }


### PR DESCRIPTION
First of six planned PRs for schellingboard/schellingboard#392 (1-on-1 meetings between attendees), following
the design proposed in [this comment](https://github.com/LWCW-Europe/schellingboard/issues/392#issuecomment-5470900325).

The design has since been discussed and approved on schellingboard/schellingboard#392, and revised to fold that
discussion in: busy slots stay bookable with a warning, the request cap counts what
you send rather than what you receive, the grid column stays visible in kiosk mode,
and notifications go through schellingboard/schellingboard#750. None of the four touches the schema — they land
in the action and UI layers of PRs 3-6 — so this PR stands as opened. Ready for
review.

## What's here

Schema and repositories only — **nothing is reachable in the app**. No routes, no
UI, no server actions.

- `meeting_points` — the organizer's suggested places to meet
- `meeting_availability` — the slots an attendee declared themselves free for
- `meetings` — the requests, with their status
- Five columns on `events` (meetings on/off, slot length, optional meeting-hours
  window, the open-request cap) and two email toggles on `guests`
- Migration `0029_meetings.sql`, purely additive

## Decisions worth a reviewer's attention

**Slots are derived, not stored.** There is no `meeting_slots` table: slots come
from an event's days and `meetingSlotMinutes`, the same way the schedule grid
derives its rows. Availability rows therefore key on the slot's start instant, so
narrowing the meeting hours later just stops offering the rows that fall outside
— nothing to regenerate when a day moves, which the days manager's edit and
delete cascades would otherwise force.

**`expired` is not a stored status.** Stored states are `pending`, `accepted`,
`declined`, `cancelled`. A pending request whose slot has passed is expired by
definition, so deriving it on read avoids needing a scheduler the app doesn't
have.

**A meeting's place is free text, not a `meeting_points` FK.** The requester may
type their own, and what a pair agreed on shouldn't change under them when the
organizer renames or removes a suggestion. `meeting_points` is a preset list
feeding the picker, nothing more.

**Meeting points are their own table, not a flag on `locations`.** They are never
booked and never a grid column, so they need none of `capacity`, `bookable`,
`hidden`, `sortIndex` or the `event_locations`/`session_locations` joins — and it
keeps them out of the flag set schellingboard/schellingboard#855 is trying to shrink.

## Two changes outside the new code

- **`events.create` now reads the row back** instead of returning its input. The
  meeting settings are configured from the admin Meetings section after the event
  exists, so they're optional at creation; returning the input would hand callers
  `undefined` where the schema supplied a default. This affects every event
  creation path.
- **`ParsedEvent` in `app/actions/admin-events.ts` excludes the meeting
  settings**, for exactly the reason the phase dates are already excluded —
  otherwise every basic-info save would reset them.

`emailSettingsSchema` also had to gain the two new keys, since it's the declared
mirror of `EmailSettings`. The settings form submits all stored keys from its
`defaultValues`, so the two round-trip invisibly for now; the actual checkboxes
belong with the emails, in PR 5.

## Deliberately left to later PRs

The repositories are thin, as elsewhere in `db/repositories/`. They don't guard
state transitions (nothing stops `updateStatus` moving an accepted meeting back
to pending) and don't reject a self-booking. Those are action-layer rules and
land with the actions that need them — accept in particular has to re-check both
parties for clashes transactionally.

`countOpenByRequester` counts every `pending` row, including requests whose slot has
already passed and which are therefore expired by the rule above. Applying that
derivation to the cap belongs with the action that enforces it in PR 4 — either by
filtering there, or by the method taking the current instant the way `create` takes
`createdAt`. Counting an expired request against the cap would lock someone out for
the rest of the event, and the cap is the feature's only limiter.

Nothing seeds meeting data yet either; PR 2 and PR 3 will want that to develop
against.

## Testing

18 integration tests in `tests/integration/meetings-repositories.test.ts`, written
first and confirmed failing before implementation. `make precommit` is green:
1615 unit + integration tests, 146 E2E. The release-upgrade tests exercised the
migration against every stored release's seeded database.

Three existing tests pinned the email settings as literals and broke on the two
new ones. Two of them are asserting *the defaults*, so I rewrote them against
`DEFAULT_EMAIL_SETTINGS` rather than extending the literal — they'd have broken
again on the next setting added.

## Note on authorship

Written with Claude Code, and self-reviewed before opening — that pass caught one
real divergence: `create` originally generated `createdAt` itself, where
`comments` takes the instant from the caller. It now matches, which also keeps
the dev fake clock usable. Reviewer attention is most valuable on the
`events.create` read-back, since it touches every event creation path.

issue schellingboard/schellingboard#392

