### PR TITLE
fix: keep the name chip reachable as an event list grows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   "Notifications" got a web address the site's own page of that name already answers, so the event
   could never be opened. Creating one now fails with the same message other reserved names give
 
+### Fixed
+
+- **Picking your name works however many events a site runs**: the header lists every event, and
+  from about seven onwards the links crowded the name chip beside them off the row, leaving no way
+  to say who you are. The links now scroll instead of pushing
+
 ### Internal
 
 - The first room photo on the schedule grid is loaded eagerly. It sits above the fold and is usually

--- a/app/(site)/nav-bar.tsx
+++ b/app/(site)/nav-bar.tsx
@@ -56,10 +56,13 @@ export default function NavBar({
                 </Disclosure.Button>
               </div>
               <div className="flex justify-between w-full items-center">
-                <div className="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
+                {/* min-w-0 + a scrolling row: a site with enough events would
+                    otherwise let the links push the name chip beside them out
+                    of reach, since a flex row does not wrap. */}
+                <div className="flex min-w-0 flex-1 items-center justify-center sm:items-stretch sm:justify-start">
                   {/* Desktop nav */}
-                  <div className="hidden sm:block">
-                    <div className="flex space-x-4">
+                  <div className="hidden min-w-0 sm:block">
+                    <div className="flex space-x-4 overflow-x-auto">
                       {navItems.map((item) => (
                         <NavBarItem
                           key={item.name}
@@ -70,7 +73,7 @@ export default function NavBar({
                     </div>
                   </div>
                 </div>
-                <div className="flex min-w-0 items-center gap-3">
+                <div className="flex shrink-0 items-center gap-3">
                   {showGuestsLink && (
                     <Link
                       href="/guests"

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -42,6 +42,7 @@ export const releaseNotes: ReleaseNote[] = [
     highlights: [
       "**Notifications in the app**: a bell in the header counts what is waiting, and clicking one takes you to it. Everything that emails you appears here too, even where email is not set up.",
       "**Meetings**: an event's Config tab can switch on 1-on-1s between attendees — the places you suggest people meet, and a cap on how many unanswered requests one person may have out.",
+      "**Picking your name** works however many events a site runs: past about seven, the header's event links crowded the name chip off the row and there was no way to say who you are.",
     ],
   },
   {


### PR DESCRIPTION
The site header renders a link per event, in a flex row that does not wrap, beside
the name chip in a container free to shrink to nothing. Past about **seven events**
the links push the chip out of the row: still in the DOM, still reported visible by
every check a test makes, and impossible to click — so on such a site nobody can say
who they are, on any page. Everything gated on having picked a name (RSVPs, voting,
proposing, commenting) is then unreachable.

The links now scroll rather than push, and the chip's container no longer shrinks.

## How it turned up

Chasing an E2E suite that passed for its first half and then failed from the middle
onwards, always inside `openNameSwitcher`. The suite creates events as it goes and
was sitting just under the threshold, so the next spec to add one tipped every later
test that picks a name into a 30-second timeout — while the page snapshots looked
perfectly healthy, because the chip really was still there.

A probe that does nothing but create N events and then pick a name:

| events created (+3 seeded) | before | after |
| --- | --- | --- |
| 0, 3 | pass | pass |
| 4, 5, 6 | **fail** | pass |
| 12 | — | pass |

## Testing

`make precommit` is green. Worth noting one flake seen on an earlier run of this
branch — `scheduling.spec.ts:75` failed once and passed on a re-run of the whole
suite and 3/3 in isolation; it is unrelated to this change, which touches only
header layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
