### PR TITLE
feat: request a 1-on-1 from an attendee's profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   **1-on-1s** link where attendees turn on "I'm open to 1-on-1 meetings at this event" and clear the
   slots they want kept free. Turning it on marks every slot free, and turning it back off clears the
   lot — nobody can book you while it's off
+- **Ask someone for a 1-on-1**: an attendee's profile now offers **Schedule a meeting** for each
+  event you both attend where they are open to them. Pick one of their free slots, say where to
+  meet and add a line of context. A slot where either of you is hosting or has RSVP'd to something
+  is marked busy, but you can still book it — only slots they cleared are off limits
 
 ### Fixed
 
 - **Event names that a site page would hide are rejected**: an event named "Guests", "Settings" or
   "Notifications" got a web address the site's own page of that name already answers, so the event
   could never be opened. Creating one now fails with the same message other reserved names give
-
-### Fixed
-
 - **Picking your name works however many events a site runs**: the header lists every event, and
   from about seven onwards the links crowded the name chip beside them off the row, leaving no way
   to say who you are. The links now scroll instead of pushing

--- a/app/(site)/[eventSlug]/clash-actions.ts
+++ b/app/(site)/[eventSlug]/clash-actions.ts
@@ -1,25 +1,14 @@
 "use server";
 
 import { getRepositories } from "@/db/container";
-import type { Session } from "@/db/repositories/interfaces";
 import { requireVerifiedGuest } from "@/utils/action-auth";
-import { getStartTimePlusBreak } from "@/utils/utils";
-import { newEmptySession, sessionsOverlap } from "../session_utils";
+import {
+  clashesForInterval,
+  loadGuestSchedules,
+  type GuestClash,
+} from "@/utils/guest-clashes";
 
-// A schedule clash for one guest, computed server-side so their private RSVPs
-// and meetings never reach the client. Hosting a session is public, so those
-// clashes name the session; RSVP'd sessions and agreed 1-on-1s are private, so
-// those only report that the guest is "busy" for the overlapping interval —
-// never which session, or who the meeting is with.
-export type GuestClash = {
-  guestName: string;
-  kind: "hosting" | "busy";
-  // Only set for hosting clashes (public); null for busy/RSVP clashes.
-  title: string | null;
-  // ISO strings; `start` is break-adjusted for display, matching the schedule.
-  start: string;
-  end: string;
-};
+export type { GuestClash };
 
 export async function detectGuestClashes(input: {
   eventId: string;
@@ -30,87 +19,19 @@ export async function detectGuestClashes(input: {
 }): Promise<GuestClash[]> {
   // Site auth is shared with every attendee, so it can't be the gate on a
   // reply that reports when another guest is privately busy.
-  await requireVerifiedGuest("checking host availability");
+  await requireVerifiedGuest("checking guest availability");
   const { eventId, guestIds, start, end, excludeSessionId } = input;
   if (guestIds.length === 0) return [];
 
-  const repos = getRepositories();
-  const event = await repos.events.findById(eventId);
+  const event = await getRepositories().events.findById(eventId);
   if (!event) return [];
-  const breakMinutes = event.breakMinutes;
 
-  // sessionsOverlap skips a session whose id matches the candidate's, which is
-  // how the session being edited is excluded from clashing with itself.
-  const candidate: Session = {
-    ...newEmptySession(eventId),
-    id: excludeSessionId ?? "",
-    startTime: new Date(start),
-    endTime: new Date(end),
-  };
-
-  const inEventAndOverlapping = (ses: Session) =>
-    ses.eventId === eventId &&
-    ses.startTime != null &&
-    ses.endTime != null &&
-    sessionsOverlap(ses, candidate);
-
-  const clashes: GuestClash[] = [];
-
-  for (const guestId of guestIds) {
-    const guest = await repos.guests.findById(guestId);
-    if (!guest) continue;
-
-    const [hosted, rsvpd, meetings] = await Promise.all([
-      repos.sessions.listHostedByGuest(guestId),
-      repos.sessions.listRsvpdByGuest(guestId),
-      repos.meetings.listByGuestAndEvent(guestId, eventId),
-    ]);
-
-    const hostingClashes = hosted.filter(inEventAndOverlapping);
-    const hostingIds = new Set(hostingClashes.map((s) => s.id));
-
-    for (const ses of hostingClashes) {
-      clashes.push({
-        guestName: guest.name,
-        kind: "hosting",
-        title: ses.title,
-        start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
-        end: ses.endTime!.toISOString(),
-      });
-    }
-
-    // A host RSVP'ing to a session they also host is already reported above.
-    for (const ses of rsvpd.filter(inEventAndOverlapping)) {
-      if (hostingIds.has(ses.id)) continue;
-      clashes.push({
-        guestName: guest.name,
-        kind: "busy",
-        title: null,
-        start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
-        end: ses.endTime!.toISOString(),
-      });
-    }
-
-    // Only accepted ones: a pending request is not yet a commitment, and
-    // declined or canceled ones never were. Who the meeting is with is as
-    // private as an RSVP, so it reports busy with no title.
-    for (const meeting of meetings) {
-      if (meeting.status !== "accepted") continue;
-      if (
-        meeting.slotStart.getTime() >= candidate.endTime!.getTime() ||
-        meeting.slotEnd.getTime() <= candidate.startTime!.getTime()
-      ) {
-        continue;
-      }
-      clashes.push({
-        guestName: guest.name,
-        kind: "busy",
-        title: null,
-        start: meeting.slotStart.toISOString(),
-        end: meeting.slotEnd.toISOString(),
-      });
-    }
-  }
-
-  return clashes;
+  const schedules = await loadGuestSchedules(eventId, guestIds);
+  return clashesForInterval(schedules, {
+    eventId,
+    start: new Date(start),
+    end: new Date(end),
+    breakMinutes: event.breakMinutes,
+    excludeSessionId,
+  });
 }

--- a/app/(site)/[eventSlug]/clash-actions.ts
+++ b/app/(site)/[eventSlug]/clash-actions.ts
@@ -6,12 +6,13 @@ import { requireVerifiedGuest } from "@/utils/action-auth";
 import { getStartTimePlusBreak } from "@/utils/utils";
 import { newEmptySession, sessionsOverlap } from "../session_utils";
 
-// A schedule clash for one host, computed server-side so a host's private
-// RSVPs never reach the client. Hosting a session is public, so those clashes
-// name the session; RSVP'd sessions are private, so those only report that the
-// host is "busy" for the overlapping interval — never which session.
-export type HostClash = {
-  hostName: string;
+// A schedule clash for one guest, computed server-side so their private RSVPs
+// and meetings never reach the client. Hosting a session is public, so those
+// clashes name the session; RSVP'd sessions and agreed 1-on-1s are private, so
+// those only report that the guest is "busy" for the overlapping interval —
+// never which session, or who the meeting is with.
+export type GuestClash = {
+  guestName: string;
   kind: "hosting" | "busy";
   // Only set for hosting clashes (public); null for busy/RSVP clashes.
   title: string | null;
@@ -20,18 +21,18 @@ export type HostClash = {
   end: string;
 };
 
-export async function detectHostClashes(input: {
+export async function detectGuestClashes(input: {
   eventId: string;
-  hostIds: string[];
+  guestIds: string[];
   start: string; // ISO — candidate session start
   end: string; // ISO — candidate session end
   excludeSessionId?: string | null;
-}): Promise<HostClash[]> {
+}): Promise<GuestClash[]> {
   // Site auth is shared with every attendee, so it can't be the gate on a
   // reply that reports when another guest is privately busy.
   await requireVerifiedGuest("checking host availability");
-  const { eventId, hostIds, start, end, excludeSessionId } = input;
-  if (hostIds.length === 0) return [];
+  const { eventId, guestIds, start, end, excludeSessionId } = input;
+  if (guestIds.length === 0) return [];
 
   const repos = getRepositories();
   const event = await repos.events.findById(eventId);
@@ -53,15 +54,16 @@ export async function detectHostClashes(input: {
     ses.endTime != null &&
     sessionsOverlap(ses, candidate);
 
-  const clashes: HostClash[] = [];
+  const clashes: GuestClash[] = [];
 
-  for (const hostId of hostIds) {
-    const guest = await repos.guests.findById(hostId);
+  for (const guestId of guestIds) {
+    const guest = await repos.guests.findById(guestId);
     if (!guest) continue;
 
-    const [hosted, rsvpd] = await Promise.all([
-      repos.sessions.listHostedByGuest(hostId),
-      repos.sessions.listRsvpdByGuest(hostId),
+    const [hosted, rsvpd, meetings] = await Promise.all([
+      repos.sessions.listHostedByGuest(guestId),
+      repos.sessions.listRsvpdByGuest(guestId),
+      repos.meetings.listByGuestAndEvent(guestId, eventId),
     ]);
 
     const hostingClashes = hosted.filter(inEventAndOverlapping);
@@ -69,7 +71,7 @@ export async function detectHostClashes(input: {
 
     for (const ses of hostingClashes) {
       clashes.push({
-        hostName: guest.name,
+        guestName: guest.name,
         kind: "hosting",
         title: ses.title,
         start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
@@ -81,11 +83,31 @@ export async function detectHostClashes(input: {
     for (const ses of rsvpd.filter(inEventAndOverlapping)) {
       if (hostingIds.has(ses.id)) continue;
       clashes.push({
-        hostName: guest.name,
+        guestName: guest.name,
         kind: "busy",
         title: null,
         start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
         end: ses.endTime!.toISOString(),
+      });
+    }
+
+    // Only accepted ones: a pending request is not yet a commitment, and
+    // declined or canceled ones never were. Who the meeting is with is as
+    // private as an RSVP, so it reports busy with no title.
+    for (const meeting of meetings) {
+      if (meeting.status !== "accepted") continue;
+      if (
+        meeting.slotStart.getTime() >= candidate.endTime!.getTime() ||
+        meeting.slotEnd.getTime() <= candidate.startTime!.getTime()
+      ) {
+        continue;
+      }
+      clashes.push({
+        guestName: guest.name,
+        kind: "busy",
+        title: null,
+        start: meeting.slotStart.toISOString(),
+        end: meeting.slotEnd.toISOString(),
       });
     }
   }

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -32,7 +32,7 @@ import { newEmptySession } from "../session_utils";
 import { useToast } from "../toast";
 import { buildSessionInterval } from "@/app/api/session-form-utils";
 import { revalidateEvent } from "./session-actions";
-import { detectHostClashes, type HostClash } from "./clash-actions";
+import { detectGuestClashes, type GuestClash } from "./clash-actions";
 import { MarkdownHint } from "@/app/(site)/markdown";
 import { BackLink } from "@/app/components/back-link";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
@@ -200,7 +200,7 @@ export function SessionForm(props: {
   // Clash detection runs on the server (see clash-actions): a host's RSVP'd
   // sessions are private, so the client never receives them — the server only
   // reports that the host is "busy" for the overlapping interval.
-  const [hostClashes, setHostClashes] = useState<HostClash[]>([]);
+  const [hostClashes, setHostClashes] = useState<GuestClash[]>([]);
   const [isCheckingClashes, setIsCheckingClashes] = useState(false);
 
   const hostIdsKey = hosts.map((h) => h.id).join(",");
@@ -216,9 +216,9 @@ export function SessionForm(props: {
       }
       setIsCheckingClashes(true);
       try {
-        const clashes = await detectHostClashes({
+        const clashes = await detectGuestClashes({
           eventId: event.id,
-          hostIds: hostIdsKey.split(","),
+          guestIds: hostIdsKey.split(","),
           start: new Date(candidateStart).toISOString(),
           end: new Date(candidateEnd).toISOString(),
           excludeSessionId: sessionID ?? null,
@@ -241,8 +241,8 @@ export function SessionForm(props: {
       DateTime.fromISO(iso).setZone(timezone).toFormat(TIME_FORMAT);
     const interval = `from ${formatTime(clash.start)} to ${formatTime(clash.end)}`;
     return clash.kind === "hosting"
-      ? `${clash.hostName} is hosting ${clash.title} ${interval}`
-      : `${clash.hostName} is busy ${interval}`;
+      ? `${clash.guestName} is hosting ${clash.title} ${interval}`
+      : `${clash.guestName} is busy ${interval}`;
   });
 
   const router = useRouter();

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Modal } from "@/app/components/modal";
+import { Input } from "@/app/input";
+import { requestMeetingAction } from "@/app/actions/meetings";
+import type {
+  MeetingDayOption,
+  MeetingOption,
+  MeetingSlotOption,
+} from "@/utils/meeting-options";
+
+const PRIMARY =
+  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+const SECONDARY =
+  "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+
+/** "Yuki is hosting Their talk" / "You are busy" — never which private session. */
+function clashLine(clash: MeetingSlotOption["clashes"][number]): string {
+  const who = clash.isViewer ? "You" : clash.guestName;
+  const is = clash.isViewer ? "are" : "is";
+  return clash.kind === "hosting" && clash.title
+    ? `${who} ${is} hosting ${clash.title}`
+    : `${who} ${is} busy`;
+}
+
+function SlotList({
+  days,
+  selected,
+  onSelect,
+}: {
+  days: MeetingDayOption[];
+  selected: string | null;
+  onSelect: (start: string) => void;
+}) {
+  return (
+    <>
+      {days.map((day) => (
+        <section key={day.label} aria-label={day.label} className="mb-4">
+          <h3 className="text-sm font-semibold text-fg mb-1">{day.label}</h3>
+          <ul className="flex flex-wrap gap-2">
+            {day.slots.map((slot) => {
+              const unavailable = slot.state === "unavailable";
+              const isSelected = selected === slot.start;
+              return (
+                <li key={slot.start}>
+                  <button
+                    type="button"
+                    disabled={unavailable}
+                    aria-pressed={isSelected}
+                    onClick={() => onSelect(slot.start)}
+                    className={`rounded-md border px-2 py-1 text-sm transition-colors ${
+                      isSelected
+                        ? "border-brand bg-brand text-on-brand"
+                        : unavailable
+                          ? "border-line-subtle bg-surface-sunken text-fg-subtle cursor-not-allowed"
+                          : slot.state === "busy"
+                            ? "border-warning bg-warning-tint text-fg hover:bg-surface-hover"
+                            : "border-line bg-surface-raised text-fg hover:bg-surface-hover"
+                    }`}
+                  >
+                    {slot.label}
+                    {unavailable && (
+                      <span className="block text-xs">Unavailable</span>
+                    )}
+                    {slot.state === "busy" && (
+                      <span className="block text-xs">Busy</span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </>
+  );
+}
+
+function RequestForm({
+  option,
+  recipientId,
+  recipientName,
+  onDone,
+}: {
+  option: MeetingOption;
+  recipientId: string;
+  recipientName: string;
+  onDone: () => void;
+}) {
+  const [slotStart, setSlotStart] = useState<string | null>(null);
+  const [meetingPoint, setMeetingPoint] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+  const [isSending, startSend] = useTransition();
+
+  const day = option.days.find((d) =>
+    d.slots.some((s) => s.start === slotStart)
+  );
+  const slot = day?.slots.find((s) => s.start === slotStart);
+  const selectedPoint = option.meetingPoints.find(
+    (p) => p.name === meetingPoint
+  );
+
+  const handleSend = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!slotStart) return;
+    setError(null);
+    startSend(async () => {
+      try {
+        const result = await requestMeetingAction({
+          eventId: option.eventId,
+          recipientId,
+          slotStart,
+          meetingPoint,
+          message,
+        });
+        if (!result.ok) setError(result.error);
+        else setSent(true);
+      } catch {
+        setError("Request failed");
+      }
+    });
+  };
+
+  if (sent) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-fg">
+          Asked {recipientName} for {slot?.label} on {day?.label}. You&apos;ll
+          hear when they answer.
+        </p>
+        <button type="button" onClick={onDone} className={PRIMARY}>
+          Done
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSend} className="flex flex-col gap-4">
+      <h2 className="text-xl font-bold text-fg">
+        Meet {recipientName}
+        <span className="block text-sm font-normal text-fg-muted">
+          {option.eventName}
+        </span>
+      </h2>
+
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
+
+      <div className="max-h-64 overflow-y-auto">
+        <SlotList
+          days={option.days}
+          selected={slotStart}
+          onSelect={setSlotStart}
+        />
+      </div>
+
+      {/* A clash is raised, never enforced: the pair decide for themselves. */}
+      {slot?.state === "busy" && (
+        <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
+          {[...new Set(slot.clashes.map(clashLine))].join("; ")} during this
+          slot — book it anyway?
+        </p>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-fg-muted">Where to meet</span>
+        {option.meetingPoints.length > 0 && (
+          <ul className="flex flex-wrap gap-2 mb-1">
+            {option.meetingPoints.map((point) => (
+              <li key={point.id}>
+                <button
+                  type="button"
+                  aria-pressed={meetingPoint === point.name}
+                  onClick={() => setMeetingPoint(point.name)}
+                  className={`rounded-full border px-3 py-1 text-sm transition-colors ${
+                    meetingPoint === point.name
+                      ? "border-brand bg-brand text-on-brand"
+                      : "border-line bg-surface-raised text-fg hover:bg-surface-hover"
+                  }`}
+                >
+                  {point.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {/* Below the chips rather than a title= on them: a tooltip is the one
+            place a touch user never reaches, and the description is how the
+            organizer says where the place actually is. */}
+        {selectedPoint?.description && (
+          <p className="mb-1 text-xs text-fg-muted">
+            {selectedPoint.description}
+          </p>
+        )}
+        <Input
+          value={meetingPoint}
+          onChange={(e) => setMeetingPoint(e.target.value)}
+          aria-label="Where to meet"
+          placeholder="or type somewhere else"
+          className="w-full h-10"
+        />
+        <p className="text-xs text-fg-subtle">
+          Nothing is reserved — this is just where to find each other.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="meeting-message"
+          className="text-sm font-medium text-fg-muted"
+        >
+          Add a line of context (optional)
+        </label>
+        <Input
+          id="meeting-message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Would love to talk about…"
+          className="w-full h-10"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={isSending || !slotStart || !meetingPoint.trim()}
+          className={PRIMARY}
+        >
+          {isSending ? "Sending..." : "Send request"}
+        </button>
+        <button type="button" onClick={onDone} className={SECONDARY}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+/**
+ * "Schedule a meeting" on an attendee's profile — one button per event the
+ * pair share where meetings are on and they are bookable, so nothing shows at
+ * all when there is nothing to book.
+ */
+export function MeetingPicker({
+  recipientId,
+  recipientName,
+  options,
+}: {
+  recipientId: string;
+  recipientName: string;
+  options: MeetingOption[];
+}) {
+  const [openEventId, setOpenEventId] = useState<string | null>(null);
+
+  if (options.length === 0) return null;
+
+  const open = options.find((o) => o.eventId === openEventId);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((option) => (
+        <button
+          key={option.eventId}
+          type="button"
+          onClick={() => setOpenEventId(option.eventId)}
+          className={SECONDARY}
+        >
+          {options.length === 1
+            ? "Schedule a meeting"
+            : `Schedule a meeting at ${option.eventName}`}
+        </button>
+      ))}
+      {/* Opened from inside the profile modal, which is z-50: without the
+          portal and a higher z it renders behind it. */}
+      <Modal
+        open={open !== undefined}
+        setOpen={() => setOpenEventId(null)}
+        zIndex="z-[60]"
+        portal
+        maxWidth="sm:max-w-2xl"
+        hideClose
+      >
+        {open && (
+          <RequestForm
+            option={open}
+            recipientId={recipientId}
+            recipientName={recipientName}
+            onDone={() => setOpenEventId(null)}
+          />
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/app/(site)/guests/profile-activity.ts
+++ b/app/(site)/guests/profile-activity.ts
@@ -1,8 +1,11 @@
 "use server";
 
+import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { requireSiteAuth } from "@/utils/action-auth";
 import { eventNameToSlug } from "@/utils/utils";
+import { meetingOptionsFor, type MeetingOption } from "@/utils/meeting-options";
 
 /** A session or proposal on a profile, ready to link to. */
 export type ProfileActivityItem = {
@@ -14,6 +17,12 @@ export type ProfileActivityItem = {
 export type ProfileActivity = {
   hosting: ProfileActivityItem[];
   proposals: ProfileActivityItem[];
+  /**
+   * What the reader may book with this guest. Folded in here rather than
+   * fetched on its own: a server action re-renders the route's RSC tree, and
+   * the directory behind a profile is a big one to render twice per open.
+   */
+  meetingOptions: MeetingOption[];
 };
 
 /**
@@ -27,10 +36,14 @@ export async function listProfileActivity(
 ): Promise<ProfileActivity> {
   await requireSiteAuth();
   const repos = getRepositories();
-  const [hostedSessions, proposals, events] = await Promise.all([
+  const viewerId = await verifiedCurrentUser(await cookies());
+  // The event list is fetched first because the meeting options are computed
+  // over it, rather than each looking its own events up again.
+  const events = await repos.events.list();
+  const [hostedSessions, proposals, meetingOptions] = await Promise.all([
     repos.sessions.listHostedByGuest(guestId),
     repos.sessionProposals.listByHost(guestId),
-    repos.events.list(),
+    meetingOptionsFor(viewerId, guestId, events),
   ]);
 
   const slugOf = (eventId: string) =>
@@ -47,5 +60,6 @@ export async function listProfileActivity(
       title: p.title,
       eventSlug: slugOf(p.eventId),
     })),
+    meetingOptions,
   };
 }

--- a/app/(site)/guests/profile-body.tsx
+++ b/app/(site)/guests/profile-body.tsx
@@ -29,6 +29,7 @@ import {
   SessionLink,
 } from "@/app/(site)/guests/profile-link";
 import { ProfileComments } from "@/app/(site)/guests/profile-comments";
+import { MeetingPicker } from "@/app/(site)/guests/meeting-picker";
 import type { ProfileActivity } from "@/app/(site)/guests/profile-activity";
 
 /**
@@ -106,6 +107,15 @@ export function ProfileBody({
           >
             Edit profile
           </Link>
+        )}
+        {/* `activity` is null for the neighbours a swipe mounts, so this is
+            the profile being read. */}
+        {!isOwnProfile && activity && (
+          <MeetingPicker
+            recipientId={guest.id}
+            recipientName={guest.name}
+            options={activity.meetingOptions}
+          />
         )}
 
         {/* Beside the photo rather than below the prompts: languages are the

--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -454,9 +454,23 @@ function useProfileActivity(guestId: string): ProfileActivity | null {
 
   useEffect(() => {
     let live = true;
-    void listProfileActivity(guestId).then((activity) => {
-      if (live) setLoaded({ guestId, activity });
-    });
+    void listProfileActivity(guestId)
+      .then((activity) => {
+        if (live) setLoaded({ guestId, activity });
+      })
+      // Leaving the page aborts the request, and the rejection that follows is
+      // expected -- there is no profile left to report it on. A navigation
+      // tears the document down without running the cleanup below, so the
+      // abort has to be told apart by its kind rather than by `live`: fetch
+      // reports it as a TypeError ("NetworkError", "Failed to fetch"), and an
+      // explicit cancel as an AbortError. Anything else is a real failure and
+      // must not vanish, or the profile keeps its skeleton unexplained.
+      .catch((e: unknown) => {
+        const aborted =
+          e instanceof TypeError ||
+          (e instanceof DOMException && e.name === "AbortError");
+        if (!aborted) console.error(e);
+      });
     return () => {
       live = false;
     };

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -9,10 +9,30 @@ import {
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
 import { requireSiteAuth } from "@/utils/action-auth";
+import { serverNow } from "@/utils/dev-clock-server";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
 import type { Event } from "@/db/repositories/interfaces";
 
 export type MeetingActionResult = { ok: true } | { ok: false; error: string };
+
+// A "use server" export is a public endpoint behind site auth, so the types
+// these schemas describe are advisory: every payload is parsed rather than
+// trusted, and a malformed one comes back as a result instead of throwing.
+//
+// The lengths are the only bound on two free-text fields that are stored
+// verbatim and shown to the recipient; they are generous rather than tuned.
+const requestSchema = z.object({
+  eventId: z.string(),
+  recipientId: z.string(),
+  slotStart: z.string(),
+  meetingPoint: z.string().max(200),
+  message: z.string().max(2000).optional(),
+});
+
+const availabilitySchema = z.object({
+  eventId: z.string(),
+  slotStarts: z.array(z.string()),
+});
 
 /**
  * Every slot start the event offers, as ISO strings. Deliberately not
@@ -30,13 +50,105 @@ async function eventSlotStarts(event: Event): Promise<Set<string>> {
   );
 }
 
-// A "use server" export is a public endpoint behind site auth, so the types
-// above it are advisory: the payload is parsed rather than trusted, and a
-// malformed one comes back as a result instead of throwing.
-const availabilitySchema = z.object({
-  eventId: z.string(),
-  slotStarts: z.array(z.string()),
-});
+export async function requestMeetingAction(
+  raw: z.input<typeof requestSchema>
+): Promise<MeetingActionResult> {
+  await requireSiteAuth();
+
+  const parsed = requestSchema.safeParse(raw);
+  if (!parsed.success) return { ok: false, error: "Invalid request" };
+  const input = parsed.data;
+
+  const requesterId = await verifiedCurrentUser(await cookies());
+  if (!requesterId) {
+    return { ok: false, error: "Sign in to request a meeting" };
+  }
+  if (requesterId === input.recipientId) {
+    return { ok: false, error: "You can't book a meeting with yourself" };
+  }
+
+  // Presets are a convenience, not a constraint -- but "we'll figure it out"
+  // is not an option, so some place has to be named.
+  const meetingPoint = input.meetingPoint.trim();
+  if (!meetingPoint) {
+    return { ok: false, error: "Choose or type where to meet" };
+  }
+
+  const repos = getRepositories();
+  const event = await repos.events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+  if (!event.meetingsEnabled) {
+    return { ok: false, error: "Meetings are not enabled for this event" };
+  }
+
+  const attending = await repos.guests.listEventsByGuests([
+    requesterId,
+    input.recipientId,
+  ]);
+  const attends = (id: string) =>
+    attending.get(id)?.some((e) => e.id === event.id) ?? false;
+  if (!attends(requesterId)) {
+    return { ok: false, error: "You are not attending this event" };
+  }
+  if (!attends(input.recipientId)) {
+    return { ok: false, error: "They are not attending this event" };
+  }
+
+  const offered = await eventSlotStarts(event);
+  if (!offered.has(input.slotStart)) {
+    return { ok: false, error: "That slot is not available" };
+  }
+
+  // A multi-day event goes on offering yesterday's slots, and the open-request
+  // cap only counts requests still ahead -- so without this, day one stays
+  // bookable on day three and every request against it is free of the cap.
+  const now = await serverNow();
+  if (new Date(input.slotStart) <= now) {
+    return { ok: false, error: "That slot has already passed" };
+  }
+
+  // A slot they cleared is the one hard no in the feature: a clash is only a
+  // warning the requester already waved through, but this is their decision.
+  const declared = await repos.meetingAvailability.listByGuestAndEvent(
+    input.recipientId,
+    event.id
+  );
+  if (!declared.some((slot) => slot.toISOString() === input.slotStart)) {
+    return { ok: false, error: "They are not available at that time" };
+  }
+
+  // The slot's length is the event's schedule increment, never the caller's.
+  const slotStart = new Date(input.slotStart);
+  const slotEnd = new Date(
+    slotStart.getTime() + event.slotIncrementMinutes * 60 * 1000
+  );
+
+  const outcome = await repos.meetings.createIfAllowed(
+    {
+      eventId: event.id,
+      requesterId,
+      recipientId: input.recipientId,
+      slotStart,
+      slotEnd,
+      meetingPoint,
+      message: input.message?.trim() ?? "",
+      createdAt: now,
+    },
+    event.maxOpenMeetingRequests,
+    now
+  );
+  if ("refused" in outcome) {
+    return {
+      ok: false,
+      error:
+        outcome.refused === "duplicate"
+          ? "You have already asked them for that slot"
+          : `You already have ${event.maxOpenMeetingRequests} requests waiting for an answer. Wait for a reply, or cancel one first.`,
+    };
+  }
+
+  return { ok: true };
+}
 
 export async function saveMeetingAvailabilityAction(
   raw: z.input<typeof availabilitySchema>

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -44,6 +44,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Meetings**: an event's Config tab can switch on 1-on-1s between attendees — the places you suggest people meet, and a cap on how many unanswered requests one person may have out.",
       "**Picking your name** works however many events a site runs: past about seven, the header's event links crowded the name chip off the row and there was no way to say who you are.",
       "**Say when you're free**: with meetings on, attendees get a 1-on-1s page to mark which slots they're open for. Turning the switch off clears it and keeps them unbookable.",
+      "**Ask someone for a 1-on-1** from their profile: pick one of their free slots, say where to meet, and send. Slots where either of you is already busy are flagged but still bookable.",
     ],
   },
   {

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -859,6 +859,9 @@ export type Meeting = {
   respondedAt?: Date;
 };
 
+export type MeetingRequestOutcome =
+  { meeting: Meeting } | { refused: "cap" | "duplicate" };
+
 export interface MeetingsRepository {
   findById(id: string): Promise<Meeting | undefined>;
   /**
@@ -881,16 +884,21 @@ export interface MeetingsRepository {
     data: Omit<Meeting, "id" | "status" | "respondedAt">
   ): Promise<Meeting>;
   /**
-   * The cap check and the insert in one transaction, returning null when the
-   * requester is already at `cap`. Two separate awaits leave a window a double
-   * submit walks straight through — the same hazard
-   * {@link RsvpsRepository.createIfUnderCapacity} exists for.
+   * Both refusals and the insert in one transaction. Two separate awaits leave
+   * a window a double submit walks straight through — the same hazard
+   * {@link RsvpsRepository.createIfUnderCapacity} exists for, and the reason
+   * "already asked them" is decided here rather than read off a constraint
+   * violation.
+   *
+   * "duplicate" means a live request already covers that pair and slot;
+   * declined and cancelled ones do not count, so the pair can agree on a slot
+   * they had earlier passed on.
    */
-  createIfUnderCap(
+  createIfAllowed(
     data: Omit<Meeting, "id" | "status" | "respondedAt">,
     cap: number,
     now: Date
-  ): Promise<Meeting | null>;
+  ): Promise<MeetingRequestOutcome>;
   /**
    * Moves the meeting to `status`, but only from one of `from` — undefined
    * when it is in some other state, which is how a caller learns that someone

--- a/db/repositories/sqlite/meetings.ts
+++ b/db/repositories/sqlite/meetings.ts
@@ -2,7 +2,12 @@ import { and, asc, count, eq, gt, inArray, or } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
-import type { Meeting, MeetingStatus, MeetingsRepository } from "../interfaces";
+import type {
+  Meeting,
+  MeetingRequestOutcome,
+  MeetingStatus,
+  MeetingsRepository,
+} from "../interfaces";
 
 type DB = BetterSQLite3Database<typeof schema>;
 
@@ -90,18 +95,19 @@ export class SqliteMeetingsRepository implements MeetingsRepository {
     return rowToMeeting(row);
   }
 
-  async createIfUnderCap(
+  async createIfAllowed(
     data: Omit<Meeting, "id" | "status" | "respondedAt">,
     cap: number,
     now: Date
-  ): Promise<Meeting | null> {
+  ): Promise<MeetingRequestOutcome> {
     return this.db.transaction((tx) => {
+      if (this.hasLiveRequest(tx, data)) return { refused: "duplicate" };
       if (this.countOpen(tx, data.requesterId, data.eventId, now) >= cap) {
-        return null;
+        return { refused: "cap" };
       }
       const row = toRow(data);
       tx.insert(schema.meetings).values(row).run();
-      return rowToMeeting(row);
+      return { meeting: rowToMeeting(row) };
     });
   }
 
@@ -119,6 +125,30 @@ export class SqliteMeetingsRepository implements MeetingsRepository {
       )
       .run();
     return result.changes === 0 ? undefined : this.findById(id);
+  }
+
+  // The same pair and slot, still awaiting or holding an answer. Mirrors the
+  // partial unique index, which stays as the backstop: this is what turns the
+  // clash into a sentence the requester can act on.
+  private hasLiveRequest(
+    db: DB,
+    data: Pick<Meeting, "eventId" | "requesterId" | "recipientId" | "slotStart">
+  ): boolean {
+    return (
+      db
+        .select({ id: schema.meetings.id })
+        .from(schema.meetings)
+        .where(
+          and(
+            eq(schema.meetings.eventId, data.eventId),
+            eq(schema.meetings.requesterId, data.requesterId),
+            eq(schema.meetings.recipientId, data.recipientId),
+            eq(schema.meetings.slotStart, data.slotStart.toISOString()),
+            inArray(schema.meetings.status, ["pending", "accepted"])
+          )
+        )
+        .get() !== undefined
+    );
   }
 
   // Shared by the plain count and the transactional create, so "outstanding"

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -479,12 +479,12 @@ export const meetings = sqliteTable(
     index("meetings_event_recipient_idx").on(t.eventId, t.recipientId),
     // Asking the same person for the same slot twice is a double submit, not a
     // second option: it would leave them two identical requests to answer.
-    uniqueIndex("meetings_no_duplicate_request").on(
-      t.eventId,
-      t.requesterId,
-      t.recipientId,
-      t.slotStart
-    ),
+    // Only while the first is live, though -- once it is declined or cancelled
+    // there is nothing to answer twice, and the pair may well agree on that
+    // slot after all.
+    uniqueIndex("meetings_no_duplicate_request")
+      .on(t.eventId, t.requesterId, t.recipientId, t.slotStart)
+      .where(sql`${t.status} in ('pending', 'accepted')`),
   ]
 );
 

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -206,6 +206,30 @@ Slots are as long as the event's schedule increment and cover the whole of each
 day. If the organizer later changes that increment, everyone's availability is
 cleared and you are asked to choose again — the slots themselves have moved.
 
+### Ask someone for a 1-on-1
+
+Open anyone from the [attendee directory](#attendee-directory--profiles). If
+they are open to meetings at an event you both attend, their profile has a
+**Schedule a meeting** button; if there is no button, they haven't said they are
+free for any slot that is still ahead.
+
+The picker lists their slots day by day:
+
+- **Plain** — they are free, and so are you.
+- **Busy** — one of you is hosting a session, has RSVP'd to one, or has another
+  1-on-1 then. It says who and, where it isn't private, what. This is only a
+  warning: you can still pick the slot and the two of you can sort it out.
+- **Unavailable** — a slot they cleared. These can't be picked.
+
+Then say **where to meet** — either one of the places the organizer suggested,
+or type your own — and optionally add a line about what you'd like to talk
+about. Nothing is reserved: the meeting point is just how you find each other.
+
+Press **Send request** and they hear about it. Asking the same person for the
+same slot twice isn't possible while that request is still open, and the
+organizer caps how many unanswered requests you may have out at once — if you
+hit it, wait for a reply or cancel one.
+
 ## Attendee directory & profiles
 
 The directory lists everyone at the event on a single page — photo and the

--- a/drizzle/0031_meeting_request_reask.sql
+++ b/drizzle/0031_meeting_request_reask.sql
@@ -1,0 +1,2 @@
+DROP INDEX `meetings_no_duplicate_request`;--> statement-breakpoint
+CREATE UNIQUE INDEX `meetings_no_duplicate_request` ON `meetings` (`event_id`,`requester_id`,`recipient_id`,`slot_start`) WHERE "meetings"."status" in ('pending', 'accepted');

--- a/drizzle/meta/0031_snapshot.json
+++ b/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,1825 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5fcab9bf-2b20-4b8c-8091-c49c9b62b090",
+  "prevId": "5c4fd37d-ef92-4a52-88c4-81aeaa22191c",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meetings_enabled": {
+          "name": "meetings_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "meeting_slot_minutes": {
+          "name": "meeting_slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "meeting_day_start": {
+          "name": "meeting_day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_day_end": {
+          "name": "meeting_day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_open_meeting_requests": {
+          "name": "max_open_meeting_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_session_comment": {
+          "name": "email_on_session_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_profile_comment": {
+          "name": "email_on_profile_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_on_meeting_request": {
+          "name": "email_on_meeting_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_meeting_response": {
+          "name": "email_on_meeting_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_availability": {
+      "name": "meeting_availability",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_availability_slot_idx": {
+          "name": "meeting_availability_slot_idx",
+          "columns": ["event_id", "slot_start"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_availability_event_id_events_id_fk": {
+          "name": "meeting_availability_event_id_events_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_availability_guest_id_guests_id_fk": {
+          "name": "meeting_availability_guest_id_guests_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meeting_availability_event_id_guest_id_slot_start_pk": {
+          "columns": ["event_id", "guest_id", "slot_start"],
+          "name": "meeting_availability_event_id_guest_id_slot_start_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_points": {
+      "name": "meeting_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "meeting_points_event_idx": {
+          "name": "meeting_points_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_points_event_id_events_id_fk": {
+          "name": "meeting_points_event_id_events_id_fk",
+          "tableFrom": "meeting_points",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_end": {
+          "name": "slot_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_point": {
+          "name": "meeting_point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meetings_event_requester_idx": {
+          "name": "meetings_event_requester_idx",
+          "columns": ["event_id", "requester_id"],
+          "isUnique": false
+        },
+        "meetings_event_recipient_idx": {
+          "name": "meetings_event_recipient_idx",
+          "columns": ["event_id", "recipient_id"],
+          "isUnique": false
+        },
+        "meetings_no_duplicate_request": {
+          "name": "meetings_no_duplicate_request",
+          "columns": ["event_id", "requester_id", "recipient_id", "slot_start"],
+          "isUnique": true,
+          "where": "\"meetings\".\"status\" in ('pending', 'accepted')"
+        }
+      },
+      "foreignKeys": {
+        "meetings_event_id_events_id_fk": {
+          "name": "meetings_event_id_events_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_requester_id_guests_id_fk": {
+          "name": "meetings_requester_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_recipient_id_guests_id_fk": {
+          "name": "meetings_recipient_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_guest_created_idx": {
+          "name": "notifications_guest_created_idx",
+          "columns": ["guest_id", "created_at"],
+          "isUnique": false
+        },
+        "notifications_guest_read_idx": {
+          "name": "notifications_guest_read_idx",
+          "columns": ["guest_id", "read_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_guest_id_guests_id_fk": {
+          "name": "notifications_guest_id_guests_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_comments": {
+      "name": "profile_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_comments_profile_idx": {
+          "name": "profile_comments_profile_idx",
+          "columns": ["profile_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_comments_comment_id_comments_id_fk": {
+          "name": "profile_comments_comment_id_comments_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_comments_profile_id_guests_id_fk": {
+          "name": "profile_comments_profile_id_guests_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "guests",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1788252381645,
       "tag": "0030_notifications",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1788511164512,
+      "tag": "0031_meeting_request_reask",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -1,0 +1,243 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "./helpers/fixtures";
+import { uniqueSuffix } from "./helpers/unique";
+import { loginAndGoto } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
+
+/**
+ * The event runs a month out. Relative to the run rather than a fixed date:
+ * the picker only offers slots that are still ahead, so a hard-coded October
+ * would quietly stop offering anything once October passed.
+ */
+const isoDay = (offsetDays: number) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+};
+const EVENT_START = isoDay(30);
+const EVENT_END = isoDay(32);
+
+/** How the picker heads that day's slots: luxon's "EEE d LLL". */
+const DAY_HEADING = new RegExp(
+  new Date(`${EVENT_START}T09:00:00Z`).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  })
+);
+
+/**
+ * Two throwaway attendees. Never the shared seeded guests: assigning those to
+ * a meetings-enabled event leaves them bookable for the rest of the run, which
+ * other specs then trip over -- admin.spec.ts warns about exactly this kind of
+ * global guest state.
+ */
+async function adminLogin(page: Page) {
+  await page.goto("/admin");
+  await page.getByLabel("Password").fill(ADMIN_PASSWORD);
+  await page.getByRole("button", { name: "Access Admin" }).click();
+  await expect(page).toHaveURL(/\/admin\/events$/);
+}
+
+async function createGuests(page: Page, names: string[]) {
+  await adminLogin(page);
+  await page.goto("/admin/users");
+  for (const name of names) {
+    await page.getByLabel("Name").fill(name);
+    await page
+      .getByLabel("Email")
+      .fill(`${name.toLowerCase().replace(/[^a-z0-9]/g, "-")}@test.example`);
+    await page.getByRole("button", { name: "Add user" }).click();
+    // The users table is paginated, so the new row isn't on screen; the form
+    // clearing itself is what says the create landed.
+    await expect(page.getByLabel("Name")).toHaveValue("");
+  }
+}
+
+/**
+ * An event with meetings on, one short day, a meeting point, and the two
+ * attendees — set up the way an organizer would, through the admin UI.
+ */
+async function meetingsEvent(page: Page, eventName: string, names: string[]) {
+  await page.goto("/admin/events");
+
+  // The list is server-rendered, so its buttons are clickable a moment before
+  // React attaches their handlers, and a click in that window is silently
+  // dropped. Re-checking first keeps a retry from acting twice.
+  // (helpers/user.ts hits the same hazard in the header.)
+  const nameField = page.getByLabel("Name *");
+  await expect(async () => {
+    if (!(await nameField.isVisible())) {
+      await page.getByRole("button", { name: "New event" }).click();
+    }
+    await expect(nameField).toBeVisible({ timeout: 2000 });
+  }).toPass();
+
+  await nameField.fill(eventName);
+  await page.getByLabel("Start *").fill(EVENT_START);
+  await page.getByLabel("End *").fill(EVENT_END);
+
+  const row = page.getByRole("listitem").filter({ hasText: eventName });
+  await expect(async () => {
+    // The form closes on success, which is what stops a retry re-submitting.
+    if (await nameField.isVisible()) {
+      await page.getByRole("button", { name: "Create event" }).click();
+    }
+    await expect(row).toBeVisible({ timeout: 3000 });
+  }).toPass();
+
+  await row.getByRole("link", { name: "Manage" }).click();
+
+  const meetings = page.getByRole("form", { name: "Meetings" });
+  await meetings.getByLabel("Enable meetings").check();
+  await meetings.getByRole("button", { name: /add meeting point/i }).click();
+  await meetings.getByLabel("Name *").fill("Coffee bar");
+  await meetings.getByRole("button", { name: /add meeting point/i }).click();
+  await meetings.getByRole("button", { name: "Save meetings" }).click();
+  await expect(meetings.getByText("Saved!")).toBeVisible();
+
+  await page.getByRole("button", { name: "Add day" }).click();
+  await page.getByLabel("Start *").last().fill(`${EVENT_START}T09:00`);
+  await page.getByLabel("End *").last().fill(`${EVENT_START}T10:00`);
+  await page.getByLabel("Bookings open *").fill(`${EVENT_START}T09:00`);
+  await page.getByLabel("Bookings close *").fill(`${EVENT_START}T10:00`);
+  await page.getByRole("button", { name: "Add day" }).last().click();
+  await expect(page.getByText(`${EVENT_START}T09:00`)).toBeVisible();
+
+  await page.getByRole("link", { name: "Guests" }).click();
+  const guests = page.getByRole("region", { name: "Guests" });
+  for (const name of names) {
+    // The list is paginated, and a just-created guest is rarely on page one.
+    await guests.getByPlaceholder("Search name or email…").fill(name);
+    const assign = guests
+      .getByRole("row")
+      .filter({ hasText: name })
+      .getByRole("checkbox", { name: /^Assign / });
+    await assign.click();
+    await expect(assign).toBeChecked();
+  }
+}
+
+// selectUser logs out and back in; navigating before that settles aborts the
+// request and drops the selection. Same helper the comment specs use.
+async function actAs(page: Page, name: RegExp) {
+  await selectUser(page, name);
+  await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
+}
+
+// Each directory row is a link whose name is the whole row, so the name alone
+// never matches exactly.
+async function openProfile(page: Page, name: string) {
+  await page.goto("/guests");
+  await page
+    .getByPlaceholder(/search/i)
+    .first()
+    .fill(name);
+  await page
+    .getByRole("link", { name: new RegExp(name) })
+    .first()
+    .click();
+  await expect(page.getByRole("heading", { name })).toBeVisible();
+}
+
+test.describe("requesting a 1-on-1", () => {
+  // Torn down in afterEach rather than at the end of the test body. Every
+  // event is a link in the site header, and a header long enough to push the
+  // name chip out of reach breaks every later spec that picks a user -- so an
+  // assertion failing halfway through must not leave one behind. The guests go
+  // too: they stop being bookable with the event, but they would otherwise
+  // pile up in the directory run after run.
+  const leftBehind: { events: string[]; guests: string[] } = {
+    events: [],
+    guests: [],
+  };
+
+  test.afterEach(async ({ page }) => {
+    for (const eventName of leftBehind.events.splice(0)) {
+      await page.goto("/admin/events");
+      await page
+        .getByRole("listitem")
+        .filter({ hasText: eventName })
+        .getByRole("link", { name: "Manage" })
+        .click();
+      await page.getByRole("button", { name: "Delete event" }).click();
+      await page.getByLabel("Type the event name to confirm").fill(eventName);
+      await page.getByRole("button", { name: "Confirm delete" }).click();
+      await expect(page).toHaveURL(/\/admin\/events$/);
+    }
+
+    for (const name of leftBehind.guests.splice(0)) {
+      await page.goto("/admin/users");
+      // The table is paginated, so a guest created mid-run is rarely on page one.
+      await page.getByPlaceholder("Search name or email…").fill(name);
+      const row = page.getByRole("listitem").filter({ hasText: name });
+      await row.getByRole("button", { name: "Delete" }).click();
+      await row.getByRole("button", { name: "Confirm delete" }).click();
+      await expect(row).toBeHidden();
+    }
+  });
+
+  test("books a slot the other attendee declared, from their profile", async ({
+    page,
+  }) => {
+    // One journey through the whole feature, and it drives the admin UI to set
+    // the event up first: it lands within a few seconds of the 30s default on
+    // an idle machine, so it goes over the moment the suite runs it alongside
+    // anything else.
+    test.slow();
+
+    const unique = uniqueSuffix();
+    const eventName = `E2E Request ${unique}`;
+    const asker = `Asker ${unique}`;
+    const askee = `Askee ${unique}`;
+    await createGuests(page, [asker, askee]);
+    leftBehind.guests.push(asker, askee);
+    await meetingsEvent(page, eventName, [asker, askee]);
+    leftBehind.events.push(eventName);
+    const slug = eventName.replace(/ /g, "-");
+
+    // Nobody is bookable yet, so the profile offers nothing.
+    await loginAndGoto(page, "/guests");
+    await actAs(page, new RegExp(asker));
+    await openProfile(page, askee);
+    await expect(
+      page.getByRole("button", { name: /schedule a meeting/i })
+    ).toBeHidden();
+
+    // The askee declares they are open to meetings.
+    await page.goto(`/${slug}/meetings`);
+    await actAs(page, new RegExp(askee));
+    await page.goto(`/${slug}/meetings`);
+    const availability = page.getByRole("form", { name: "1-on-1 meetings" });
+    await availability.getByLabel(/open to 1-on-1 meetings/).check();
+    await availability
+      .getByRole("button", { name: "Save availability" })
+      .click();
+    await expect(availability.getByText("Saved!")).toBeVisible();
+
+    // Alice books him from his profile.
+    await actAs(page, new RegExp(asker));
+    await openProfile(page, askee);
+
+    const schedule = page.getByRole("button", { name: /schedule a meeting/i });
+    await expect(schedule).toBeVisible();
+    await schedule.click();
+
+    // Where to meet first: picking a slot can insert a busy warning above
+    // this row, and clicking into a shifting layout is what Playwright
+    // reports as "element is not stable".
+    const send = page.getByRole("button", { name: "Send request" });
+    await expect(send).toBeVisible();
+    await page.getByRole("button", { name: "Coffee bar" }).click();
+
+    // Every day has an 09:00, so the slot has to be found within its own day.
+    const dayRegion = page.getByRole("region", { name: DAY_HEADING }).first();
+    await dayRegion.getByRole("button", { name: /^09:00/ }).click();
+
+    await send.click();
+
+    await expect(page.getByText(new RegExp(`Asked ${askee}`))).toBeVisible();
+  });
+});

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -147,6 +147,15 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       await import("@/app/(site)/[eventSlug]/comment-actions");
     return deleteComment({ commentId: "c", eventSlug: "s" });
   },
+  "actions/meetings.ts:requestMeetingAction": async () => {
+    const { requestMeetingAction } = await import("@/app/actions/meetings");
+    return requestMeetingAction({
+      eventId: "e",
+      recipientId: "g",
+      slotStart: new Date().toISOString(),
+      meetingPoint: "Coffee bar",
+    });
+  },
   "actions/meetings.ts:saveMeetingAvailabilityAction": async () => {
     const { saveMeetingAvailabilityAction } =
       await import("@/app/actions/meetings");

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -83,12 +83,12 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       await import("@/app/(site)/guests/profile-activity");
     return listProfileActivity("some-guest");
   },
-  "(site)/[eventSlug]/clash-actions.ts:detectHostClashes": async () => {
-    const { detectHostClashes } =
+  "(site)/[eventSlug]/clash-actions.ts:detectGuestClashes": async () => {
+    const { detectGuestClashes } =
       await import("@/app/(site)/[eventSlug]/clash-actions");
-    return detectHostClashes({
+    return detectGuestClashes({
       eventId: "e",
-      hostIds: ["g"],
+      guestIds: ["g"],
       start: new Date().toISOString(),
       end: new Date().toISOString(),
     });

--- a/tests/integration/action-site-auth.test.ts
+++ b/tests/integration/action-site-auth.test.ts
@@ -45,7 +45,7 @@ import {
 } from "../helpers/guest-cookie";
 import { AUTH_COOKIE_NAME, createAuthCookie } from "@/utils/auth";
 import { listProfileActivity } from "@/app/(site)/guests/profile-activity";
-import { detectHostClashes } from "@/app/(site)/[eventSlug]/clash-actions";
+import { detectGuestClashes } from "@/app/(site)/[eventSlug]/clash-actions";
 import { revalidateEvent } from "@/app/(site)/[eventSlug]/session-actions";
 import { createProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
 
@@ -108,13 +108,13 @@ describe("server actions require site auth", () => {
     expect(revalidatePath).toHaveBeenCalledWith("/some-event", "layout");
   });
 
-  it("detectHostClashes refuses a caller with no site-auth cookie", async () => {
+  it("detectGuestClashes refuses a caller with no site-auth cookie", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     await expect(
-      detectHostClashes({
+      detectGuestClashes({
         eventId: event.id,
-        hostIds: [host.id],
+        guestIds: [host.id],
         start: T(10).toISOString(),
         end: T(11).toISOString(),
       })
@@ -124,22 +124,22 @@ describe("server actions require site auth", () => {
   // The `busy` clash kind exists to keep a host's private RSVPs off the
   // client, so site auth alone is too weak a gate: it is shared with every
   // attendee. The caller must be acting as a guest in their own right.
-  it("detectHostClashes refuses a site-authenticated caller with no name selected", async () => {
+  it("detectGuestClashes refuses a site-authenticated caller with no name selected", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     await siteAuthenticate();
 
     await expect(
-      detectHostClashes({
+      detectGuestClashes({
         eventId: event.id,
-        hostIds: [host.id],
+        guestIds: [host.id],
         start: T(10).toISOString(),
         end: T(11).toISOString(),
       })
     ).rejects.toThrow();
   });
 
-  it("detectHostClashes refuses a caller claiming a protected guest without a verified session", async () => {
+  it("detectGuestClashes refuses a caller claiming a protected guest without a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     const caller = await createGuest({ eventId: event.id });
@@ -148,16 +148,16 @@ describe("server actions require site auth", () => {
     cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(caller.id));
 
     await expect(
-      detectHostClashes({
+      detectGuestClashes({
         eventId: event.id,
-        hostIds: [host.id],
+        guestIds: [host.id],
         start: T(10).toISOString(),
         end: T(11).toISOString(),
       })
     ).rejects.toThrow();
   });
 
-  it("detectHostClashes answers a verified guest", async () => {
+  it("detectGuestClashes answers a verified guest", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     const caller = await createGuest({ eventId: event.id });
@@ -170,9 +170,9 @@ describe("server actions require site auth", () => {
     await siteAuthenticate();
     cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(caller.id));
 
-    const clashes = await detectHostClashes({
+    const clashes = await detectGuestClashes({
       eventId: event.id,
-      hostIds: [host.id],
+      guestIds: [host.id],
       start: T(10).toISOString(),
       end: T(11).toISOString(),
     });

--- a/tests/integration/guest-clashes.test.ts
+++ b/tests/integration/guest-clashes.test.ts
@@ -23,7 +23,7 @@ vi.mock("next/headers", () => ({
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { detectHostClashes } from "@/app/(site)/[eventSlug]/clash-actions";
+import { detectGuestClashes } from "@/app/(site)/[eventSlug]/clash-actions";
 import { AUTH_COOKIE_NAME, createAuthCookie } from "@/utils/auth";
 import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
 
@@ -32,7 +32,7 @@ const VALID_SECRET = "0123456789abcdef0123456789abcdef";
 // A host's own hosted sessions are public, so a clash may name them; the
 // sessions a host merely RSVP'd to are private, so a clash must only report
 // that they are "busy" at that time — never which session.
-describe("detectHostClashes", () => {
+describe("detectGuestClashes", () => {
   beforeAll(() => setupTestDb());
   // Clash detection reports when a host is privately busy, so it needs both
   // site auth and a guest the caller may act as; these tests are about what
@@ -61,9 +61,9 @@ describe("detectHostClashes", () => {
       endTime: T(11),
     });
 
-    const clashes = await detectHostClashes({
+    const clashes = await detectGuestClashes({
       eventId: event.id,
-      hostIds: [host.id],
+      guestIds: [host.id],
       start: T(10, 30).toISOString(),
       end: T(11, 30).toISOString(),
     });
@@ -86,9 +86,9 @@ describe("detectHostClashes", () => {
       guestId: host.id,
     });
 
-    const clashes = await detectHostClashes({
+    const clashes = await detectGuestClashes({
       eventId: event.id,
-      hostIds: [host.id],
+      guestIds: [host.id],
       start: T(10, 30).toISOString(),
       end: T(11, 30).toISOString(),
     });
@@ -109,9 +109,9 @@ describe("detectHostClashes", () => {
       endTime: T(10),
     });
 
-    const clashes = await detectHostClashes({
+    const clashes = await detectGuestClashes({
       eventId: event.id,
-      hostIds: [host.id],
+      guestIds: [host.id],
       start: T(10).toISOString(),
       end: T(11).toISOString(),
     });
@@ -129,14 +129,117 @@ describe("detectHostClashes", () => {
       endTime: T(11),
     });
 
-    const clashes = await detectHostClashes({
+    const clashes = await detectGuestClashes({
       eventId: event.id,
-      hostIds: [host.id],
+      guestIds: [host.id],
       start: T(10).toISOString(),
       end: T(11).toISOString(),
       excludeSessionId: editing.id,
     });
 
     expect(clashes).toEqual([]);
+  });
+
+  // An accepted 1-on-1 occupies the guest just as an RSVP does, and who it is
+  // with is nobody else's business -- so it reports busy with no title.
+  it("reports an accepted meeting as busy, without naming the other party", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest();
+    const other = await createGuest({ name: "Their counterpart" });
+    const meeting = await getRepositories().meetings.create({
+      eventId: event.id,
+      requesterId: other.id,
+      recipientId: guest.id,
+      slotStart: T(10),
+      slotEnd: T(10, 30),
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: T(9),
+    });
+    await getRepositories().meetings.updateStatus(
+      meeting.id,
+      "accepted",
+      T(9, 30),
+      ["pending"]
+    );
+
+    const clashes = await detectGuestClashes({
+      eventId: event.id,
+      guestIds: [guest.id],
+      start: T(10).toISOString(),
+      end: T(10, 30).toISOString(),
+    });
+
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].kind).toBe("busy");
+    expect(clashes[0].title).toBeNull();
+    expect(JSON.stringify(clashes)).not.toContain("Their counterpart");
+  });
+
+  // Only an agreed meeting is a commitment; the other three states are not
+  // something the guest has to be anywhere for.
+  for (const status of ["pending", "declined", "canceled"] as const) {
+    it(`ignores a meeting that is only ${status}`, async () => {
+      const event = await createEvent({ phase: "scheduling" });
+      const guest = await createGuest();
+      const other = await createGuest();
+      const repos = getRepositories();
+      const meeting = await repos.meetings.create({
+        eventId: event.id,
+        requesterId: other.id,
+        recipientId: guest.id,
+        slotStart: T(10),
+        slotEnd: T(10, 30),
+        meetingPoint: "Coffee bar",
+        message: "",
+        createdAt: T(9),
+      });
+      if (status !== "pending") {
+        await repos.meetings.updateStatus(meeting.id, status, T(9, 30), [
+          "pending",
+        ]);
+      }
+
+      const clashes = await detectGuestClashes({
+        eventId: event.id,
+        guestIds: [guest.id],
+        start: T(10).toISOString(),
+        end: T(10, 30).toISOString(),
+      });
+
+      expect(clashes).toEqual([]);
+    });
+  }
+
+  it("counts a meeting the guest requested, not only ones they received", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest();
+    const other = await createGuest();
+    const meeting = await getRepositories().meetings.create({
+      eventId: event.id,
+      requesterId: guest.id,
+      recipientId: other.id,
+      slotStart: T(10),
+      slotEnd: T(10, 30),
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: T(9),
+    });
+    await getRepositories().meetings.updateStatus(
+      meeting.id,
+      "accepted",
+      T(9, 30),
+      ["pending"]
+    );
+
+    const clashes = await detectGuestClashes({
+      eventId: event.id,
+      guestIds: [guest.id],
+      start: T(10, 15).toISOString(),
+      end: T(10, 45).toISOString(),
+    });
+
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].kind).toBe("busy");
   });
 });

--- a/tests/integration/meeting-options.test.ts
+++ b/tests/integration/meeting-options.test.ts
@@ -1,0 +1,273 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { siteAuthenticate } from "../helpers/site-auth";
+import {
+  createEvent,
+  createGuest,
+  createDay,
+  createSession,
+} from "../helpers/factories";
+import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import { cookies } from "next/headers";
+import { meetingOptionsFor } from "@/utils/meeting-options";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+const DAY_START = new Date("2026-10-01T09:00:00.000Z");
+const DAY_END = new Date("2026-10-01T12:00:00.000Z");
+const SLOT_A = "2026-10-01T09:00:00.000Z";
+const SLOT_B = "2026-10-01T09:30:00.000Z";
+const SLOT_C = "2026-10-01T10:00:00.000Z";
+
+async function signIn(guestId: string) {
+  cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guestId));
+}
+
+async function scenario(opts?: {
+  declared?: string[];
+  eventPatch?: Record<string, unknown>;
+}) {
+  const repos = getRepositories();
+  const event = await createEvent({ phase: "scheduling" });
+  await repos.events.update(event.id, {
+    meetingsEnabled: true,
+    ...opts?.eventPatch,
+  });
+  await createDay(event.id, { start: DAY_START, end: DAY_END });
+  const viewer = await createGuest({ eventId: event.id });
+  const other = await createGuest({ name: "Yuki", eventId: event.id });
+  await repos.meetingAvailability.replaceForGuest(
+    other.id,
+    event.id,
+    (opts?.declared ?? [SLOT_A, SLOT_B, SLOT_C]).map((s) => new Date(s))
+  );
+  await signIn(viewer.id);
+  return { event, viewer, other };
+}
+
+type Option = Awaited<ReturnType<typeof meetingOptionsFor>>[number];
+
+// The profile resolves the viewer from their cookie before calling, so the
+// signed-out case stays a real one.
+const listMeetingOptions = async (recipientId: string): Promise<Option[]> =>
+  meetingOptionsFor(
+    await verifiedCurrentUser(await cookies()),
+    recipientId,
+    await getRepositories().events.list()
+  );
+
+const allSlots = (option: Option) => option.days.flatMap((d) => d.slots);
+
+const slotAt = (option: Option, start: string) =>
+  allSlots(option).find((s) => s.start === start)!;
+
+describe("meeting options on a profile", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await siteAuthenticate(cookieJar);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("offers the event, its meeting points and their declared slots", async () => {
+    const { event, other } = await scenario({ declared: [SLOT_A, SLOT_C] });
+    await getRepositories().meetingPoints.create({
+      eventId: event.id,
+      name: "Coffee bar",
+      description: "By reception",
+      sortIndex: 0,
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    expect(option.eventName).toBe(event.name);
+    expect(option.meetingPoints.map((p) => p.name)).toEqual(["Coffee bar"]);
+    expect(slotAt(option, SLOT_A).state).toBe("available");
+    expect(slotAt(option, SLOT_C).state).toBe("available");
+  });
+
+  // A slot they cleared reads as their decision, not a clash, and is the only
+  // state the picker refuses to select.
+  it("marks a slot they cleared unavailable", async () => {
+    const { other } = await scenario({ declared: [SLOT_A] });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    expect(slotAt(option, SLOT_B).state).toBe("unavailable");
+  });
+
+  it("marks a slot busy when they are hosting, and names the session", async () => {
+    const { event, other } = await scenario();
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [other.id],
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    const slot = slotAt(option, SLOT_A);
+    expect(slot.state).toBe("busy");
+    expect(slot.clashes[0].kind).toBe("hosting");
+    expect(slot.clashes[0].title).toBe("Their talk");
+  });
+
+  it("never names a session they only RSVP'd to", async () => {
+    const { event, other } = await scenario();
+    const secret = await createSession(event.id, {
+      title: "Secret RSVP session",
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+    await getRepositories().rsvps.create({
+      sessionId: secret.id,
+      guestId: other.id,
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    const slot = slotAt(option, SLOT_A);
+    expect(slot.state).toBe("busy");
+    expect(slot.clashes[0].title).toBeNull();
+    expect(JSON.stringify(option)).not.toContain("Secret RSVP session");
+  });
+
+  // The warning covers either party: your own clash matters to you too.
+  it("marks a slot busy when the viewer is the one with the clash", async () => {
+    const { event, viewer, other } = await scenario();
+    await createSession(event.id, {
+      title: "My own talk",
+      hostIds: [viewer.id],
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    const slot = slotAt(option, SLOT_A);
+    expect(slot.state).toBe("busy");
+    // Marked so the warning can say "You are hosting", not name the reader
+    // back to themselves in the third person.
+    expect(slot.clashes[0].isViewer).toBe(true);
+  });
+
+  it("does not mark the other party's clash as the viewer's own", async () => {
+    const { event, other } = await scenario();
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [other.id],
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    expect(slotAt(option, SLOT_A).clashes[0].isViewer).toBe(false);
+  });
+
+  it("says nothing when they are open to no slots at all", async () => {
+    const { other } = await scenario({ declared: [] });
+
+    expect(await listMeetingOptions(other.id)).toEqual([]);
+  });
+
+  it("says nothing when the organizer has meetings off", async () => {
+    const { other } = await scenario({
+      eventPatch: { meetingsEnabled: false },
+    });
+
+    expect(await listMeetingOptions(other.id)).toEqual([]);
+  });
+
+  it("says nothing about your own profile", async () => {
+    const { viewer } = await scenario();
+
+    expect(await listMeetingOptions(viewer.id)).toEqual([]);
+  });
+
+  it("says nothing when nobody is signed in", async () => {
+    const { other } = await scenario();
+    cookieJar.clear();
+    await siteAuthenticate(cookieJar);
+
+    expect(await listMeetingOptions(other.id)).toEqual([]);
+  });
+
+  it("says nothing about an event only one of you attends", async () => {
+    const { other } = await scenario();
+    const outsider = await createGuest();
+    await signIn(outsider.id);
+
+    expect(await listMeetingOptions(other.id)).toEqual([]);
+  });
+
+  // Day one of a three-day event must stop being bookable on day three.
+  it("leaves out slots that have already passed", async () => {
+    const { event, other } = await scenario();
+    const repos = getRepositories();
+    await createDay(event.id, {
+      start: new Date("2020-10-01T09:00:00.000Z"),
+      end: new Date("2020-10-01T12:00:00.000Z"),
+    });
+    await repos.meetingAvailability.replaceForGuest(other.id, event.id, [
+      new Date(SLOT_A),
+      new Date("2020-10-01T09:00:00.000Z"),
+    ]);
+
+    const [option] = await listMeetingOptions(other.id);
+
+    expect(allSlots(option).every((s) => s.start > "2021")).toBe(true);
+  });
+
+  it("offers one option per shared event that has meetings on", async () => {
+    const { event, viewer, other } = await scenario();
+    const repos = getRepositories();
+    const second = await createEvent({ phase: "scheduling", name: "Second" });
+    await repos.events.update(second.id, {
+      meetingsEnabled: true,
+    });
+    await createDay(second.id, { start: DAY_START, end: DAY_END });
+    await repos.guests.assignToEvent(second.id, [viewer.id, other.id]);
+    await repos.meetingAvailability.replaceForGuest(other.id, second.id, [
+      new Date(SLOT_A),
+    ]);
+
+    const options = await listMeetingOptions(other.id);
+
+    expect(options.map((o) => o.eventName).sort()).toEqual(
+      [event.name, second.name].sort()
+    );
+  });
+});

--- a/tests/integration/meeting-request-action.test.ts
+++ b/tests/integration/meeting-request-action.test.ts
@@ -1,0 +1,306 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { siteAuthenticate } from "../helpers/site-auth";
+import { createEvent, createGuest, createDay } from "../helpers/factories";
+import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import { requestMeetingAction } from "@/app/actions/meetings";
+import type { Event, Guest } from "@/db/repositories/interfaces";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+const DAY_START = new Date("2026-10-01T09:00:00.000Z");
+const DAY_END = new Date("2026-10-01T17:00:00.000Z");
+const SLOT = "2026-10-01T10:00:00.000Z";
+const SLOT_2 = "2026-10-01T10:30:00.000Z";
+
+// A day of the same event that has already happened. Multi-day events spend
+// most of their run with days on both sides of "now".
+const PAST_DAY_START = new Date("2020-10-01T09:00:00.000Z");
+const PAST_DAY_END = new Date("2020-10-01T17:00:00.000Z");
+const PAST_SLOT = "2020-10-01T10:00:00.000Z";
+
+async function signIn(guestId: string) {
+  cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guestId));
+}
+
+/** An event with meetings on, a day, and two attendees; the recipient is bookable. */
+async function scenario(patch?: Record<string, unknown>) {
+  const repos = getRepositories();
+  const event = await createEvent();
+  await repos.events.update(event.id, {
+    meetingsEnabled: true,
+    maxOpenMeetingRequests: 5,
+    ...patch,
+  });
+  await createDay(event.id, { start: DAY_START, end: DAY_END });
+  const requester = await createGuest({ eventId: event.id });
+  const recipient = await createGuest({ eventId: event.id });
+  await repos.meetingAvailability.replaceForGuest(recipient.id, event.id, [
+    new Date(SLOT),
+    new Date(SLOT_2),
+  ]);
+  await signIn(requester.id);
+  const reloaded = (await repos.events.findById(event.id)) as Event;
+  return { event: reloaded, requester, recipient };
+}
+
+const request = (
+  event: Event,
+  recipient: Guest,
+  patch?: Partial<Parameters<typeof requestMeetingAction>[0]>
+) =>
+  requestMeetingAction({
+    eventId: event.id,
+    recipientId: recipient.id,
+    slotStart: SLOT,
+    meetingPoint: "Coffee bar",
+    message: "Would love to talk about the attendance model",
+    ...patch,
+  });
+
+describe("requestMeetingAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await siteAuthenticate(cookieJar);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("creates a pending request", async () => {
+    const { event, requester, recipient } = await scenario();
+
+    const result = await request(event, recipient);
+
+    expect(result.ok).toBe(true);
+    const [meeting] = await getRepositories().meetings.listByGuestAndEvent(
+      requester.id,
+      event.id
+    );
+    expect(meeting.requesterId).toBe(requester.id);
+    expect(meeting.recipientId).toBe(recipient.id);
+    expect(meeting.status).toBe("pending");
+    expect(meeting.meetingPoint).toBe("Coffee bar");
+    expect(meeting.slotStart.toISOString()).toBe(SLOT);
+    // The slot's length comes from the event, never from the caller.
+    expect(meeting.slotEnd.toISOString()).toBe(SLOT_2);
+  });
+
+  it("requires a meeting point", async () => {
+    const { event, recipient } = await scenario();
+
+    const result = await request(event, recipient, { meetingPoint: "   " });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("keeps the message optional", async () => {
+    const { event, requester, recipient } = await scenario();
+
+    const result = await request(event, recipient, { message: undefined });
+
+    expect(result.ok).toBe(true);
+    const [meeting] = await getRepositories().meetings.listByGuestAndEvent(
+      requester.id,
+      event.id
+    );
+    expect(meeting.message).toBe("");
+  });
+
+  // Only slots the recipient cleared are a hard no (the design on issue #392);
+  // a clash is a warning the requester waves through, so it must not be
+  // rejected here.
+  it("refuses a slot the recipient did not declare", async () => {
+    const { event, recipient } = await scenario();
+
+    const result = await request(event, recipient, {
+      slotStart: "2026-10-01T11:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a slot the event does not offer at all", async () => {
+    const { event, recipient } = await scenario();
+
+    const result = await request(event, recipient, {
+      slotStart: "2026-10-01T10:17:00.000Z",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses booking yourself", async () => {
+    const { event, requester } = await scenario();
+    await getRepositories().meetingAvailability.replaceForGuest(
+      requester.id,
+      event.id,
+      [new Date(SLOT)]
+    );
+
+    const result = await request(event, requester);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a recipient who is not attending the event", async () => {
+    const { event } = await scenario();
+    const outsider = await createGuest();
+
+    const result = await request(event, outsider);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses when meetings are off for the event", async () => {
+    const { event, recipient } = await scenario({ meetingsEnabled: false });
+
+    const result = await request(event, recipient);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a second request for the same person and slot", async () => {
+    const { event, recipient } = await scenario();
+    await request(event, recipient);
+
+    const again = await request(event, recipient);
+
+    expect(again.ok).toBe(false);
+  });
+
+  it("stops the requester at the organizer's open-request cap", async () => {
+    const { event, requester, recipient } = await scenario({
+      maxOpenMeetingRequests: 1,
+    });
+    await request(event, recipient);
+
+    const second = await request(event, recipient, { slotStart: SLOT_2 });
+
+    expect(second.ok).toBe(false);
+    expect(
+      await getRepositories().meetings.listByGuestAndEvent(
+        requester.id,
+        event.id
+      )
+    ).toHaveLength(1);
+  });
+
+  // The cap only counts requests whose slot is still ahead, so a past slot
+  // that could be booked would be an unbounded hole in it.
+  it("refuses a slot that has already passed", async () => {
+    const { event, recipient } = await scenario();
+    await createDay(event.id, {
+      start: PAST_DAY_START,
+      end: PAST_DAY_END,
+    });
+    await getRepositories().meetingAvailability.replaceForGuest(
+      recipient.id,
+      event.id,
+      [new Date(SLOT), new Date(PAST_SLOT)]
+    );
+
+    const result = await request(event, recipient, { slotStart: PAST_SLOT });
+
+    expect(result.ok).toBe(false);
+  });
+
+  // A "use server" export is a public endpoint: the declared types are
+  // advisory, so a hand-made payload has to come back as a result rather than
+  // a 500.
+  it("answers a malformed payload instead of throwing", async () => {
+    const { event, recipient } = await scenario();
+
+    const result = await request(event, recipient, {
+      meetingPoint: 123 as unknown as string,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Invalid request" });
+  });
+
+  it("refuses a message longer than the field allows", async () => {
+    const { event, recipient } = await scenario();
+
+    const result = await request(event, recipient, {
+      message: "x".repeat(5000),
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a second request while the first is still accepted", async () => {
+    const { event, requester, recipient } = await scenario();
+    await request(event, recipient);
+    const repos = getRepositories();
+    const [meeting] = await repos.meetings.listByGuestAndEvent(
+      requester.id,
+      event.id
+    );
+    await repos.meetings.updateStatus(meeting.id, "accepted", new Date(), [
+      "pending",
+    ]);
+
+    expect((await request(event, recipient)).ok).toBe(false);
+  });
+
+  // Once a request is off the table the pair may well agree on that slot after
+  // all -- and a requester who cancelled by accident must not be locked out of
+  // the time they wanted.
+  for (const status of ["declined", "canceled"] as const) {
+    it(`lets them ask again after the first was ${status}`, async () => {
+      const { event, requester, recipient } = await scenario();
+      await request(event, recipient);
+      const repos = getRepositories();
+      const [meeting] = await repos.meetings.listByGuestAndEvent(
+        requester.id,
+        event.id
+      );
+      await repos.meetings.updateStatus(meeting.id, status, new Date(), [
+        "pending",
+      ]);
+
+      const again = await request(event, recipient);
+
+      expect(again.ok).toBe(true);
+    });
+  }
+
+  it("refuses when nobody is signed in", async () => {
+    const { event, recipient } = await scenario();
+    cookieJar.clear();
+    await siteAuthenticate(cookieJar);
+
+    const result = await request(event, recipient);
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/tests/integration/meetings-repositories.test.ts
+++ b/tests/integration/meetings-repositories.test.ts
@@ -399,19 +399,19 @@ describe("meetings", () => {
       createdAt: new Date("2026-09-01T08:00:00.000Z"),
     });
 
-    const first = await meetings.createIfUnderCap(
+    const first = await meetings.createIfAllowed(
       request(SLOT_A, SLOT_B),
       1,
       BEFORE_SLOTS
     );
-    const second = await meetings.createIfUnderCap(
+    const second = await meetings.createIfAllowed(
       request(SLOT_B, SLOT_C),
       1,
       BEFORE_SLOTS
     );
 
-    expect(first?.status).toBe("pending");
-    expect(second).toBeNull();
+    expect(first).toHaveProperty("meeting.status", "pending");
+    expect(second).toEqual({ refused: "cap" });
     expect(
       await meetings.listByGuestAndEvent(requester.id, event.id)
     ).toHaveLength(1);
@@ -430,20 +430,25 @@ describe("meetings", () => {
       message: "",
       createdAt: new Date("2026-09-01T08:00:00.000Z"),
     });
-    const first = await meetings.createIfUnderCap(
+    const first = await meetings.createIfAllowed(
       request(SLOT_A, SLOT_B),
       1,
       BEFORE_SLOTS
     );
-    await meetings.updateStatus(first!.id, "declined", new Date(), ["pending"]);
+    await meetings.updateStatus(
+      (first as { meeting: { id: string } }).meeting.id,
+      "declined",
+      new Date(),
+      ["pending"]
+    );
 
-    const second = await meetings.createIfUnderCap(
+    const second = await meetings.createIfAllowed(
       request(SLOT_B, SLOT_C),
       1,
       BEFORE_SLOTS
     );
 
-    expect(second?.status).toBe("pending");
+    expect(second).toHaveProperty("meeting.status", "pending");
   });
 
   // Asking the same person twice for the same slot is a double submit, not a

--- a/utils/guest-clashes.ts
+++ b/utils/guest-clashes.ts
@@ -1,0 +1,146 @@
+import { getRepositories } from "@/db/container";
+import type { Meeting, Session } from "@/db/repositories/interfaces";
+import { newEmptySession, sessionsOverlap } from "@/app/(site)/session_utils";
+import { getStartTimePlusBreak } from "./utils";
+
+// A schedule clash for one guest, computed server-side so their private RSVPs
+// and meetings never reach the client. Hosting a session is public, so those
+// clashes name the session; RSVP'd sessions and agreed 1-on-1s are private, so
+// those only report that the guest is "busy" for the overlapping interval —
+// never which session, or who the meeting is with.
+export type GuestClash = {
+  guestId: string;
+  guestName: string;
+  kind: "hosting" | "busy";
+  /** Only set for hosting clashes (public); null for busy/RSVP clashes. */
+  title: string | null;
+  /** ISO strings; `start` is break-adjusted for display, matching the schedule. */
+  start: string;
+  end: string;
+};
+
+/**
+ * One guest's commitments at an event. Loaded once and asked about many
+ * intervals: the slot picker checks a hundred of them, and reloading per
+ * interval would be hundreds of queries for one screen.
+ */
+export type GuestSchedule = {
+  guestId: string;
+  guestName: string;
+  hosted: Session[];
+  rsvpd: Session[];
+  meetings: Meeting[];
+};
+
+export async function loadGuestSchedules(
+  eventId: string,
+  guestIds: string[]
+): Promise<GuestSchedule[]> {
+  const repos = getRepositories();
+  const schedules: GuestSchedule[] = [];
+  for (const guestId of guestIds) {
+    const guest = await repos.guests.findById(guestId);
+    if (!guest) continue;
+    const [hosted, rsvpd, meetings] = await Promise.all([
+      repos.sessions.listHostedByGuest(guestId),
+      repos.sessions.listRsvpdByGuest(guestId),
+      repos.meetings.listByGuestAndEvent(guestId, eventId),
+    ]);
+    schedules.push({
+      guestId,
+      guestName: guest.name,
+      hosted,
+      rsvpd,
+      meetings,
+    });
+  }
+  return schedules;
+}
+
+/**
+ * Everything in `schedules` that overlaps [start, end). The one place the
+ * clash rule lives: the session form asks about a single candidate, the slot
+ * picker asks about every slot of the event.
+ */
+export function clashesForInterval(
+  schedules: GuestSchedule[],
+  opts: {
+    eventId: string;
+    start: Date;
+    end: Date;
+    breakMinutes: number;
+    /** The session being edited, which must not clash with itself. */
+    excludeSessionId?: string | null;
+  }
+): GuestClash[] {
+  const { eventId, start, end, breakMinutes, excludeSessionId } = opts;
+
+  // sessionsOverlap skips a session whose id matches the candidate's, which is
+  // how the session being edited is excluded from clashing with itself.
+  const candidate: Session = {
+    ...newEmptySession(eventId),
+    id: excludeSessionId ?? "",
+    startTime: start,
+    endTime: end,
+  };
+
+  const inEventAndOverlapping = (ses: Session) =>
+    ses.eventId === eventId &&
+    ses.startTime != null &&
+    ses.endTime != null &&
+    sessionsOverlap(ses, candidate);
+
+  const clashes: GuestClash[] = [];
+
+  for (const schedule of schedules) {
+    const hostingClashes = schedule.hosted.filter(inEventAndOverlapping);
+    const hostingIds = new Set(hostingClashes.map((s) => s.id));
+
+    for (const ses of hostingClashes) {
+      clashes.push({
+        guestId: schedule.guestId,
+        guestName: schedule.guestName,
+        kind: "hosting",
+        title: ses.title,
+        start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
+        end: ses.endTime!.toISOString(),
+      });
+    }
+
+    // A host RSVP'ing to a session they also host is already reported above.
+    for (const ses of schedule.rsvpd.filter(inEventAndOverlapping)) {
+      if (hostingIds.has(ses.id)) continue;
+      clashes.push({
+        guestId: schedule.guestId,
+        guestName: schedule.guestName,
+        kind: "busy",
+        title: null,
+        start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
+        end: ses.endTime!.toISOString(),
+      });
+    }
+
+    // Only accepted ones: a pending request is not yet a commitment, and
+    // declined or canceled ones never were. Who the meeting is with is as
+    // private as an RSVP, so it reports busy with no title.
+    for (const meeting of schedule.meetings) {
+      if (meeting.status !== "accepted") continue;
+      if (
+        meeting.slotStart.getTime() >= end.getTime() ||
+        meeting.slotEnd.getTime() <= start.getTime()
+      ) {
+        continue;
+      }
+      clashes.push({
+        guestId: schedule.guestId,
+        guestName: schedule.guestName,
+        kind: "busy",
+        title: null,
+        start: meeting.slotStart.toISOString(),
+        end: meeting.slotEnd.toISOString(),
+      });
+    }
+  }
+
+  return clashes;
+}

--- a/utils/meeting-options.ts
+++ b/utils/meeting-options.ts
@@ -1,0 +1,152 @@
+import { getRepositories } from "@/db/container";
+import { serverNow } from "@/utils/dev-clock-server";
+import { meetingSlotsForDay } from "@/utils/meeting-slots";
+import {
+  clashesForInterval,
+  loadGuestSchedules,
+  type GuestClash,
+} from "@/utils/guest-clashes";
+import { DateTime } from "luxon";
+import type { Event, MeetingPoint } from "@/db/repositories/interfaces";
+
+/** One slot of the picker, in the three states of the design (issue #392). */
+export type MeetingSlotOption = {
+  start: string;
+  label: string;
+  state: "available" | "busy" | "unavailable";
+  /** Why it reads as busy. Empty unless `state` is "busy". */
+  clashes: (Pick<GuestClash, "guestName" | "kind" | "title"> & {
+    /** The viewer's own clash, so the warning can say "you" rather than
+        naming the reader back to themselves in the third person. */
+    isViewer: boolean;
+  })[];
+};
+
+/**
+ * One day's worth of the picker. Slots are grouped rather than each carrying
+ * its own day label: this ships on every profile open, for every shared event,
+ * and the label is the same string for every slot of the day.
+ */
+export type MeetingDayOption = {
+  label: string;
+  slots: MeetingSlotOption[];
+};
+
+export type MeetingOption = {
+  eventId: string;
+  eventName: string;
+  meetingPoints: Pick<MeetingPoint, "id" | "name" | "description">[];
+  days: MeetingDayOption[];
+};
+
+/**
+ * What the viewer may book with `recipientId`, one entry per event they both
+ * attend where meetings are on and the recipient is bookable. Empty means no
+ * button: the profile shows nothing rather than a dead control.
+ *
+ * `events` is the site's event list, passed in rather than looked up per
+ * shared event: the caller already holds it.
+ */
+export async function meetingOptionsFor(
+  viewerId: string | null,
+  recipientId: string,
+  events: Event[]
+): Promise<MeetingOption[]> {
+  // Booking yourself is not a thing, and an unidentified visitor has no
+  // schedule to compare against.
+  if (!viewerId || viewerId === recipientId) return [];
+
+  const repos = getRepositories();
+  const attending = await repos.guests.listEventsByGuests([
+    viewerId,
+    recipientId,
+  ]);
+  const viewerEvents = attending.get(viewerId) ?? [];
+  const sharedIds = new Set(
+    (attending.get(recipientId) ?? []).map((e) => e.id)
+  );
+
+  const now = await serverNow();
+  const options: MeetingOption[] = [];
+  for (const { id: eventId } of viewerEvents) {
+    if (!sharedIds.has(eventId)) continue;
+    const event = events.find((e) => e.id === eventId);
+    if (!event?.meetingsEnabled) continue;
+
+    const declared = await repos.meetingAvailability.listByGuestAndEvent(
+      recipientId,
+      eventId
+    );
+    // No declared slots is exactly the state of someone who never switched
+    // meetings on, so there is nothing to offer.
+    if (declared.length === 0) continue;
+    const declaredStarts = new Set(declared.map((d) => d.toISOString()));
+
+    const [days, meetingPoints, schedules] = await Promise.all([
+      repos.days.listByEvent(eventId),
+      repos.meetingPoints.listByEvent(eventId),
+      // Both parties: a clash of the viewer's own is a warning they want too.
+      loadGuestSchedules(eventId, [recipientId, viewerId]),
+    ]);
+
+    const zoned = (date: Date) =>
+      DateTime.fromJSDate(date).setZone(event.timezone);
+
+    const dayOptions: MeetingDayOption[] = [];
+    for (const day of days) {
+      const slots: MeetingSlotOption[] = [];
+      for (const slot of meetingSlotsForDay(day, event.slotIncrementMinutes)) {
+        // Day one of a three-day event stops being bookable once it is past --
+        // and the organizer's cap only counts requests still ahead.
+        if (slot.start <= now) continue;
+        const start = slot.start.toISOString();
+        const label = `${zoned(slot.start).toFormat("HH:mm")} – ${zoned(
+          slot.end
+        ).toFormat("HH:mm")}`;
+        if (!declaredStarts.has(start)) {
+          slots.push({ start, label, state: "unavailable", clashes: [] });
+          continue;
+        }
+        const clashes = clashesForInterval(schedules, {
+          eventId,
+          start: slot.start,
+          end: slot.end,
+          breakMinutes: event.breakMinutes,
+        });
+        slots.push({
+          start,
+          label,
+          // Busy is a warning, never a wall: still selectable.
+          state: clashes.length > 0 ? "busy" : "available",
+          clashes: clashes.map(({ guestId, guestName, kind, title }) => ({
+            guestName,
+            kind,
+            title,
+            isViewer: guestId === viewerId,
+          })),
+        });
+      }
+      if (slots.length > 0) {
+        dayOptions.push({
+          label: zoned(day.start).toFormat("EEE d LLL"),
+          slots,
+        });
+      }
+    }
+
+    if (dayOptions.length === 0) continue;
+
+    options.push({
+      eventId,
+      eventName: event.name,
+      meetingPoints: meetingPoints.map(({ id, name, description }) => ({
+        id,
+        name,
+        description,
+      })),
+      days: dayOptions,
+    });
+  }
+
+  return options;
+}


### PR DESCRIPTION
Fifth of the PRs for schellingboard/schellingboard#392 (1-on-1 meetings), following the
[design approved on the issue](https://github.com/LWCW-Europe/schellingboard/issues/392#issuecomment-5470900325).

**Stacked on schellingboard/schellingboard-legacy#939**, which is stacked on schellingboard/schellingboard-legacy#937 — review those first. Bases move down the
chain as each lands.

> **One commit to ignore**: the tip commit is schellingboard/schellingboard-legacy#938's nav fix, included so this branch's
> E2E suite can pass (the suite creates enough events to hit the bug it fixes). It is
> *not* part of this change and disappears when schellingboard/schellingboard-legacy#938 merges and this rebases. The four
> commits below it are the actual PR.

## What's here

Asking someone for a 1-on-1. On an attendee's profile, **Schedule a meeting** — one
button per event the pair share where meetings are on and that attendee is bookable, so
nothing shows at all when there is nothing to book. The picker lists their slots day by
day in the design's three states, takes a meeting point and an optional line of context,
and sends.

**Busy is a warning, never a wall.** A slot either party has a session or an accepted
meeting in is still selectable, and picking one says so — *"You are busy during this slot
— book it anyway?"*. Only a slot the recipient cleared is unselectable, because that is
their decision rather than a clash. That follows the parallel-RSVP policy from schellingboard/schellingboard-legacy#11.

## Decisions worth a reviewer's attention

**The clash rule now lives in one place, split in two.** `utils/guest-clashes.ts` has
`loadGuestSchedules` (a guest's commitments, fetched once) and `clashesForInterval`
(answers about one interval, in memory). The session form asks about a single candidate;
the picker asks about every slot of the event, and reloading per slot would be hundreds
of queries for one screen. `detectGuestClashes` is now a thin `"use server"` wrapper over
both, so the privacy rule — hosted sessions may be named, RSVP'd ones may not, and now
neither may the other party in a meeting — still has exactly one implementation.

**The picker's options ride along with `listProfileActivity`**, the call the profile
already makes, rather than an action of their own. A server action re-renders the route's
RSC tree, and the tree behind a profile is the whole attendee directory.

**A clash carries whose it is**, so the warning says "You are" rather than naming the
reader back to themselves in the third person. Compared by guest id, not name — two
attendees may share a name.

**The request action enforces what is enforceable and nothing else.** A slot the
recipient cleared is refused; a clash is not, because the pair decide that themselves.
The slot's length comes from the event, never the caller. The cap goes through
`createIfUnderCap` so the check and the insert are one transaction, and the unique index
turns a repeat request into a friendly error rather than a 500.

## Testing

`make precommit` is green on this branch. Two bugs found by driving the real app rather
than the tests: the picker's modal rendered *behind* the profile modal (it needs
`portal` + a higher z-index, as `comment-likes.tsx` already does), and the meeting-point
field showed an invalid-red border before anyone had typed in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
