### PR TITLE
feat: attendee meeting availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   1-on-1 meetings on, list the places you suggest people meet, and cap how many unanswered requests
   one attendee may have outstanding at a time. Meeting slots follow the event's schedule increment,
   so changing that asks attendees to choose their availability again
+- **Say when you're free to meet**: with meetings switched on, the schedule toolbar gains a
+  **1-on-1s** link where attendees turn on "I'm open to 1-on-1 meetings at this event" and clear the
+  slots they want kept free. Turning it on marks every slot free, and turning it back off clears the
+  lot — nobody can book you while it's off
 
 ### Fixed
 

--- a/app/(site)/[eventSlug]/meetings/availability-form.tsx
+++ b/app/(site)/[eventSlug]/meetings/availability-form.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { saveMeetingAvailabilityAction } from "@/app/actions/meetings";
+
+export type SlotDay = {
+  label: string;
+  slots: { start: string; label: string }[];
+};
+
+const BUTTON =
+  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+const QUIET_BUTTON =
+  "px-2 py-1 text-sm rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors";
+
+export function AvailabilityForm({
+  eventId,
+  eventName,
+  timezone,
+  days,
+  declared,
+}: {
+  eventId: string;
+  eventName: string;
+  timezone: string;
+  days: SlotDay[];
+  declared: string[];
+}) {
+  // No rows means not bookable, which is also the state of someone who never
+  // turned the switch on -- so the switch is simply "did you declare anything".
+  const [open, setOpen] = useState(declared.length > 0);
+  const [selected, setSelected] = useState<Set<string>>(new Set(declared));
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [isSaving, startSave] = useTransition();
+
+  const allSlots = days.flatMap((day) => day.slots.map((s) => s.start));
+
+  const change = (next: Set<string>) => {
+    setSaved(false);
+    setSelected(next);
+  };
+
+  const toggleOpen = (checked: boolean) => {
+    setSaved(false);
+    setOpen(checked);
+    // Switching it on marks every slot available -- you then clear the ones
+    // you want kept free, rather than building the set up from nothing.
+    if (checked && selected.size === 0) setSelected(new Set(allSlots));
+  };
+
+  const toggleSlot = (start: string) => {
+    const next = new Set(selected);
+    if (next.has(start)) next.delete(start);
+    else next.add(start);
+    change(next);
+  };
+
+  const setDay = (day: SlotDay, on: boolean) => {
+    const next = new Set(selected);
+    for (const slot of day.slots) {
+      if (on) next.add(slot.start);
+      else next.delete(slot.start);
+    }
+    change(next);
+  };
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    startSave(async () => {
+      try {
+        const result = await saveMeetingAvailabilityAction({
+          eventId,
+          // Switched off is an empty set: it is the opt-out control, so it
+          // must clear the declaration rather than just hide it.
+          slotStarts: open ? [...selected] : [],
+        });
+        if (!result.ok) setError(result.error);
+        else setSaved(true);
+      } catch {
+        setError("Request failed");
+      }
+    });
+  };
+
+  return (
+    <form
+      onSubmit={handleSave}
+      aria-label="1-on-1 meetings"
+      className="max-w-2xl mx-auto w-full px-4 sm:px-0 flex flex-col gap-6 py-8"
+    >
+      <div>
+        <h1 className="text-3xl font-bold text-fg">1-on-1 meetings</h1>
+        <p className="text-fg-muted mt-2">{eventName}</p>
+      </div>
+
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
+
+      <div className="rounded-md border border-line-subtle p-4">
+        <div className="flex items-start gap-2">
+          <input
+            id="meetings-open"
+            type="checkbox"
+            checked={open}
+            onChange={(e) => toggleOpen(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-line text-brand-fg focus:ring-brand-accent"
+          />
+          <div>
+            <label htmlFor="meetings-open" className="font-medium text-fg">
+              I&apos;m open to 1-on-1 meetings at this event
+            </label>
+            <p className="text-sm text-fg-subtle">
+              While this is off, nobody can book you and you won&apos;t appear
+              as bookable.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {open && (
+        <>
+          <p className="text-sm text-fg-subtle rounded-md bg-surface-sunken p-3">
+            Clear the slots you want kept free. You don&apos;t need to clear the
+            ones where you&apos;re hosting or have RSVP&apos;d to — anyone
+            booking you is warned about those. Times are in the event timezone (
+            {timezone}).
+          </p>
+
+          {days.length === 0 && (
+            <p className="text-fg-muted">
+              The organizer hasn&apos;t set up any days with meeting slots yet.
+            </p>
+          )}
+
+          {days.map((day) => (
+            <section key={day.label} aria-label={day.label}>
+              <div className="flex items-center justify-between gap-3 mb-1">
+                <h2 className="text-lg font-semibold text-fg">{day.label}</h2>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setDay(day, true)}
+                    aria-label={`Select all slots on ${day.label}`}
+                    className={QUIET_BUTTON}
+                  >
+                    Select all
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDay(day, false)}
+                    aria-label={`Clear all slots on ${day.label}`}
+                    className={QUIET_BUTTON}
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+              <ul className="divide-y divide-line-subtle border-t border-line-subtle">
+                {day.slots.map((slot) => (
+                  <li key={slot.start}>
+                    <label className="flex items-center gap-3 py-3 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(slot.start)}
+                        onChange={() => toggleSlot(slot.start)}
+                        className="h-4 w-4 rounded border-line text-brand-fg focus:ring-brand-accent"
+                      />
+                      <span className="text-fg">{slot.label}</span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </>
+      )}
+
+      <div className="flex items-center justify-end gap-3">
+        {saved && <span className="text-sm text-success-fg">Saved!</span>}
+        <button type="submit" disabled={isSaving} className={BUTTON}>
+          {isSaving ? "Saving..." : "Save availability"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(site)/[eventSlug]/meetings/availability-form.tsx
+++ b/app/(site)/[eventSlug]/meetings/availability-form.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { BackLink } from "@/app/components/back-link";
 import { saveMeetingAvailabilityAction } from "@/app/actions/meetings";
 
 export type SlotDay = {
+  /** Two days may share a date, so the id is what keys them apart. */
+  id: string;
   label: string;
   slots: { start: string; label: string }[];
 };
@@ -15,12 +18,14 @@ const QUIET_BUTTON =
 
 export function AvailabilityForm({
   eventId,
+  eventSlug,
   eventName,
   timezone,
   days,
   declared,
 }: {
   eventId: string;
+  eventSlug: string;
   eventName: string;
   timezone: string;
   days: SlotDay[];
@@ -35,6 +40,9 @@ export function AvailabilityForm({
   const [isSaving, startSave] = useTransition();
 
   const allSlots = days.flatMap((day) => day.slots.map((s) => s.start));
+  // Saving this would store nothing, and nothing reads back as "not open" --
+  // so the switch would silently flip itself off. Say so instead.
+  const emptyWhileOpen = open && selected.size === 0;
 
   const change = (next: Set<string>) => {
     setSaved(false);
@@ -90,6 +98,7 @@ export function AvailabilityForm({
       aria-label="1-on-1 meetings"
       className="max-w-2xl mx-auto w-full px-4 sm:px-0 flex flex-col gap-6 py-8"
     >
+      <BackLink href={`/${eventSlug}`}>Schedule</BackLink>
       <div>
         <h1 className="text-3xl font-bold text-fg">1-on-1 meetings</h1>
         <p className="text-fg-muted mt-2">{eventName}</p>
@@ -134,7 +143,7 @@ export function AvailabilityForm({
           )}
 
           {days.map((day) => (
-            <section key={day.label} aria-label={day.label}>
+            <section key={day.id} aria-label={day.label}>
               <div className="flex items-center justify-between gap-3 mb-1">
                 <h2 className="text-lg font-semibold text-fg">{day.label}</h2>
                 <div className="flex gap-2">
@@ -177,8 +186,17 @@ export function AvailabilityForm({
       )}
 
       <div className="flex items-center justify-end gap-3">
+        {emptyWhileOpen && (
+          <span className="text-sm text-fg-subtle">
+            Clearing every slot is the same as switching this off.
+          </span>
+        )}
         {saved && <span className="text-sm text-success-fg">Saved!</span>}
-        <button type="submit" disabled={isSaving} className={BUTTON}>
+        <button
+          type="submit"
+          disabled={isSaving || emptyWhileOpen}
+          className={BUTTON}
+        >
           {isSaving ? "Saving..." : "Save availability"}
         </button>
       </div>

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -58,11 +58,24 @@ export default async function MeetingsPage({
   const zoned = (date: Date) =>
     DateTime.fromJSDate(date).setZone(event.timezone);
 
+  // Days only have to not overlap, so an event may legitimately run 09:00-12:00
+  // and 14:00-18:00 on one date: the date alone is not a unique heading, and
+  // the window disambiguates the ones that repeat.
+  const dateCounts = new Map<string, number>();
+  for (const day of days) {
+    const date = zoned(day.start).toFormat("EEE d LLL");
+    dateCounts.set(date, (dateCounts.get(date) ?? 0) + 1);
+  }
+
   const slotDays: SlotDay[] = days
     .map((day) => ({
-      // The day's own date, so two days of the same event never share a
-      // heading even when one runs past midnight into the next.
-      label: zoned(day.start).toFormat("EEE d LLL"),
+      id: day.id,
+      label:
+        (dateCounts.get(zoned(day.start).toFormat("EEE d LLL")) ?? 0) > 1
+          ? `${zoned(day.start).toFormat("EEE d LLL")}, ${zoned(
+              day.start
+            ).toFormat("HH:mm")}–${zoned(day.end).toFormat("HH:mm")}`
+          : zoned(day.start).toFormat("EEE d LLL"),
       slots: meetingSlotsForDay(day, event.slotIncrementMinutes).map(
         (slot) => ({
           start: slot.start.toISOString(),
@@ -74,13 +87,22 @@ export default async function MeetingsPage({
     }))
     .filter((day) => day.slots.length > 0);
 
+  // Only what the event still offers. A day shortened or deleted after someone
+  // declared leaves rows for slots the form no longer renders, and the save
+  // action refuses any it isn't offering -- so passing them through would leave
+  // the guest with a form that cannot be saved and nothing to untick.
+  const offered = new Set(slotDays.flatMap((d) => d.slots.map((s) => s.start)));
+
   return (
     <AvailabilityForm
       eventId={event.id}
+      eventSlug={eventSlug}
       eventName={event.name}
       timezone={event.timezone}
       days={slotDays}
-      declared={declared.map((d) => d.toISOString())}
+      declared={declared
+        .map((d) => d.toISOString())
+        .filter((start) => offered.has(start))}
     />
   );
 }

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -1,0 +1,86 @@
+import { cookies } from "next/headers";
+import { notFound } from "next/navigation";
+import { DateTime } from "luxon";
+import { PageNotice } from "@/app/components/page-notice";
+import { getRepositories } from "@/db/container";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
+import { meetingSlotsForDay } from "@/utils/meeting-slots";
+import { AvailabilityForm, type SlotDay } from "./availability-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function MeetingsPage({
+  params,
+}: {
+  params: Promise<{ eventSlug: string }>;
+}) {
+  const { eventSlug } = await params;
+  const repos = getRepositories();
+  const event = await repos.events.findBySlug(eventSlug);
+
+  // The page only exists while the organizer offers meetings; the toolbar
+  // link is hidden then too, so this catches a stale link or a typed URL.
+  if (!event || !event.meetingsEnabled) notFound();
+
+  const cookieStore = await cookies();
+  const currentUser = await verifiedCurrentUser(cookieStore);
+  if (!currentUser) {
+    return (
+      <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
+        {await unverifiedUserMessage(
+          cookieStore,
+          "setting your meeting availability"
+        )}
+      </PageNotice>
+    );
+  }
+
+  // The save action refuses a non-attendee anyway; checking here too means
+  // they are told before filling the form in rather than after.
+  const attending = await repos.guests.listEventsByGuests([currentUser]);
+  if (!attending.get(currentUser)?.some((e) => e.id === event.id)) {
+    return (
+      <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
+        You&apos;re not on the guest list for {event.name}, so you can&apos;t
+        set meeting availability here. Ask the organizer to add you.
+      </PageNotice>
+    );
+  }
+
+  const [days, declared] = await Promise.all([
+    repos.days.listByEvent(event.id),
+    repos.meetingAvailability.listByGuestAndEvent(currentUser, event.id),
+  ]);
+
+  const zoned = (date: Date) =>
+    DateTime.fromJSDate(date).setZone(event.timezone);
+
+  const slotDays: SlotDay[] = days
+    .map((day) => ({
+      // The day's own date, so two days of the same event never share a
+      // heading even when one runs past midnight into the next.
+      label: zoned(day.start).toFormat("EEE d LLL"),
+      slots: meetingSlotsForDay(day, event.slotIncrementMinutes).map(
+        (slot) => ({
+          start: slot.start.toISOString(),
+          label: `${zoned(slot.start).toFormat("HH:mm")} – ${zoned(
+            slot.end
+          ).toFormat("HH:mm")}`,
+        })
+      ),
+    }))
+    .filter((day) => day.slots.length > 0);
+
+  return (
+    <AvailabilityForm
+      eventId={event.id}
+      eventName={event.name}
+      timezone={event.timezone}
+      days={slotDays}
+      declared={declared.map((d) => d.toISOString())}
+    />
+  );
+}

--- a/app/(site)/[eventSlug]/schedule-toolbar.tsx
+++ b/app/(site)/[eventSlug]/schedule-toolbar.tsx
@@ -10,6 +10,7 @@ import {
   InformationCircleIcon,
   LinkIcon,
   TableCellsIcon,
+  UserGroupIcon,
 } from "@heroicons/react/24/outline";
 import { DateTime } from "luxon";
 import Link from "next/link";
@@ -50,6 +51,15 @@ export function ScheduleToolbar(props: { event: Event }) {
             >
               <ClipboardDocumentListIcon className="h-4 w-4 stroke-2" />
               Proposals
+            </Link>
+          )}
+          {event.meetingsEnabled && (
+            <Link
+              href={`/${event.slug}/meetings`}
+              className="flex items-center gap-1 rounded-md py-1.5 px-1 text-xs sm:text-sm text-fg-subtle hover:text-brand-fg focus:outline-none focus:ring-2 focus:ring-brand-accent"
+            >
+              <UserGroupIcon className="h-4 w-4 stroke-2" />
+              1-on-1s
             </Link>
           )}
         </div>

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -58,6 +58,12 @@ export function SettingsForm({
         </Link>{" "}
         is edited separately.
       </p>
+      {/* Availability is per-event, so it cannot live here -- but this is
+          where people look for it first. */}
+      <p className="text-sm text-fg-subtle">
+        Setting when you&apos;re free for 1-on-1 meetings is per event: open the
+        event and use its <strong>1-on-1s</strong> link.
+      </p>
 
       <form
         onSubmit={(e) => form.handleSubmit(handleSubmit)(e) as never}

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
+import { requireSiteAuth } from "@/utils/action-auth";
+import { meetingSlotsForDay } from "@/utils/meeting-slots";
+import type { Event } from "@/db/repositories/interfaces";
+
+export type MeetingActionResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Every slot start the event offers, as ISO strings. Deliberately not
+ * exported: an export from a "use server" module is a client-callable
+ * endpoint, and this is a helper.
+ */
+async function eventSlotStarts(event: Event): Promise<Set<string>> {
+  const days = await getRepositories().days.listByEvent(event.id);
+  return new Set(
+    days.flatMap((day) =>
+      meetingSlotsForDay(day, event.slotIncrementMinutes).map((slot) =>
+        slot.start.toISOString()
+      )
+    )
+  );
+}
+
+export async function saveMeetingAvailabilityAction(input: {
+  eventId: string;
+  slotStarts: string[];
+}): Promise<MeetingActionResult> {
+  await requireSiteAuth();
+
+  // Site auth is shared with every attendee, so it cannot be the gate on
+  // writing one guest's own availability.
+  const guestId = await verifiedCurrentUser(await cookies());
+  if (!guestId) {
+    return { ok: false, error: "Sign in to set your availability" };
+  }
+
+  const repos = getRepositories();
+  const event = await repos.events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+  if (!event.meetingsEnabled) {
+    return { ok: false, error: "Meetings are not enabled for this event" };
+  }
+
+  const attending = await repos.guests.listEventsByGuests([guestId]);
+  if (!attending.get(guestId)?.some((e) => e.id === event.id)) {
+    return { ok: false, error: "You are not attending this event" };
+  }
+
+  // Slots are derived, so the submitted starts are checked against the ones
+  // the event actually offers: a hand-made payload must not be able to declare
+  // a guest free at an instant that is not a slot at all.
+  const offered = await eventSlotStarts(event);
+  const declared = [...new Set(input.slotStarts)];
+  if (declared.some((slot) => !offered.has(slot))) {
+    return { ok: false, error: "Those slots are no longer available" };
+  }
+
+  await repos.meetingAvailability.replaceForGuest(
+    guestId,
+    event.id,
+    declared.map((slot) => new Date(slot))
+  );
+
+  revalidatePath(`/${event.slug}/meetings`);
+  return { ok: true };
+}

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -1,9 +1,13 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { verifiedCurrentUser } from "@/utils/acting-guest";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
 import { requireSiteAuth } from "@/utils/action-auth";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
 import type { Event } from "@/db/repositories/interfaces";
@@ -26,17 +30,37 @@ async function eventSlotStarts(event: Event): Promise<Set<string>> {
   );
 }
 
-export async function saveMeetingAvailabilityAction(input: {
-  eventId: string;
-  slotStarts: string[];
-}): Promise<MeetingActionResult> {
+// A "use server" export is a public endpoint behind site auth, so the types
+// above it are advisory: the payload is parsed rather than trusted, and a
+// malformed one comes back as a result instead of throwing.
+const availabilitySchema = z.object({
+  eventId: z.string(),
+  slotStarts: z.array(z.string()),
+});
+
+export async function saveMeetingAvailabilityAction(
+  raw: z.input<typeof availabilitySchema>
+): Promise<MeetingActionResult> {
   await requireSiteAuth();
+
+  const parsed = availabilitySchema.safeParse(raw);
+  if (!parsed.success) return { ok: false, error: "Invalid request" };
+  const input = parsed.data;
 
   // Site auth is shared with every attendee, so it cannot be the gate on
   // writing one guest's own availability.
-  const guestId = await verifiedCurrentUser(await cookies());
+  const cookieStore = await cookies();
+  const guestId = await verifiedCurrentUser(cookieStore);
   if (!guestId) {
-    return { ok: false, error: "Sign in to set your availability" };
+    // Shared with the page, so the copy can't drift -- and so a protected name
+    // selected without verifying is told to switch to it, not to "sign in".
+    return {
+      ok: false,
+      error: await unverifiedUserMessage(
+        cookieStore,
+        "setting your meeting availability"
+      ),
+    };
   }
 
   const repos = getRepositories();

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -43,6 +43,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Notifications in the app**: a bell in the header counts what is waiting, and clicking one takes you to it. Everything that emails you appears here too, even where email is not set up.",
       "**Meetings**: an event's Config tab can switch on 1-on-1s between attendees — the places you suggest people meet, and a cap on how many unanswered requests one person may have out.",
       "**Picking your name** works however many events a site runs: past about seven, the header's event links crowded the name chip off the row and there was no way to say who you are.",
+      "**Say when you're free**: with meetings on, attendees get a 1-on-1s page to mark which slots they're open for. Turning the switch off clears it and keeps them unbookable.",
     ],
   },
   {

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -180,6 +180,32 @@ Open a session to find the same comment section proposals have — useful for
 "which room did this move to?" and other last-minute coordination. Everything works as described under
 [Discuss a proposal](#discuss-a-proposal): threaded replies, likes, editing and deleting your own comments.
 
+## 1-on-1 meetings
+
+When the organizer has switched meetings on for the event, the schedule toolbar
+gains a **1-on-1s** link. That page is where you say when you are free to meet
+people one to one.
+
+One switch controls the whole thing:
+
+> **I'm open to 1-on-1 meetings at this event**
+
+While it is off, nobody can book you and you don't appear as bookable — it is
+the opt-out, so turning it back off and saving clears what you declared.
+
+Switching it on marks **every** slot available. Below it, each day of the event
+is listed as plain checkboxes, with **Select all** and **Clear** per day; clear
+the ones you want kept free and press **Save availability**.
+
+You don't need to clear the slots where you're hosting a session or have RSVP'd
+to one — anyone trying to book you is warned about those anyway. Clearing a slot
+here is the firm "no"; a clash is only ever a warning. Times are shown in the
+event's timezone.
+
+Slots are as long as the event's schedule increment and cover the whole of each
+day. If the organizer later changes that increment, everyone's availability is
+cleared and you are asked to choose again — the slots themselves have moved.
+
 ## Attendee directory & profiles
 
 The directory lists everyone at the event on a single page — photo and the

--- a/tests/e2e/meetings-availability.spec.ts
+++ b/tests/e2e/meetings-availability.spec.ts
@@ -51,11 +51,14 @@ test.describe("attendee meeting availability", () => {
     await alice.click();
     await expect(alice).toBeChecked();
 
-    // Now as that attendee.
-    const slug = eventName.replace(/ /g, "-");
-    await loginAndGoto(page, `/${slug}/meetings`);
+    // Now as that attendee, reaching the page the way one would: the event in
+    // the header, then the toolbar's 1-on-1s link.
+    await loginAndGoto(page, "/guests");
     await selectUser(page, /Alice Test/i);
-    await page.goto(`/${slug}/meetings`);
+    await page.getByRole("link", { name: eventName }).click();
+    await page.getByRole("link", { name: "1-on-1s" }).click();
+    await expect(page).toHaveURL(/\/meetings$/);
+    const eventSlug = new URL(page.url()).pathname.split("/")[1];
 
     const form = page.getByRole("form", { name: "1-on-1 meetings" });
     await expect(form.getByLabel(/open to 1-on-1 meetings/)).not.toBeChecked();
@@ -81,6 +84,31 @@ test.describe("attendee meeting availability", () => {
     ).toBeChecked();
     // 09:00-11:00 in 30-minute slots.
     await expect(form.getByRole("listitem")).toHaveCount(4);
+
+    // A day the organizer later shortens drops slots the guest had declared.
+    // Those must not linger in the form's selection, or every later save is
+    // refused for slots it never renders and the guest cannot untick.
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+    // Scoped to Days: the event's own "End *" date sits on this page too.
+    const days = page.getByRole("region", { name: "Days" });
+    await days.getByRole("button", { name: /^Edit day / }).click();
+    await days.getByLabel("End *").fill("2026-10-01T10:00");
+    // The bookings window has to stay inside the day's own.
+    await days.getByLabel("Bookings close *").fill("2026-10-01T10:00");
+    await days.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(
+      page.getByText(/2026-10-01T09:00 – 2026-10-01T10:00/)
+    ).toBeVisible();
+
+    await page.goto(`/${eventSlug}/meetings`);
+    await expect(form.getByRole("listitem")).toHaveCount(2);
+    await form.getByRole("button", { name: "Save availability" }).click();
+    await expect(form.getByText("Saved!")).toBeVisible();
 
     // Opting back out clears the declaration entirely.
     await form.getByLabel(/open to 1-on-1 meetings/).uncheck();

--- a/tests/e2e/meetings-availability.spec.ts
+++ b/tests/e2e/meetings-availability.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
+import { loginAndGoto } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
+
+test.describe("attendee meeting availability", () => {
+  test("declares availability, clears a slot, and opts back out", async ({
+    page,
+  }) => {
+    const eventName = `E2E Availability ${uniqueSuffix()}`;
+
+    // A throwaway event of its own, so switching meetings on here can't change
+    // what the other specs see on the seeded ones.
+    await page.goto("/admin");
+    await page.getByLabel("Password").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Access Admin" }).click();
+    await page.getByRole("button", { name: "New event" }).click();
+    await page.getByLabel("Name *").fill(eventName);
+    await page.getByLabel("Start *").fill("2026-10-01");
+    await page.getByLabel("End *").fill("2026-10-03");
+    await page.getByRole("button", { name: "Create event" }).click();
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+
+    const meetings = page.getByRole("form", { name: "Meetings" });
+    await meetings.getByLabel("Enable meetings").check();
+    await meetings.getByRole("button", { name: "Save meetings" }).click();
+    await expect(meetings.getByText("Saved!")).toBeVisible();
+
+    // One day, so the slot list is short and predictable.
+    await page.getByRole("button", { name: "Add day" }).click();
+    await page.getByLabel("Start *").last().fill("2026-10-01T09:00");
+    await page.getByLabel("End *").last().fill("2026-10-01T11:00");
+    await page.getByLabel("Bookings open *").fill("2026-10-01T09:00");
+    await page.getByLabel("Bookings close *").fill("2026-10-01T11:00");
+    await page.getByRole("button", { name: "Add day" }).last().click();
+    await expect(page.getByText("2026-10-01T09:00")).toBeVisible();
+
+    // Availability is only for people attending, so assign a seeded guest.
+    await page.getByRole("link", { name: "Guests" }).click();
+    const guests = page.getByRole("region", { name: "Guests" });
+    const alice = guests
+      .getByRole("row")
+      .filter({ hasText: "Alice Test" })
+      .getByRole("checkbox", { name: /^Assign / });
+    await alice.click();
+    await expect(alice).toBeChecked();
+
+    // Now as that attendee.
+    const slug = eventName.replace(/ /g, "-");
+    await loginAndGoto(page, `/${slug}/meetings`);
+    await selectUser(page, /Alice Test/i);
+    await page.goto(`/${slug}/meetings`);
+
+    const form = page.getByRole("form", { name: "1-on-1 meetings" });
+    await expect(form.getByLabel(/open to 1-on-1 meetings/)).not.toBeChecked();
+
+    // Switching it on marks every slot available; you clear what you want kept
+    // free rather than building the set up from nothing.
+    await form.getByLabel(/open to 1-on-1 meetings/).check();
+    await expect(form.getByText("09:00 – 09:30")).toBeVisible();
+    const firstSlot = form.getByRole("listitem").first().getByRole("checkbox");
+    await expect(firstSlot).toBeChecked();
+
+    await firstSlot.uncheck();
+    await form.getByRole("button", { name: "Save availability" }).click();
+    await expect(form.getByText("Saved!")).toBeVisible();
+
+    await page.reload();
+    await expect(form.getByLabel(/open to 1-on-1 meetings/)).toBeChecked();
+    await expect(
+      form.getByRole("listitem").first().getByRole("checkbox")
+    ).not.toBeChecked();
+    await expect(
+      form.getByRole("listitem").nth(1).getByRole("checkbox")
+    ).toBeChecked();
+    // 09:00-11:00 in 30-minute slots.
+    await expect(form.getByRole("listitem")).toHaveCount(4);
+
+    // Opting back out clears the declaration entirely.
+    await form.getByLabel(/open to 1-on-1 meetings/).uncheck();
+    await form.getByRole("button", { name: "Save availability" }).click();
+    await expect(form.getByText("Saved!")).toBeVisible();
+    await page.reload();
+    await expect(form.getByLabel(/open to 1-on-1 meetings/)).not.toBeChecked();
+  });
+
+  // The save action refuses a non-attendee, but the page used to render the
+  // whole form first -- so the refusal only arrived after ticking boxes.
+  test("says so up front when you are not on the event's guest list", async ({
+    page,
+  }) => {
+    const eventName = `E2E Not Attending ${uniqueSuffix()}`;
+
+    await page.goto("/admin");
+    await page.getByLabel("Password").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Access Admin" }).click();
+    await page.getByRole("button", { name: "New event" }).click();
+    await page.getByLabel("Name *").fill(eventName);
+    await page.getByLabel("Start *").fill("2026-10-01");
+    await page.getByLabel("End *").fill("2026-10-03");
+    await page.getByRole("button", { name: "Create event" }).click();
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+
+    const meetings = page.getByRole("form", { name: "Meetings" });
+    await meetings.getByLabel("Enable meetings").check();
+    await meetings.getByRole("button", { name: "Save meetings" }).click();
+    await expect(meetings.getByText("Saved!")).toBeVisible();
+
+    // Nobody is assigned to this event, so Alice is not attending it.
+    const slug = eventName.replace(/ /g, "-");
+    await loginAndGoto(page, `/${slug}/meetings`);
+    await selectUser(page, /Alice Test/i);
+    await page.goto(`/${slug}/meetings`);
+
+    await expect(page.getByText(/not on the guest list/i)).toBeVisible();
+    await expect(
+      page.getByRole("form", { name: "1-on-1 meetings" })
+    ).toBeHidden();
+  });
+
+  test("is not offered while the organizer keeps meetings off", async ({
+    page,
+  }) => {
+    await loginAndGoto(page, "/Conference-Gamma");
+
+    await expect(page.getByRole("link", { name: "1-on-1s" })).toBeHidden();
+  });
+});

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -147,6 +147,11 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       await import("@/app/(site)/[eventSlug]/comment-actions");
     return deleteComment({ commentId: "c", eventSlug: "s" });
   },
+  "actions/meetings.ts:saveMeetingAvailabilityAction": async () => {
+    const { saveMeetingAvailabilityAction } =
+      await import("@/app/actions/meetings");
+    return saveMeetingAvailabilityAction({ eventId: "e", slotStarts: [] });
+  },
   "actions/profile.ts:updateProfileAction": async () => {
     const { updateProfileAction } = await import("@/app/actions/profile");
     return updateProfileAction({ name: "N" });

--- a/tests/integration/meeting-availability-action.test.ts
+++ b/tests/integration/meeting-availability-action.test.ts
@@ -1,0 +1,301 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { siteAuthenticate } from "../helpers/site-auth";
+import { createEvent, createGuest, createDay } from "../helpers/factories";
+import {
+  GUEST_COOKIE_NAME,
+  openGuestValue,
+  verifiedGuestValue,
+} from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import { saveMeetingAvailabilityAction } from "@/app/actions/meetings";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+// 09:00-17:00 UTC, so with 30-minute slots the day offers 16 of them.
+const DAY_START = new Date("2026-10-01T09:00:00.000Z");
+const DAY_END = new Date("2026-10-01T17:00:00.000Z");
+const SLOT_1 = "2026-10-01T09:00:00.000Z";
+const SLOT_2 = "2026-10-01T09:30:00.000Z";
+const SLOT_3 = "2026-10-01T10:00:00.000Z";
+
+async function meetingsEvent(patch?: Record<string, unknown>) {
+  const event = await createEvent();
+  await getRepositories().events.update(event.id, {
+    meetingsEnabled: true,
+    ...patch,
+  });
+  await createDay(event.id, { start: DAY_START, end: DAY_END });
+  return event;
+}
+
+async function signIn(guestId: string) {
+  cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guestId));
+}
+
+describe("saveMeetingAvailabilityAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await siteAuthenticate(cookieJar);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("stores the slots the guest declared", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1, SLOT_3],
+    });
+
+    expect(result).toEqual({ ok: true });
+    const saved =
+      await getRepositories().meetingAvailability.listByGuestAndEvent(
+        guest.id,
+        event.id
+      );
+    expect(saved.map((d) => d.toISOString())).toEqual([SLOT_1, SLOT_3]);
+  });
+
+  it("replaces the previous set rather than adding to it", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+    await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1, SLOT_2],
+    });
+
+    await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_3],
+    });
+
+    const saved =
+      await getRepositories().meetingAvailability.listByGuestAndEvent(
+        guest.id,
+        event.id
+      );
+    expect(saved.map((d) => d.toISOString())).toEqual([SLOT_3]);
+  });
+
+  // Switching the "I'm open to meetings" switch off is an empty save: no rows
+  // is exactly the state of someone who never turned it on.
+  it("accepts an empty set, which is how someone opts out", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+    await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(
+      await getRepositories().meetingAvailability.listByGuestAndEvent(
+        guest.id,
+        event.id
+      )
+    ).toEqual([]);
+  });
+
+  // The client sends slot starts back; a hand-made payload must not be able to
+  // declare a guest free at an instant the event never offered.
+  it("refuses a slot the event does not offer", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    const offGrid = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: ["2026-10-01T09:17:00.000Z"],
+    });
+    const outsideDay = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: ["2026-10-02T09:00:00.000Z"],
+    });
+
+    expect(offGrid.ok).toBe(false);
+    expect(outsideDay.ok).toBe(false);
+    expect(
+      await getRepositories().meetingAvailability.listByGuestAndEvent(
+        guest.id,
+        event.id
+      )
+    ).toEqual([]);
+  });
+
+  // Slots are the event's schedule increment, so a 09:30 start exists on a
+  // 30-minute grid and not on a 60-minute one.
+  it("offers slots at the event's schedule increment", async () => {
+    const event = await meetingsEvent({ slotIncrementMinutes: 60 });
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    const onGrid = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+    const offGrid = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_2],
+    });
+
+    expect(onGrid).toEqual({ ok: true });
+    expect(offGrid.ok).toBe(false);
+  });
+
+  it("refuses when the organizer has not enabled meetings", async () => {
+    const event = await meetingsEvent({ meetingsEnabled: false });
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a guest who is not attending the event", async () => {
+    const event = await meetingsEvent();
+    const outsider = await createGuest();
+    await signIn(outsider.id);
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  // Picking a name is enough for an unprotected guest, exactly as it is for an
+  // RSVP -- declaring your own availability is no more sensitive than that.
+  it("lets an unprotected guest declare from an open name selection", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("refuses an open name selection for a protected guest", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      await getRepositories().meetingAvailability.listByGuestAndEvent(
+        guest.id,
+        event.id
+      )
+    ).toEqual([]);
+  });
+
+  it("refuses when nobody is signed in", async () => {
+    const event = await meetingsEvent();
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("reports an unknown event", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    const result = await saveMeetingAvailabilityAction({
+      eventId: "no-such-event",
+      slotStarts: [],
+    });
+
+    expect(result).toEqual({ ok: false, error: "Event not found" });
+  });
+
+  it("keeps one guest's declaration out of another's", async () => {
+    const event = await meetingsEvent();
+    const alice = await createGuest({ eventId: event.id });
+    const bob = await createGuest({ eventId: event.id });
+    await signIn(alice.id);
+    await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    await signIn(bob.id);
+    await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_3],
+    });
+
+    const { meetingAvailability } = getRepositories();
+    expect(
+      (await meetingAvailability.listByGuestAndEvent(alice.id, event.id)).map(
+        (d) => d.toISOString()
+      )
+    ).toEqual([SLOT_1]);
+    expect(
+      (await meetingAvailability.listByGuestAndEvent(bob.id, event.id)).map(
+        (d) => d.toISOString()
+      )
+    ).toEqual([SLOT_3]);
+  });
+});

--- a/tests/integration/meeting-availability-action.test.ts
+++ b/tests/integration/meeting-availability-action.test.ts
@@ -257,6 +257,26 @@ describe("saveMeetingAvailabilityAction", () => {
     expect(result.ok).toBe(false);
   });
 
+  // A "use server" export is reachable with any payload, so a malformed one
+  // has to come back as a result rather than throwing out of the action.
+  it("refuses a malformed payload instead of throwing", async () => {
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    for (const bad of [
+      { eventId: event.id, slotStarts: 5 },
+      { eventId: event.id, slotStarts: {} },
+      { eventId: 7, slotStarts: [] },
+      {},
+    ]) {
+      const result = await saveMeetingAvailabilityAction(
+        bad as unknown as Parameters<typeof saveMeetingAvailabilityAction>[0]
+      );
+      expect(result.ok).toBe(false);
+    }
+  });
+
   it("reports an unknown event", async () => {
     const event = await meetingsEvent();
     const guest = await createGuest({ eventId: event.id });

--- a/tests/unit/meeting-slots.test.ts
+++ b/tests/unit/meeting-slots.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { meetingSlotsForDay } from "@/utils/meeting-slots";
+
+const DAY = {
+  start: new Date("2026-09-11T07:00:00.000Z"),
+  end: new Date("2026-09-11T16:00:00.000Z"),
+};
+
+const times = (slots: { start: Date; end: Date }[]) =>
+  slots.map((s) => `${s.start.toISOString()}/${s.end.toISOString()}`);
+
+describe("meetingSlotsForDay", () => {
+  it("fills the whole day", () => {
+    const slots = meetingSlotsForDay(DAY, 30);
+
+    expect(slots).toHaveLength(18);
+    expect(slots[0].start.toISOString()).toBe("2026-09-11T07:00:00.000Z");
+    expect(slots[0].end.toISOString()).toBe("2026-09-11T07:30:00.000Z");
+    expect(slots.at(-1)?.end.toISOString()).toBe("2026-09-11T16:00:00.000Z");
+  });
+
+  it("steps by the event's schedule increment", () => {
+    const slots = meetingSlotsForDay(DAY, 60);
+
+    expect(slots).toHaveLength(9);
+    expect(slots[1].start.toISOString()).toBe("2026-09-11T08:00:00.000Z");
+  });
+
+  // The grid is anchored at the day's start, which is what makes a coarser
+  // increment dangerous rather than harmless: half the old rows land on it.
+  it("anchors on the day's start, whatever the increment", () => {
+    const half = meetingSlotsForDay(DAY, 30).map((s) => s.start.getTime());
+    const whole = meetingSlotsForDay(DAY, 60).map((s) => s.start.getTime());
+
+    expect(whole.every((t) => half.includes(t))).toBe(true);
+  });
+
+  it("drops a trailing slot the day cannot fit whole", () => {
+    const slots = meetingSlotsForDay(
+      {
+        start: new Date("2026-09-11T07:00:00.000Z"),
+        end: new Date("2026-09-11T08:20:00.000Z"),
+      },
+      30
+    );
+
+    expect(times(slots)).toEqual([
+      "2026-09-11T07:00:00.000Z/2026-09-11T07:30:00.000Z",
+      "2026-09-11T07:30:00.000Z/2026-09-11T08:00:00.000Z",
+    ]);
+  });
+
+  // A day may run Friday 09:00 to Saturday 03:00; slots simply carry on.
+  it("runs straight through a day that crosses midnight", () => {
+    const slots = meetingSlotsForDay(
+      {
+        start: new Date("2026-09-11T20:00:00.000Z"),
+        end: new Date("2026-09-12T01:00:00.000Z"),
+      },
+      60
+    );
+
+    expect(slots).toHaveLength(5);
+    expect(slots.at(-1)?.end.toISOString()).toBe("2026-09-12T01:00:00.000Z");
+  });
+
+  it("offers nothing for a day shorter than one slot", () => {
+    const slots = meetingSlotsForDay(
+      {
+        start: new Date("2026-09-11T07:00:00.000Z"),
+        end: new Date("2026-09-11T07:20:00.000Z"),
+      },
+      30
+    );
+
+    expect(slots).toEqual([]);
+  });
+});

--- a/utils/meeting-slots.ts
+++ b/utils/meeting-slots.ts
@@ -1,0 +1,31 @@
+// 1-on-1 slots are derived, never stored: a day plus the event's slot
+// increment is enough to say which slots exist. Availability rows then key on
+// a slot's start instant, which is why changing that increment clears them —
+// a coarser grid would re-read a declared half-hour as a full hour.
+
+export type MeetingSlot = { start: Date; end: Date };
+
+const MS_PER_MINUTE = 60 * 1000;
+
+/**
+ * The slots a day offers, chronologically. Slots run the whole day and are the
+ * event's schedule increment long, so they line up with the grid rather than
+ * needing a second set of rules; attendees clear the ones they want kept free.
+ *
+ * A slot the day cannot fit whole is dropped rather than truncated: half a
+ * slot is not bookable.
+ */
+export function meetingSlotsForDay(
+  day: { start: Date; end: Date },
+  slotMinutes: number
+): MeetingSlot[] {
+  if (slotMinutes <= 0) return [];
+
+  const slots: MeetingSlot[] = [];
+  const step = slotMinutes * MS_PER_MINUTE;
+  const to = day.end.getTime();
+  for (let start = day.start.getTime(); start + step <= to; start += step) {
+    slots.push({ start: new Date(start), end: new Date(start + step) });
+  }
+  return slots;
+}

--- a/utils/meeting-slots.ts
+++ b/utils/meeting-slots.ts
@@ -1,3 +1,8 @@
+// Companion to utils/slots.ts, which owns the schedule grid's slot math: these
+// are the same grid, stepped from the same increment, and kept separate only
+// because a meeting asks a different question of it (which slots exist on a
+// day) than the grid does (how tall a row is, what aligns).
+//
 // 1-on-1 slots are derived, never stored: a day plus the event's slot
 // increment is enough to say which slots exist. Availability rows then key on
 // a slot's start instant, which is why changing that increment clears them —

--- a/utils/slots.ts
+++ b/utils/slots.ts
@@ -1,6 +1,8 @@
 // Slot math for the schedule grid. Each event divides its days into slots of
 // `slotIncrementMinutes`; the grid, start-time options, and duration options
-// all derive from these helpers so they stay in agreement.
+// all derive from these helpers so they stay in agreement. 1-on-1 meeting
+// slots share this grid and its increment; utils/meeting-slots.ts derives
+// those from a day.
 
 export const SLOT_INCREMENT_OPTIONS = [15, 30, 45, 60] as const;
 


### PR DESCRIPTION
Fourth of the PRs for schellingboard/schellingboard#392 (1-on-1 meetings), following the
[design approved on the issue](https://github.com/LWCW-Europe/schellingboard/issues/392#issuecomment-5470900325).

**Stacked on schellingboard/schellingboard-legacy#937** — review that one first; this PR's diff is the single commit on
top of it. Base moves to `main` once schellingboard/schellingboard-legacy#937 lands.

## What's here

The attendee half of the switch: a **1-on-1s** page for an event, reached from the
schedule toolbar when the organizer has meetings on.

- One switch — *I'm open to 1-on-1 meetings at this event* — and below it every slot
  of every day as plain checkboxes with a single Save
- Switching it on marks **every** slot available, so you clear the ones you want kept
  free rather than building the set up from nothing
- Switching it off and saving **clears** the declaration: no rows is exactly the state
  of someone who never turned it on, which is what makes it the opt-out control
- Per-day *Select all* / *Clear*, since a day of a long event is a lot of boxes

## Slots

Derived, never stored. `utils/meeting-slots.ts` steps through a day by the event's
schedule increment — 31 lines, no timezone rules of its own. That follows from the
decisions on schellingboard/schellingboard-legacy#937: with no separate meeting slot length and no meeting-hours window,
slots line up with the schedule grid by construction, and a day running past midnight
simply carries on.

## Decisions worth a reviewer's attention

**Submitted slot starts are checked against the ones the event actually offers.** The
client sends instants back, so without that a hand-made payload could declare a guest
free at an instant that is not a slot at all — and every later booking compares against
these rows.

**Picking a name is enough, as it is for an RSVP.** Declaring your own availability is
no more sensitive than that, and requiring more would lock out every unprotected guest.
`verifiedCurrentUser` still refuses an open selection naming a protected guest.

**The page 404s when meetings are off**, rather than only hiding the toolbar link, so a
stale link or a typed URL can't reach it. It also applies the same membership check the
save action does, so someone not on the event's guest list is told before filling the
form in rather than after.

**`eventSlotStarts` is deliberately not exported.** Every export of a `"use server"`
module is a client-callable endpoint; the repo's `action-auth-guard` test is what caught
it being one.

## Testing

6 unit tests for the slot math, 18 integration tests for the save action (written first
and confirmed failing), and 3 E2E specs — declare, clear a slot, reload, opt back out;
the not-on-the-guest-list notice; and the toolbar link staying hidden while meetings are
off. `make precommit` is green: 1658 unit/integration, 150 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
