### PR TITLE
feat: accept or decline a 1-on-1 request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   **1-on-1s** link where attendees turn on "I'm open to 1-on-1 meetings at this event" and clear the
   slots they want kept free. Turning it on marks every slot free, and turning it back off clears the
   lot — nobody can book you while it's off
-- **Ask someone for a 1-on-1**: an attendee's profile now offers **Schedule a meeting** for each
-  event you both attend where they are open to them. Pick one of their free slots, say where to
-  meet and add a line of context. A slot where either of you is hosting or has RSVP'd to something
-  is marked busy, but you can still book it — only slots they cleared are off limits
+- **Ask an attendee for a 1-on-1, and answer the ones you get**: their profile gains a **Schedule a
+  meeting** button — pick one of the slots they're open for, say where to meet and add a line of
+  context. A slot where either of you is hosting or has RSVP'd is still bookable, with a warning;
+  only the slots they cleared are off limits. The person asked gets a notification with **Accept**
+  and **Decline**, and hears about their own clashes before they answer; the asker is told either
+  way. A request nobody answers before its slot begins simply lapses
 
 ### Fixed
 

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -11,6 +11,7 @@ import { EventContext } from "../context";
 import { getDefaultFoldedDayIds } from "@/utils/schedule-fold";
 import { KioskController, useKioskMode } from "./kiosk";
 import { SessionModal } from "./session-modal";
+import { MeetingModalFromUrl } from "./meeting-modal";
 import type { DayWithSessions } from "../context";
 import { useDragToPan } from "./use-drag-to-pan";
 import Footer from "@/app/footer";
@@ -157,6 +158,7 @@ export function EventDisplay() {
       {viewSession && (
         <SessionModal sessionId={viewSession} eventSlug={event.slug} />
       )}
+      <MeetingModalFromUrl />
       {kiosk && <KioskController />}
     </>
   );

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useContext, useEffect, useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { respondToMeetingAction } from "@/app/actions/meetings";
+import { clashLine } from "@/utils/meeting-clash-text";
+import type { MeetingView } from "@/utils/meeting-views";
+import { EventContext } from "../context";
+import { dismissViewMeeting } from "./modal-nav";
+
+const PRIMARY =
+  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+const SECONDARY =
+  "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+
+/** What has become of the request, in the words of whoever is reading. */
+function statusLine(meeting: MeetingView): string {
+  const them = meeting.otherName;
+  switch (meeting.status) {
+    case "pending":
+      return meeting.role === "recipient"
+        ? `${them} is waiting for your answer.`
+        : `Waiting for ${them} to answer.`;
+    case "accepted":
+      return "Confirmed — see you there.";
+    case "declined":
+      return meeting.role === "recipient"
+        ? "You declined this."
+        : `${them} declined this.`;
+    case "canceled":
+      return "This meeting was canceled.";
+    case "expired":
+      // Nobody is at fault for an unanswered request, so it is not phrased as
+      // one: the slot simply came and went (issue #392, section 1.4).
+      return "Nobody answered before the slot began.";
+  }
+}
+
+/**
+ * The meeting modal wherever `?viewMeeting=` can be opened — the meetings page
+ * a notification links to, and the schedule. Reads the parameter itself rather
+ * than taking it as a prop so dismissing it (a history replaceState) closes the
+ * modal on a server-rendered page too.
+ */
+export function MeetingModalFromUrl() {
+  const meetingId = useSearchParams()?.get("viewMeeting");
+  return meetingId ? <MeetingModal meetingId={meetingId} /> : null;
+}
+
+/**
+ * One 1-on-1 in full, and — for the person asked — the Accept and Decline
+ * buttons.
+ */
+function MeetingModal({ meetingId }: { meetingId: string }) {
+  const { event } = useContext(EventContext);
+  const router = useRouter();
+  const [meetings, setMeetings] = useState<MeetingView[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isAnswering, startAnswer] = useTransition();
+
+  const eventId = event?.id;
+
+  // Duplication, anchor: waggHhba
+  useEffect(() => {
+    document.documentElement.style.overflow = "hidden";
+    const handleEscapeKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dismissViewMeeting();
+    };
+    document.addEventListener("keydown", handleEscapeKey);
+    return () => {
+      document.documentElement.style.overflow = "";
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, []);
+
+  // Fetched rather than server-rendered: a meeting is private to its two
+  // guests, so it has no place in the schedule's shared render
+  // (issue #392, section 2.6).
+  useEffect(() => {
+    if (!eventId) return;
+    const controller = new AbortController();
+    void fetch(`/api/meetings?event=${eventId}`, { signal: controller.signal })
+      .then((res) => (res.ok ? (res.json() as Promise<MeetingView[]>) : []))
+      .then(setMeetings)
+      // Closing the modal aborts the request, and leaving the page has the
+      // browser kill it; either way there is nobody left to tell.
+      .catch(() => undefined);
+    return () => controller.abort();
+  }, [eventId]);
+
+  const meeting = meetings?.find((m) => m.id === meetingId);
+
+  const answer = (response: "accept" | "decline") => {
+    setError(null);
+    startAnswer(async () => {
+      try {
+        const result = await respondToMeetingAction({ meetingId, response });
+        if (!result.ok) {
+          setError(result.error);
+          return;
+        }
+        setMeetings(
+          (current) =>
+            current?.map((m) =>
+              m.id === meetingId
+                ? {
+                    ...m,
+                    status: response === "accept" ? "accepted" : "declined",
+                  }
+                : m
+            ) ?? null
+        );
+        // An accepted meeting is a commitment, so the schedule behind the
+        // modal now has one more thing in it.
+        router.refresh();
+      } catch {
+        setError("Request failed");
+      }
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Meeting details"
+    >
+      <div className="fixed inset-0 bg-overlay" onClick={dismissViewMeeting} />
+      <div className="relative bg-surface-raised rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto p-6">
+        <button
+          onClick={dismissViewMeeting}
+          className="absolute top-4 right-4 text-fg-subtle hover:text-fg-muted"
+          aria-label="Close"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+
+        {meetings === null ? (
+          <p className="text-fg-muted">Loading…</p>
+        ) : !meeting ? (
+          <p className="text-fg-muted">Meeting not found.</p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <h2 className="text-xl font-bold text-fg pr-8">
+              1-on-1 with {meeting.otherName}
+            </h2>
+
+            <dl className="flex flex-col gap-1 text-sm">
+              <div className="flex gap-2">
+                <dt className="font-medium text-fg-muted">When</dt>
+                <dd className="text-fg">
+                  {meeting.dayLabel}, {meeting.timeLabel}
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-medium text-fg-muted">Where</dt>
+                <dd className="text-fg">{meeting.meetingPoint}</dd>
+              </div>
+            </dl>
+
+            <p className="text-sm text-fg-muted">{statusLine(meeting)}</p>
+
+            {meeting.message && (
+              <p className="text-sm rounded-md bg-surface-sunken p-3 text-fg">
+                {meeting.message}
+              </p>
+            )}
+
+            {/* The same fact the requester was shown when they booked it, from
+                the other side: the person answering knows whether their own
+                session matters more (issue #392, section 1.4). */}
+            {meeting.clashes.length > 0 && (
+              <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
+                {[...new Set(meeting.clashes.map(clashLine))].join("; ")} during
+                this slot.
+              </p>
+            )}
+
+            {error && <p className="text-sm text-danger-fg">{error}</p>}
+
+            {meeting.role === "recipient" && meeting.status === "pending" && (
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => answer("accept")}
+                  disabled={isAnswering}
+                  className={PRIMARY}
+                >
+                  Accept
+                </button>
+                {/* Declining takes no explanation: the failure mode of this
+                    feature is people feeling obliged (issue #392,
+                    section 1.4). */}
+                <button
+                  type="button"
+                  onClick={() => answer("decline")}
+                  disabled={isAnswering}
+                  className={SECONDARY}
+                >
+                  Decline
+                </button>
+              </div>
+            )}
+
+            <p className="text-xs text-fg-subtle">
+              Nothing is reserved — the meeting point is just where to find each
+              other.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useContext, useEffect, useState, useTransition } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { respondToMeetingAction } from "@/app/actions/meetings";
+import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
 import { clashLine } from "@/utils/meeting-clash-text";
 import type { MeetingView } from "@/utils/meeting-views";
 import { EventContext } from "../context";
 import { dismissViewMeeting } from "./modal-nav";
-
-const PRIMARY =
-  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
-const SECONDARY =
-  "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 
 /** What has become of the request, in the words of whoever is reading. */
 function statusLine(meeting: MeetingView): string {
@@ -77,17 +79,26 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
   // Fetched rather than server-rendered: a meeting is private to its two
   // guests, so it has no place in the schedule's shared render
   // (issue #392, section 2.6).
+  const load = useCallback(
+    (signal?: AbortSignal) => {
+      if (!eventId) return;
+      void fetch(`/api/meetings?event=${eventId}`, { signal })
+        .then((res) => (res.ok ? (res.json() as Promise<MeetingView[]>) : []))
+        .then(setMeetings)
+        // Closing the modal aborts the request, and leaving the page has the
+        // browser kill it; either way there is nobody left to tell.
+        .catch(() => undefined);
+    },
+    [eventId]
+  );
+
+  // Keyed on the meeting too: an opener that swaps one id for another without
+  // unmounting would otherwise render the second from the first one's answer.
   useEffect(() => {
-    if (!eventId) return;
     const controller = new AbortController();
-    void fetch(`/api/meetings?event=${eventId}`, { signal: controller.signal })
-      .then((res) => (res.ok ? (res.json() as Promise<MeetingView[]>) : []))
-      .then(setMeetings)
-      // Closing the modal aborts the request, and leaving the page has the
-      // browser kill it; either way there is nobody left to tell.
-      .catch(() => undefined);
+    load(controller.signal);
     return () => controller.abort();
-  }, [eventId]);
+  }, [load, meetingId]);
 
   const meeting = meetings?.find((m) => m.id === meetingId);
 
@@ -98,6 +109,10 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
         const result = await respondToMeetingAction({ meetingId, response });
         if (!result.ok) {
           setError(result.error);
+          // Refused because the meeting has moved on -- answered in another
+          // tab, or its slot has begun -- so the buttons and the status line
+          // are describing a request that no longer exists.
+          load();
           return;
         }
         setMeetings(
@@ -119,6 +134,9 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
       }
     });
   };
+
+  // The modal has no event to ask about; the same guard session-modal.tsx has.
+  if (!event) return null;
 
   return (
     <div
@@ -199,7 +217,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                   type="button"
                   onClick={() => answer("accept")}
                   disabled={isAnswering}
-                  className={PRIMARY}
+                  className={PRIMARY_BUTTON}
                 >
                   Accept
                 </button>
@@ -210,7 +228,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                   type="button"
                   onClick={() => answer("decline")}
                   disabled={isAnswering}
-                  className={SECONDARY}
+                  className={SECONDARY_BUTTON}
                 >
                   Decline
                 </button>

--- a/app/(site)/[eventSlug]/meetings/availability-form.tsx
+++ b/app/(site)/[eventSlug]/meetings/availability-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { BackLink } from "@/app/components/back-link";
 import { saveMeetingAvailabilityAction } from "@/app/actions/meetings";
+import { PRIMARY_BUTTON } from "@/app/components/buttons";
 
 export type SlotDay = {
   /** Two days may share a date, so the id is what keys them apart. */
@@ -11,8 +12,6 @@ export type SlotDay = {
   slots: { start: string; label: string }[];
 };
 
-const BUTTON =
-  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 const QUIET_BUTTON =
   "px-2 py-1 text-sm rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors";
 
@@ -195,7 +194,7 @@ export function AvailabilityForm({
         <button
           type="submit"
           disabled={isSaving || emptyWhileOpen}
-          className={BUTTON}
+          className={PRIMARY_BUTTON}
         >
           {isSaving ? "Saving..." : "Save availability"}
         </button>

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -15,16 +15,35 @@ export const dynamic = "force-dynamic";
 
 export default async function MeetingsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ eventSlug: string }>;
+  searchParams: Promise<{ viewMeeting?: string | string[] }>;
 }) {
   const { eventSlug } = await params;
   const repos = getRepositories();
   const event = await repos.events.findBySlug(eventSlug);
 
-  // The page only exists while the organizer offers meetings; the toolbar
-  // link is hidden then too, so this catches a stale link or a typed URL.
-  if (!event || !event.meetingsEnabled) notFound();
+  if (!event) notFound();
+
+  // Turning meetings off neither cancels nor deletes the requests already
+  // made, and every notification about one points here for good -- so a
+  // meeting still opens, even where there is no longer any availability to
+  // set. The toolbar link is hidden either way.
+  const { viewMeeting } = await searchParams;
+  if (!event.meetingsEnabled) {
+    if (!viewMeeting) notFound();
+    return (
+      <>
+        <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
+          {event.name} is no longer offering 1-on-1s, so there is no
+          availability to set — but the ones already arranged are still yours to
+          settle.
+        </PageNotice>
+        <MeetingModalFromUrl />
+      </>
+    );
+  }
 
   const cookieStore = await cookies();
   const currentUser = await verifiedCurrentUser(cookieStore);

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -8,6 +8,7 @@ import {
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
+import { MeetingModalFromUrl } from "../meeting-modal";
 import { AvailabilityForm, type SlotDay } from "./availability-form";
 
 export const dynamic = "force-dynamic";
@@ -94,15 +95,20 @@ export default async function MeetingsPage({
   const offered = new Set(slotDays.flatMap((d) => d.slots.map((s) => s.start)));
 
   return (
-    <AvailabilityForm
-      eventId={event.id}
-      eventSlug={eventSlug}
-      eventName={event.name}
-      timezone={event.timezone}
-      days={slotDays}
-      declared={declared
-        .map((d) => d.toISOString())
-        .filter((start) => offered.has(start))}
-    />
+    <>
+      <AvailabilityForm
+        eventId={event.id}
+        eventSlug={eventSlug}
+        eventName={event.name}
+        timezone={event.timezone}
+        days={slotDays}
+        declared={declared
+          .map((d) => d.toISOString())
+          .filter((start) => offered.has(start))}
+      />
+      {/* Where a meeting notification lands: this page is here in every phase,
+          while the schedule only exists once scheduling starts. */}
+      <MeetingModalFromUrl />
+    </>
   );
 }

--- a/app/(site)/[eventSlug]/modal-nav.ts
+++ b/app/(site)/[eventSlug]/modal-nav.ts
@@ -107,6 +107,19 @@ export function openingModalFromRedirect() {
   proposalDismissMode = "replace";
 }
 
+// Meetings have no in-place opener yet, so a meeting modal is always reached
+// by a link from elsewhere — a notification — where "back" would leave the
+// site rather than the modal.
+export function dismissViewMeeting() {
+  const params = new URLSearchParams(window.location.search);
+  params.delete("viewMeeting");
+  const query = params.toString();
+  const url = query
+    ? `${window.location.pathname}?${query}`
+    : window.location.pathname;
+  window.history.replaceState(null, "", url);
+}
+
 export function dismissViewProposal(router: ReturnType<typeof useRouter>) {
   if (proposalDismissMode === "back") {
     router.back();

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -4,25 +4,13 @@ import { useState, useTransition } from "react";
 import { Modal } from "@/app/components/modal";
 import { Input } from "@/app/input";
 import { requestMeetingAction } from "@/app/actions/meetings";
-import type {
-  MeetingDayOption,
-  MeetingOption,
-  MeetingSlotOption,
-} from "@/utils/meeting-options";
+import { clashLine } from "@/utils/meeting-clash-text";
+import type { MeetingDayOption, MeetingOption } from "@/utils/meeting-options";
 
 const PRIMARY =
   "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 const SECONDARY =
   "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
-
-/** "Yuki is hosting Their talk" / "You are busy" — never which private session. */
-function clashLine(clash: MeetingSlotOption["clashes"][number]): string {
-  const who = clash.isViewer ? "You" : clash.guestName;
-  const is = clash.isViewer ? "are" : "is";
-  return clash.kind === "hosting" && clash.title
-    ? `${who} ${is} hosting ${clash.title}`
-    : `${who} ${is} busy`;
-}
 
 function SlotList({
   days,

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -4,13 +4,9 @@ import { useState, useTransition } from "react";
 import { Modal } from "@/app/components/modal";
 import { Input } from "@/app/input";
 import { requestMeetingAction } from "@/app/actions/meetings";
+import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
 import { clashLine } from "@/utils/meeting-clash-text";
 import type { MeetingDayOption, MeetingOption } from "@/utils/meeting-options";
-
-const PRIMARY =
-  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
-const SECONDARY =
-  "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 
 function SlotList({
   days,
@@ -119,7 +115,7 @@ function RequestForm({
           Asked {recipientName} for {slot?.label} on {day?.label}. You&apos;ll
           hear when they answer.
         </p>
-        <button type="button" onClick={onDone} className={PRIMARY}>
+        <button type="button" onClick={onDone} className={PRIMARY_BUTTON}>
           Done
         </button>
       </div>
@@ -215,11 +211,11 @@ function RequestForm({
         <button
           type="submit"
           disabled={isSending || !slotStart || !meetingPoint.trim()}
-          className={PRIMARY}
+          className={PRIMARY_BUTTON}
         >
           {isSending ? "Sending..." : "Send request"}
         </button>
-        <button type="button" onClick={onDone} className={SECONDARY}>
+        <button type="button" onClick={onDone} className={SECONDARY_BUTTON}>
           Cancel
         </button>
       </div>
@@ -254,7 +250,7 @@ export function MeetingPicker({
           key={option.eventId}
           type="button"
           onClick={() => setOpenEventId(option.eventId)}
-          className={SECONDARY}
+          className={SECONDARY_BUTTON}
         >
           {options.length === 1
             ? "Schedule a meeting"

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -106,6 +106,14 @@ export function SettingsForm({
             someone comments on a proposal, session or profile I&rsquo;ve
             commented on
           </label>
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
+            <input type="checkbox" {...form.register("meetingRequest")} />
+            someone asks me for a 1-on-1 meeting
+          </label>
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
+            <input type="checkbox" {...form.register("meetingResponse")} />a
+            1-on-1 meeting of mine is accepted, declined or canceled
+          </label>
         </fieldset>
 
         {form.formState.errors.root && (

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -187,6 +187,9 @@ export async function respondToMeetingAction(
   if (meeting.recipientId !== guestId) {
     return { ok: false, error: "Only the person asked can answer this" };
   }
+  // No `meetingsEnabled` check, unlike requesting one: the switch stops new
+  // requests, and a pair already holding one still have to settle it. The
+  // meetings page renders the modal for the same reason.
 
   const now = await serverNow();
   // Expiry is derived rather than swept (issue #392, section 2.4), so it is

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -11,6 +11,10 @@ import {
 import { requireSiteAuth } from "@/utils/action-auth";
 import { serverNow } from "@/utils/dev-clock-server";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
+import {
+  notifyMeetingOutcome,
+  notifyMeetingRequested,
+} from "@/utils/notifications";
 import type { Event } from "@/db/repositories/interfaces";
 
 export type MeetingActionResult = { ok: true } | { ok: false; error: string };
@@ -27,6 +31,11 @@ const requestSchema = z.object({
   slotStart: z.string(),
   meetingPoint: z.string().max(200),
   message: z.string().max(2000).optional(),
+});
+
+const respondSchema = z.object({
+  meetingId: z.string(),
+  response: z.enum(["accept", "decline"]),
 });
 
 const availabilitySchema = z.object({
@@ -147,6 +156,63 @@ export async function requestMeetingAction(
     };
   }
 
+  await notifyMeetingRequested({ meeting: outcome.meeting, now });
+
+  return { ok: true };
+}
+
+/**
+ * The recipient's answer to a request. Accepting has nothing to reject — no
+ * room is reserved and a clash is only ever a warning — so this is a status
+ * change plus telling the requester.
+ */
+export async function respondToMeetingAction(
+  raw: z.input<typeof respondSchema>
+): Promise<MeetingActionResult> {
+  await requireSiteAuth();
+
+  const parsed = respondSchema.safeParse(raw);
+  if (!parsed.success) return { ok: false, error: "Invalid request" };
+  const input = parsed.data;
+
+  const guestId = await verifiedCurrentUser(await cookies());
+  if (!guestId) {
+    return { ok: false, error: "Sign in to answer a meeting request" };
+  }
+
+  const repos = getRepositories();
+  const meeting = await repos.meetings.findById(input.meetingId);
+  if (!meeting) return { ok: false, error: "Meeting not found" };
+  // Only the person asked can answer; the requester's own control is cancelling.
+  if (meeting.recipientId !== guestId) {
+    return { ok: false, error: "Only the person asked can answer this" };
+  }
+
+  const now = await serverNow();
+  // Expiry is derived rather than swept (issue #392, section 2.4), so it is
+  // checked here: answering a request whose slot has begun would agree to a
+  // past meeting.
+  if (meeting.slotStart.getTime() <= now.getTime()) {
+    return { ok: false, error: "That slot has already started" };
+  }
+
+  const outcome = input.response === "accept" ? "accepted" : "declined";
+  const answered = await repos.meetings.updateStatus(meeting.id, outcome, now, [
+    "pending",
+  ]);
+  if (!answered) {
+    return { ok: false, error: "This request has already been answered" };
+  }
+
+  await notifyMeetingOutcome({
+    meeting: answered,
+    outcome,
+    actorId: guestId,
+    now,
+  });
+
+  const event = await repos.events.findById(meeting.eventId);
+  if (event) revalidatePath(`/${event.slug}`);
   return { ok: true };
 }
 

--- a/app/api/meetings/route.ts
+++ b/app/api/meetings/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
+import { requestNow } from "@/utils/dev-clock";
+import { meetingViewsFor } from "@/utils/meeting-views";
+
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response and
+// go on showing a request that has since been answered.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
+// The viewer's own 1-on-1s at an event. Always the caller's own: a guest's
+// meetings are as private as their RSVPs, so there is no id parameter to ask
+// about someone else's.
+export async function GET(request: NextRequest) {
+  const eventId = request.nextUrl.searchParams.get("event");
+  if (!eventId) {
+    return NextResponse.json(
+      { error: "event parameter is required" },
+      { ...NO_STORE, status: 400 }
+    );
+  }
+
+  const guestId = await verifiedCurrentUser(request.cookies);
+  if (!guestId) {
+    return NextResponse.json(
+      { error: "Select your name to see your meetings" },
+      { ...NO_STORE, status: 403 }
+    );
+  }
+
+  try {
+    return NextResponse.json(
+      await meetingViewsFor(guestId, eventId, requestNow(request)),
+      NO_STORE
+    );
+  } catch (error) {
+    console.error("Error fetching meetings:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch meetings" },
+      { ...NO_STORE, status: 500 }
+    );
+  }
+}

--- a/app/components/buttons.ts
+++ b/app/components/buttons.ts
@@ -1,0 +1,9 @@
+/**
+ * The site's two button looks, as class strings. Shared because four copies
+ * of the same literal had already drifted apart in review; `app/admin` keeps
+ * its own pair, which the admin chrome is free to restyle on its own.
+ */
+export const PRIMARY_BUTTON =
+  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+export const SECONDARY_BUTTON =
+  "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -44,7 +44,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Meetings**: an event's Config tab can switch on 1-on-1s between attendees — the places you suggest people meet, and a cap on how many unanswered requests one person may have out.",
       "**Picking your name** works however many events a site runs: past about seven, the header's event links crowded the name chip off the row and there was no way to say who you are.",
       "**Say when you're free**: with meetings on, attendees get a 1-on-1s page to mark which slots they're open for. Turning the switch off clears it and keeps them unbookable.",
-      "**Ask someone for a 1-on-1** from their profile: pick one of their free slots, say where to meet, and send. Slots where either of you is already busy are flagged but still bookable.",
+      "**Ask for a 1-on-1**: attendees book one of the slots someone is open for from their profile, and say where to meet. The person asked accepts or declines, warned about anything it clashes with.",
     ],
   },
   {

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -206,29 +206,40 @@ Slots are as long as the event's schedule increment and cover the whole of each
 day. If the organizer later changes that increment, everyone's availability is
 cleared and you are asked to choose again — the slots themselves have moved.
 
-### Ask someone for a 1-on-1
+### Ask someone for a meeting
 
-Open anyone from the [attendee directory](#attendee-directory--profiles). If
-they are open to meetings at an event you both attend, their profile has a
-**Schedule a meeting** button; if there is no button, they haven't said they are
-free for any slot that is still ahead.
+Anyone who is open to meetings has a **Schedule a meeting** button on their
+profile. It shows their slots day by day:
 
-The picker lists their slots day by day:
+- **Available** — tap to pick it.
+- **Busy** — one of you is hosting a session then, has RSVP'd to one, or has
+  already agreed another 1-on-1. Still bookable: you get a warning naming the
+  clash, and decide for yourselves. You are never told which session someone
+  else RSVP'd to, only that they are busy.
+- **Unavailable** — a slot they cleared. That is their decision, and the one
+  thing you can't book.
 
-- **Plain** — they are free, and so are you.
-- **Busy** — one of you is hosting a session, has RSVP'd to one, or has another
-  1-on-1 then. It says who and, where it isn't private, what. This is only a
-  warning: you can still pick the slot and the two of you can sort it out.
-- **Unavailable** — a slot they cleared. These can't be picked.
+Then say **where to meet** — one of the organizer's suggestions, or anywhere you
+type yourself. Nothing is reserved and no place is ever "full": a meeting point
+is just where to find each other. You can add one line of context, and that's
+the whole message — this is a request, not a chat.
 
-Then say **where to meet** — either one of the places the organizer suggested,
-or type your own — and optionally add a line about what you'd like to talk
-about. Nothing is reserved: the meeting point is just how you find each other.
+The organizer sets how many requests you may have waiting for an answer at once.
+Once you are at that number, wait for a reply or cancel one first.
 
-Press **Send request** and they hear about it. Asking the same person for the
-same slot twice isn't possible while that request is still open, and the
-organizer caps how many unanswered requests you may have out at once — if you
-hit it, wait for a reply or cancel one.
+### Answering a request
+
+You'll get a notification (and an email, unless you've turned that off) with
+who, when, where and their line of context, and **Accept** or **Decline**.
+Declining takes no explanation — nobody should feel obliged.
+
+If the slot clashes with something of yours, the request says so before you
+answer: you are the one who knows whether your own session matters more. The
+person who asked was shown the same clash when they booked it.
+
+You can't change the time or the place — accept it or decline it, and let them
+ask again if it doesn't suit. Either way they are told. A request nobody answers
+before its slot begins simply lapses; nothing is held against you.
 
 ## Attendee directory & profiles
 
@@ -315,6 +326,7 @@ page lists everything newest first. You'll be told when:
 - someone adds you as a co-host
 - someone comments on a proposal or session you host, or on your profile
 - someone else comments on something you commented on
+- someone asks you for a 1-on-1, or answers a request of yours
 
 **Clicking a notification marks it read and takes you straight to what
 happened.** If you'd rather clear one without opening it, use the tick beside

--- a/emails/meeting.tsx
+++ b/emails/meeting.tsx
@@ -1,0 +1,82 @@
+import type { EmailMessage } from "@/utils/mailer";
+
+/** How a pending 1-on-1 ended, from the point of view of the guest being told. */
+export type MeetingOutcome = "accepted" | "declined" | "canceled";
+
+// The one-line version, for the in-app notification. The time is what tells
+// two requests from the same person apart, so it is always named.
+export function meetingRequestNoticeText(
+  requesterName: string,
+  time: string
+): string {
+  return `${requesterName} asked you for a 1-on-1 on ${time}`;
+}
+
+export function meetingOutcomeNoticeText(
+  actorName: string,
+  outcome: MeetingOutcome,
+  time: string
+): string {
+  return outcome === "canceled"
+    ? `${actorName} canceled the 1-on-1 on ${time}`
+    : `${actorName} ${outcome} your 1-on-1 request for ${time}`;
+}
+
+// Sent when someone asks the guest for a 1-on-1.
+//
+// The requester's line of context is deliberately left out, as comment text
+// is: it is enough to say there is a request and link to it, and what guests
+// write to each other need not go to their email providers.
+export function meetingRequestEmail(props: {
+  requesterName: string;
+  time: string;
+  meetingPoint: string;
+  url: string;
+}): EmailMessage {
+  return {
+    subject: `1-on-1 request from ${props.requesterName}`,
+    body: (
+      <>
+        <h1>{props.requesterName} would like to meet you</h1>
+        <p>
+          <strong>When:</strong> {props.time}
+        </p>
+        <p>
+          <strong>Where:</strong> {props.meetingPoint}
+        </p>
+        <p>
+          <a href={props.url}>Accept or decline</a>
+        </p>
+      </>
+    ),
+  };
+}
+
+// Sent to the other party when a 1-on-1 is accepted, declined or canceled.
+export function meetingOutcomeEmail(props: {
+  actorName: string;
+  outcome: MeetingOutcome;
+  time: string;
+  meetingPoint: string;
+  url: string;
+}): EmailMessage {
+  const accepted = props.outcome === "accepted";
+  return {
+    subject: `1-on-1 ${props.outcome}: ${props.time}`,
+    body: (
+      <>
+        <h1>
+          {meetingOutcomeNoticeText(props.actorName, props.outcome, props.time)}
+        </h1>
+        {accepted && (
+          <p>
+            <strong>Where:</strong> {props.meetingPoint}
+          </p>
+        )}
+        <p>
+          <a href={props.url}>View the meeting</a>
+        </p>
+      </>
+    ),
+  };
+}

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -142,7 +142,7 @@ async function openProfile(page: Page, name: string) {
   await expect(page.getByRole("heading", { name })).toBeVisible();
 }
 
-test.describe("requesting a 1-on-1", () => {
+test.describe("1-on-1 meetings", () => {
   // Torn down in afterEach rather than at the end of the test body. Every
   // event is a link in the site header, and a header long enough to push the
   // name chip out of reach breaks every later spec that picks a user -- so an
@@ -179,7 +179,7 @@ test.describe("requesting a 1-on-1", () => {
     }
   });
 
-  test("books a slot the other attendee declared, from their profile", async ({
+  test("books a slot the other attendee declared, and gets an answer", async ({
     page,
   }) => {
     // One journey through the whole feature, and it drives the admin UI to set
@@ -239,5 +239,36 @@ test.describe("requesting a 1-on-1", () => {
     await send.click();
 
     await expect(page.getByText(new RegExp(`Asked ${askee}`))).toBeVisible();
+
+    // The askee is told, and answers from the notification.
+    await page.goto("/guests");
+    await actAs(page, new RegExp(askee));
+    await page.getByRole("link", { name: /^Notifications/ }).click();
+    await page
+      .getByRole("button", {
+        name: new RegExp(`${asker} asked you for a 1-on-1`),
+      })
+      .click();
+
+    const meeting = page.getByRole("dialog", { name: "Meeting details" });
+    await expect(meeting).toBeVisible();
+    await expect(meeting.getByText("Coffee bar")).toBeVisible();
+    await meeting.getByRole("button", { name: "Accept" }).click();
+    await expect(meeting.getByText(/Confirmed/)).toBeVisible();
+
+    // Answering refreshes the page behind the modal. Navigating away while
+    // that RSC fetch is in flight aborts it, and Next reports the abort on the
+    // console -- which the console guard fails the test for.
+    await page.waitForLoadState("networkidle");
+
+    // And the asker hears back.
+    await page.goto("/guests");
+    await actAs(page, new RegExp(asker));
+    await page.getByRole("link", { name: /^Notifications/ }).click();
+    await expect(
+      page.getByRole("button", {
+        name: new RegExp(`${askee} accepted your 1-on-1`),
+      })
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -256,18 +256,60 @@ test.describe("1-on-1 meetings", () => {
     await meeting.getByRole("button", { name: "Accept" }).click();
     await expect(meeting.getByText(/Confirmed/)).toBeVisible();
 
+    // Closing it is a history replaceState rather than a navigation, which on
+    // this server-rendered page is the only thing that takes the modal away.
+    await meeting.getByRole("button", { name: "Close" }).click();
+    await expect(meeting).toBeHidden();
+
     // Answering refreshes the page behind the modal. Navigating away while
     // that RSC fetch is in flight aborts it, and Next reports the abort on the
     // console -- which the console guard fails the test for.
     await page.waitForLoadState("networkidle");
 
-    // And the asker hears back.
+    // And the asker hears back, then asks for the day's other slot.
     await page.goto("/guests");
     await actAs(page, new RegExp(asker));
     await page.getByRole("link", { name: /^Notifications/ }).click();
     await expect(
       page.getByRole("button", {
         name: new RegExp(`${askee} accepted your 1-on-1`),
+      })
+    ).toBeVisible();
+
+    await openProfile(page, askee);
+    await page.getByRole("button", { name: /schedule a meeting/i }).click();
+    const sendAgain = page.getByRole("button", { name: "Send request" });
+    await expect(sendAgain).toBeVisible();
+    await page.getByRole("button", { name: "Coffee bar" }).click();
+    await page
+      .getByRole("region", { name: DAY_HEADING })
+      .first()
+      .getByRole("button", { name: /^09:30/ })
+      .click();
+    await sendAgain.click();
+    await expect(page.getByText(new RegExp(`Asked ${askee}`))).toBeVisible();
+
+    // Declining takes no explanation, and says so in the reader's own words.
+    await page.goto("/guests");
+    await actAs(page, new RegExp(askee));
+    await page.getByRole("link", { name: /^Notifications/ }).click();
+    await page
+      .getByRole("button", {
+        name: new RegExp(`${asker} asked you for a 1-on-1`),
+      })
+      .first()
+      .click();
+    await expect(meeting).toBeVisible();
+    await meeting.getByRole("button", { name: "Decline" }).click();
+    await expect(meeting.getByText("You declined this.")).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    await page.goto("/guests");
+    await actAs(page, new RegExp(asker));
+    await page.getByRole("link", { name: /^Notifications/ }).click();
+    await expect(
+      page.getByRole("button", {
+        name: new RegExp(`${askee} declined your 1-on-1`),
       })
     ).toBeVisible();
   });

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -156,6 +156,10 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       meetingPoint: "Coffee bar",
     });
   },
+  "actions/meetings.ts:respondToMeetingAction": async () => {
+    const { respondToMeetingAction } = await import("@/app/actions/meetings");
+    return respondToMeetingAction({ meetingId: "m", response: "accept" });
+  },
   "actions/meetings.ts:saveMeetingAvailabilityAction": async () => {
     const { saveMeetingAvailabilityAction } =
       await import("@/app/actions/meetings");

--- a/tests/integration/meeting-request-action.test.ts
+++ b/tests/integration/meeting-request-action.test.ts
@@ -24,6 +24,10 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { siteAuthenticate } from "../helpers/site-auth";
 import { createEvent, createGuest, createDay } from "../helpers/factories";
@@ -113,6 +117,23 @@ describe("requestMeetingAction", () => {
     expect(meeting.slotStart.toISOString()).toBe(SLOT);
     // The slot's length comes from the event, never from the caller.
     expect(meeting.slotEnd.toISOString()).toBe(SLOT_2);
+  });
+
+  it("tells the recipient they were asked", async () => {
+    const { event, requester, recipient } = await scenario();
+
+    await request(event, recipient);
+
+    const [notification] = await getRepositories().notifications.listByGuest(
+      recipient.id
+    );
+    expect(notification.type).toBe("meetingRequest");
+    expect(notification.text).toContain(requester.name);
+    const [meeting] = await getRepositories().meetings.listByGuestAndEvent(
+      requester.id,
+      event.id
+    );
+    expect(notification.url).toContain(`/meetings?viewMeeting=${meeting.id}`);
   });
 
   it("requires a meeting point", async () => {

--- a/tests/integration/meeting-respond-action.test.ts
+++ b/tests/integration/meeting-respond-action.test.ts
@@ -162,6 +162,26 @@ describe("respondToMeetingAction", () => {
     ).toBe("accepted");
   });
 
+  // The pair are left holding a request either way, so the switch stops new
+  // ones rather than stranding the ones already made; the meetings page
+  // renders the modal for the same reason.
+  it("answers a request after the organizer switched meetings off", async () => {
+    const { event, meeting } = await scenario();
+    await getRepositories().events.update(event.id, {
+      meetingsEnabled: false,
+    });
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "accept",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("accepted");
+  });
+
   it("refuses a request whose slot has already started", async () => {
     const { meeting } = await scenario({ slotStart: PAST_SLOT });
 

--- a/tests/integration/meeting-respond-action.test.ts
+++ b/tests/integration/meeting-respond-action.test.ts
@@ -1,0 +1,215 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { siteAuthenticate } from "../helpers/site-auth";
+import { createEvent, createGuest } from "../helpers/factories";
+import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import { respondToMeetingAction } from "@/app/actions/meetings";
+import type { Event, Guest, Meeting } from "@/db/repositories/interfaces";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+const FUTURE_SLOT = new Date("2099-10-01T10:00:00.000Z");
+const PAST_SLOT = new Date("2020-10-01T10:00:00.000Z");
+
+async function signIn(guestId: string) {
+  cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guestId));
+}
+
+/** A pending request from one attendee to another, with the recipient signed in. */
+async function scenario(opts?: { slotStart?: Date }): Promise<{
+  event: Event;
+  requester: Guest;
+  recipient: Guest;
+  meeting: Meeting;
+}> {
+  const repos = getRepositories();
+  const event = await createEvent();
+  await repos.events.update(event.id, { meetingsEnabled: true });
+  const requester = await createGuest({ eventId: event.id });
+  const recipient = await createGuest({ eventId: event.id });
+  const slotStart = opts?.slotStart ?? FUTURE_SLOT;
+  const meeting = await repos.meetings.create({
+    eventId: event.id,
+    requesterId: requester.id,
+    recipientId: recipient.id,
+    slotStart,
+    slotEnd: new Date(slotStart.getTime() + 30 * 60 * 1000),
+    meetingPoint: "Coffee bar",
+    message: "Would love to talk about the attendance model",
+    createdAt: new Date(),
+  });
+  await signIn(recipient.id);
+  return {
+    event: (await repos.events.findById(event.id)) as Event,
+    requester,
+    recipient,
+    meeting,
+  };
+}
+
+describe("respondToMeetingAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await siteAuthenticate(cookieJar);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("accepts a pending request", async () => {
+    const { meeting } = await scenario();
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "accept",
+    });
+
+    expect(result.ok).toBe(true);
+    const after = await getRepositories().meetings.findById(meeting.id);
+    expect(after?.status).toBe("accepted");
+    expect(after?.respondedAt).toBeDefined();
+  });
+
+  it("declines a pending request", async () => {
+    const { meeting } = await scenario();
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "decline",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("declined");
+  });
+
+  it("tells the requester what was answered", async () => {
+    const { requester, meeting } = await scenario();
+
+    await respondToMeetingAction({ meetingId: meeting.id, response: "accept" });
+
+    const [notification] = await getRepositories().notifications.listByGuest(
+      requester.id
+    );
+    expect(notification.type).toBe("meetingResponse");
+    expect(notification.text).toMatch(/accepted/);
+    expect(notification.url).toContain(`/meetings?viewMeeting=${meeting.id}`);
+  });
+
+  it("refuses an answer from anyone but the recipient", async () => {
+    const { requester, meeting } = await scenario();
+    await signIn(requester.id);
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "accept",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("pending");
+  });
+
+  // Someone answering in a second tab, or a requester who cancelled meanwhile:
+  // the first answer stands rather than being overwritten.
+  it("refuses to answer a request twice", async () => {
+    const { meeting } = await scenario();
+    await respondToMeetingAction({ meetingId: meeting.id, response: "accept" });
+
+    const again = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "decline",
+    });
+
+    expect(again.ok).toBe(false);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("accepted");
+  });
+
+  it("refuses a request whose slot has already started", async () => {
+    const { meeting } = await scenario({ slotStart: PAST_SLOT });
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "accept",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("pending");
+  });
+
+  it("refuses when nobody is signed in", async () => {
+    const { meeting } = await scenario();
+    cookieJar.clear();
+    await siteAuthenticate(cookieJar);
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "accept",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses an unknown meeting", async () => {
+    await scenario();
+
+    const result = await respondToMeetingAction({
+      meetingId: "no-such-meeting",
+      response: "accept",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  // A "use server" export is a public endpoint: the declared types are
+  // advisory, so a hand-made payload has to come back as a result, not a 500.
+  it("answers a malformed payload instead of throwing", async () => {
+    const { meeting } = await scenario();
+
+    const result = await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "maybe" as unknown as "accept",
+    });
+
+    expect(result).toEqual({ ok: false, error: "Invalid request" });
+  });
+});

--- a/tests/integration/meeting-views.test.ts
+++ b/tests/integration/meeting-views.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { meetingViewsFor } from "@/utils/meeting-views";
+import type { Event, Guest, Meeting } from "@/db/repositories/interfaces";
+
+const SLOT_START = new Date("2026-10-01T13:00:00.000Z");
+const SLOT_END = new Date("2026-10-01T13:30:00.000Z");
+const BEFORE = new Date("2026-09-30T09:00:00.000Z");
+const AFTER = new Date("2026-10-01T18:00:00.000Z");
+
+async function meetingBetween(
+  event: Event,
+  requester: Guest,
+  recipient: Guest,
+  patch?: Partial<Pick<Meeting, "slotStart" | "slotEnd" | "message">>
+): Promise<Meeting> {
+  return getRepositories().meetings.create({
+    eventId: event.id,
+    requesterId: requester.id,
+    recipientId: recipient.id,
+    slotStart: patch?.slotStart ?? SLOT_START,
+    slotEnd: patch?.slotEnd ?? SLOT_END,
+    meetingPoint: "Coffee bar",
+    message: patch?.message ?? "",
+    createdAt: BEFORE,
+  });
+}
+
+async function scenario() {
+  const event = await createEvent({ phase: "scheduling" });
+  const requester = await createGuest({ name: "Ada", eventId: event.id });
+  const recipient = await createGuest({ name: "Grace", eventId: event.id });
+  return { event, requester, recipient };
+}
+
+describe("meetingViewsFor", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => resetTestDb());
+
+  it("describes a request the viewer received", async () => {
+    const { event, requester, recipient } = await scenario();
+    const meeting = await meetingBetween(event, requester, recipient, {
+      message: "the attendance model",
+    });
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.id).toBe(meeting.id);
+    expect(view.role).toBe("recipient");
+    expect(view.otherName).toBe("Ada");
+    expect(view.status).toBe("pending");
+    expect(view.meetingPoint).toBe("Coffee bar");
+    expect(view.message).toBe("the attendance model");
+    expect(view.timeLabel).toBe("13:00 – 13:30");
+  });
+
+  it("describes the same meeting from the requester's side", async () => {
+    const { event, requester, recipient } = await scenario();
+    await meetingBetween(event, requester, recipient);
+
+    const [view] = await meetingViewsFor(requester.id, event.id, BEFORE);
+
+    expect(view.role).toBe("requester");
+    expect(view.otherName).toBe("Grace");
+  });
+
+  // Expiry is derived on read rather than swept by a scheduler
+  // (issue #392, section 2.4).
+  it("reads a pending request whose slot has started as expired", async () => {
+    const { event, requester, recipient } = await scenario();
+    await meetingBetween(event, requester, recipient);
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, AFTER);
+
+    expect(view.status).toBe("expired");
+  });
+
+  it("leaves an answered meeting alone once its slot has passed", async () => {
+    const { event, requester, recipient } = await scenario();
+    const meeting = await meetingBetween(event, requester, recipient);
+    await getRepositories().meetings.updateStatus(
+      meeting.id,
+      "accepted",
+      BEFORE,
+      ["pending"]
+    );
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, AFTER);
+
+    expect(view.status).toBe("accepted");
+  });
+
+  it("names a session either party is hosting in the slot", async () => {
+    const { event, requester, recipient } = await scenario();
+    const room = await createLocation({ eventId: event.id });
+    await createSession(event.id, {
+      title: "Microservices for Dummies",
+      hostIds: [recipient.id],
+      locationIds: [room.id],
+      startTime: SLOT_START,
+      endTime: SLOT_END,
+    });
+    await meetingBetween(event, requester, recipient);
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.clashes).toEqual([
+      {
+        guestName: "Grace",
+        kind: "hosting",
+        title: "Microservices for Dummies",
+        isViewer: true,
+      },
+    ]);
+  });
+
+  // The same privacy rule the slot picker relies on: an RSVP is reported as
+  // "busy" with no title, so one attendee never learns another's plans.
+  it("reports the other party's RSVP without naming the session", async () => {
+    const { event, requester, recipient } = await scenario();
+    const room = await createLocation({ eventId: event.id });
+    const session = await createSession(event.id, {
+      title: "Secret Session",
+      locationIds: [room.id],
+      startTime: SLOT_START,
+      endTime: SLOT_END,
+    });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: requester.id,
+    });
+    await meetingBetween(event, requester, recipient);
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.clashes).toEqual([
+      { guestName: "Ada", kind: "busy", title: null, isViewer: false },
+    ]);
+  });
+
+  // An accepted meeting counts as busy for clash detection, so without this
+  // every accepted meeting would warn about itself.
+  it("does not report a meeting as clashing with itself", async () => {
+    const { event, requester, recipient } = await scenario();
+    const meeting = await meetingBetween(event, requester, recipient);
+    await getRepositories().meetings.updateStatus(
+      meeting.id,
+      "accepted",
+      BEFORE,
+      ["pending"]
+    );
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.clashes).toEqual([]);
+  });
+
+  it("returns nothing for a guest with no meetings at the event", async () => {
+    const { event, requester, recipient } = await scenario();
+    await meetingBetween(event, requester, recipient);
+    const bystander = await createGuest({ eventId: event.id });
+
+    expect(await meetingViewsFor(bystander.id, event.id, BEFORE)).toEqual([]);
+  });
+});

--- a/tests/integration/meetings-page.test.tsx
+++ b/tests/integration/meetings-page.test.tsx
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+// Both are client components — one reads router search params, the other a
+// form's own state. This test only cares which of them the page renders.
+vi.mock("@/app/(site)/[eventSlug]/meetings/availability-form", () => ({
+  AvailabilityForm: () => "AVAILABILITY_FORM_STUB",
+}));
+vi.mock("@/app/(site)/[eventSlug]/meeting-modal", () => ({
+  MeetingModalFromUrl: () => "MEETING_MODAL_STUB",
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createDay } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function renderPage(
+  eventSlug: string,
+  searchParams: { viewMeeting?: string } = {}
+): Promise<string> {
+  const { default: MeetingsPage } =
+    await import("@/app/(site)/[eventSlug]/meetings/page");
+  return renderToStaticMarkup(
+    await MeetingsPage({
+      params: Promise.resolve({ eventSlug }),
+      searchParams: Promise.resolve(searchParams),
+    })
+  );
+}
+
+describe("the meetings page", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  async function scenario(meetingsEnabled: boolean) {
+    const event = await createEvent({ phase: "scheduling" });
+    await createDay(event.id);
+    const guest = await createGuest({ name: "Ada", eventId: event.id });
+    await getRepositories().events.update(event.id, { meetingsEnabled });
+    cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guest.id));
+    return { event, guest };
+  }
+
+  it("offers the availability form while the organizer offers meetings", async () => {
+    const { event } = await scenario(true);
+
+    expect(await renderPage(event.slug)).toMatch(/AVAILABILITY_FORM_STUB/);
+  });
+
+  // A request outlives the switch: it is neither canceled nor deleted when the
+  // organizer turns meetings off, and its notification points here forever.
+  it("still opens a meeting once the organizer has switched meetings off", async () => {
+    const { event } = await scenario(false);
+
+    const html = await renderPage(event.slug, { viewMeeting: "any-id" });
+
+    expect(html).toMatch(/MEETING_MODAL_STUB/);
+    expect(html).not.toMatch(/AVAILABILITY_FORM_STUB/);
+  });
+
+  it("is gone with the feature when there is no meeting to open", async () => {
+    const { event } = await scenario(false);
+
+    await expect(renderPage(event.slug)).rejects.toThrow();
+  });
+});

--- a/tests/integration/meetings-route.test.ts
+++ b/tests/integration/meetings-route.test.ts
@@ -1,0 +1,85 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest } from "../helpers/factories";
+import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import { GET as meetings } from "@/app/api/meetings/route";
+import type { MeetingView } from "@/utils/meeting-views";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+const SLOT_START = new Date("2099-10-01T13:00:00.000Z");
+
+async function asGuest(eventId: string, guestId?: string) {
+  const url = `http://test/api/meetings?event=${eventId}`;
+  if (!guestId) return new NextRequest(url);
+  const request = new NextRequest(url);
+  request.cookies.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guestId));
+  return request;
+}
+
+describe("the meetings endpoint", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  async function withPendingRequest() {
+    const event = await createEvent({ phase: "scheduling" });
+    const requester = await createGuest({ name: "Ada", eventId: event.id });
+    const recipient = await createGuest({ name: "Grace", eventId: event.id });
+    await getRepositories().meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: SLOT_START,
+      slotEnd: new Date(SLOT_START.getTime() + 30 * 60 * 1000),
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: new Date(),
+    });
+    return { event, requester, recipient };
+  }
+
+  it("serves the caller their own meetings", async () => {
+    const { event, recipient } = await withPendingRequest();
+
+    const res = await meetings(await asGuest(event.id, recipient.id));
+
+    expect(res.status).toBe(200);
+    const views = (await res.json()) as MeetingView[];
+    expect(views).toHaveLength(1);
+    expect(views[0].otherName).toBe("Ada");
+    expect(views[0].role).toBe("recipient");
+  });
+
+  // Meetings are as private as RSVPs, so there is no way to ask about
+  // somebody else's — not even by naming them.
+  it("refuses a caller who has not selected a name", async () => {
+    const { event } = await withPendingRequest();
+
+    const res = await meetings(await asGuest(event.id));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("needs an event", async () => {
+    const res = await meetings(new NextRequest("http://test/api/meetings"));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -88,6 +88,7 @@ const OUT_OF_SCOPE_EXACT = new Set(["health"]);
 
 // Read-only surfaces are exempt from the invariant per CONTRIBUTING.md.
 const READ_ONLY = new Set([
+  "meetings",
   "rsvps",
   "votes",
   "session/[sessionId]/comments",

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -31,6 +31,8 @@ import {
   notifyProfileCommented,
   notifyProposalCommented,
   notifySessionCommented,
+  notifyMeetingOutcome,
+  notifyMeetingRequested,
   notifySessionChanged,
   notifySessionDeleted,
 } from "@/utils/notifications";
@@ -1175,6 +1177,150 @@ describe("notifyProfileCommented", () => {
 
     await expect(
       notifyProfileCommented({ profileId: owner.id, comment: posted, now: NOW })
+    ).resolves.toBeUndefined();
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});
+
+describe("meeting notifications", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+    vi.stubEnv("SITE_URL", "https://site.example");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  // A pending request from Ada to Grace, half an hour at the coffee bar.
+  async function setupRequest(patch?: { timezone?: string }) {
+    const event = await createEvent({ phase: "scheduling" });
+    if (patch?.timezone) {
+      await getRepositories().events.update(event.id, {
+        timezone: patch.timezone,
+      });
+    }
+    const requester = await createGuest({
+      name: "Ada",
+      email: "ada@test.example",
+    });
+    const recipient = await createGuest({
+      name: "Grace",
+      email: "grace@test.example",
+    });
+    const meeting = await getRepositories().meetings.create({
+      eventId: event.id,
+      requesterId: requester.id,
+      recipientId: recipient.id,
+      slotStart: new Date("2026-08-02T13:00:00.000Z"),
+      slotEnd: new Date("2026-08-02T13:30:00.000Z"),
+      meetingPoint: "Coffee bar",
+      message: "the attendance model",
+      createdAt: NOW,
+    });
+    const reloaded = await getRepositories().events.findById(event.id);
+    return { event: reloaded!, requester, recipient, meeting };
+  }
+
+  it("emails the recipient when they are asked", async () => {
+    const { event, meeting } = await setupRequest();
+
+    await notifyMeetingRequested({ meeting, now: NOW });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    const message = vi.mocked(sendMail).mock.calls[0][0];
+    expect(message.to).toBe("grace@test.example");
+    expect(message.subject).toContain("Ada");
+    const html = await render(message.body);
+    expect(html).toContain("Sunday 2 August, 13:00–13:30");
+    expect(html).toContain("Coffee bar");
+    expect(html).toContain(
+      `href="https://site.example/${event.slug}/meetings?viewMeeting=${meeting.id}"`
+    );
+  });
+
+  // The line of context stays on the site, as comment text does.
+  it("leaves the requester's message out of the email", async () => {
+    const { meeting } = await setupRequest();
+
+    await notifyMeetingRequested({ meeting, now: NOW });
+
+    const html = await render(vi.mocked(sendMail).mock.calls[0][0].body);
+    expect(html).not.toContain("attendance model");
+  });
+
+  it("says the time in the event's timezone", async () => {
+    const { meeting } = await setupRequest({ timezone: "Pacific/Auckland" });
+
+    await notifyMeetingRequested({ meeting, now: NOW });
+
+    const html = await render(vi.mocked(sendMail).mock.calls[0][0].body);
+    expect(html).toContain("Monday 3 August, 01:00–01:30");
+  });
+
+  it("skips the mail for a recipient who opted out, keeping the notification", async () => {
+    const { event, meeting, recipient } = await setupRequest();
+    await getRepositories().guests.updateEmailSettings(recipient.id, {
+      ...DEFAULT_EMAIL_SETTINGS,
+      meetingRequest: false,
+    });
+
+    await notifyMeetingRequested({ meeting, now: NOW });
+
+    expect(sendMail).not.toHaveBeenCalled();
+    const [notification] = await getRepositories().notifications.listByGuest(
+      recipient.id
+    );
+    expect(notification.text).toContain("Ada");
+    expect(notification.url).toBe(
+      `/${event.slug}/meetings?viewMeeting=${meeting.id}`
+    );
+  });
+
+  it("tells the requester when the recipient answers", async () => {
+    const { meeting, requester } = await setupRequest();
+
+    await notifyMeetingOutcome({
+      meeting,
+      outcome: "accepted",
+      actorId: meeting.recipientId,
+      now: NOW,
+    });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("ada@test.example");
+    const [notification] = await getRepositories().notifications.listByGuest(
+      requester.id
+    );
+    expect(notification.type).toBe("meetingResponse");
+    expect(notification.text).toContain("Grace accepted");
+  });
+
+  // Either party can cancel, so who is left to tell depends on who acted.
+  it("tells the recipient when the requester cancels", async () => {
+    const { meeting, recipient } = await setupRequest();
+
+    await notifyMeetingOutcome({
+      meeting,
+      outcome: "canceled",
+      actorId: meeting.requesterId,
+      now: NOW,
+    });
+
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("grace@test.example");
+    const [notification] = await getRepositories().notifications.listByGuest(
+      recipient.id
+    );
+    expect(notification.text).toContain("Ada canceled");
+  });
+
+  it("does not throw when the event is gone", async () => {
+    const { event, meeting } = await setupRequest();
+    await getRepositories().events.delete(event.id);
+
+    await expect(
+      notifyMeetingRequested({ meeting, now: NOW })
     ).resolves.toBeUndefined();
     expect(sendMail).not.toHaveBeenCalled();
   });

--- a/utils/guest-clashes.ts
+++ b/utils/guest-clashes.ts
@@ -71,9 +71,18 @@ export function clashesForInterval(
     breakMinutes: number;
     /** The session being edited, which must not clash with itself. */
     excludeSessionId?: string | null;
+    /** The meeting being examined, which must not clash with itself. */
+    excludeMeetingId?: string;
   }
 ): GuestClash[] {
-  const { eventId, start, end, breakMinutes, excludeSessionId } = opts;
+  const {
+    eventId,
+    start,
+    end,
+    breakMinutes,
+    excludeSessionId,
+    excludeMeetingId,
+  } = opts;
 
   // sessionsOverlap skips a session whose id matches the candidate's, which is
   // how the session being edited is excluded from clashing with itself.
@@ -125,6 +134,7 @@ export function clashesForInterval(
     // private as an RSVP, so it reports busy with no title.
     for (const meeting of schedule.meetings) {
       if (meeting.status !== "accepted") continue;
+      if (meeting.id === excludeMeetingId) continue;
       if (
         meeting.slotStart.getTime() >= end.getTime() ||
         meeting.slotEnd.getTime() <= start.getTime()

--- a/utils/meeting-clash-text.ts
+++ b/utils/meeting-clash-text.ts
@@ -1,0 +1,22 @@
+/**
+ * A clash as the browser sees one: who is busy and, for a hosted session
+ * (public), what with. RSVP'd sessions and agreed 1-on-1s carry no title, so
+ * one attendee never learns another's private commitments — see GuestClash.
+ */
+export type MeetingClash = {
+  guestName: string;
+  kind: "hosting" | "busy";
+  title: string | null;
+  /** The viewer's own clash, so the line can say "you" rather than naming
+      the reader back to themselves in the third person. */
+  isViewer: boolean;
+};
+
+/** "Yuki is hosting Their talk" / "You are busy". */
+export function clashLine(clash: MeetingClash): string {
+  const who = clash.isViewer ? "You" : clash.guestName;
+  const is = clash.isViewer ? "are" : "is";
+  return clash.kind === "hosting" && clash.title
+    ? `${who} ${is} hosting ${clash.title}`
+    : `${who} ${is} busy`;
+}

--- a/utils/meeting-options.ts
+++ b/utils/meeting-options.ts
@@ -1,11 +1,8 @@
 import { getRepositories } from "@/db/container";
 import { serverNow } from "@/utils/dev-clock-server";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
-import {
-  clashesForInterval,
-  loadGuestSchedules,
-  type GuestClash,
-} from "@/utils/guest-clashes";
+import { clashesForInterval, loadGuestSchedules } from "@/utils/guest-clashes";
+import type { MeetingClash } from "@/utils/meeting-clash-text";
 import { DateTime } from "luxon";
 import type { Event, MeetingPoint } from "@/db/repositories/interfaces";
 
@@ -15,11 +12,7 @@ export type MeetingSlotOption = {
   label: string;
   state: "available" | "busy" | "unavailable";
   /** Why it reads as busy. Empty unless `state` is "busy". */
-  clashes: (Pick<GuestClash, "guestName" | "kind" | "title"> & {
-    /** The viewer's own clash, so the warning can say "you" rather than
-        naming the reader back to themselves in the third person. */
-    isViewer: boolean;
-  })[];
+  clashes: MeetingClash[];
 };
 
 /**

--- a/utils/meeting-views.ts
+++ b/utils/meeting-views.ts
@@ -1,0 +1,108 @@
+import { DateTime } from "luxon";
+import { getRepositories } from "@/db/container";
+import type { MeetingStatus } from "@/db/repositories/interfaces";
+import { clashesForInterval, loadGuestSchedules } from "@/utils/guest-clashes";
+import type { MeetingClash } from "@/utils/meeting-clash-text";
+
+/**
+ * A stored status, or "expired" — a pending request whose slot has begun.
+ * Derived on read so nothing has to sweep the table on a timer
+ * (issue #392, section 2.4).
+ */
+export type MeetingViewStatus = MeetingStatus | "expired";
+
+/** One of the viewer's 1-on-1s, ready to render: no ids of anyone's else's. */
+export type MeetingView = {
+  id: string;
+  status: MeetingViewStatus;
+  /** Which side the viewer is on — only a recipient can answer. */
+  role: "requester" | "recipient";
+  otherName: string;
+  /** ISO instants, for placing the meeting on the schedule grid. */
+  slotStart: string;
+  slotEnd: string;
+  /** Both in the event's timezone, as the picker labels its slots. */
+  dayLabel: string;
+  timeLabel: string;
+  meetingPoint: string;
+  message: string;
+  /** Either party's commitments in the slot, so both can weigh the clash. */
+  clashes: MeetingClash[];
+};
+
+/**
+ * The viewer's own 1-on-1s at an event, in every state — the caller decides
+ * what to show, since the grid drops declined and expired ones while the modal
+ * a notification links to must still explain them.
+ *
+ * Clashes are computed here rather than in the browser: they rest on other
+ * guests' RSVPs, which never leave the server.
+ */
+export async function meetingViewsFor(
+  viewerId: string,
+  eventId: string,
+  now: Date
+): Promise<MeetingView[]> {
+  const repos = getRepositories();
+  const event = await repos.events.findById(eventId);
+  if (!event) return [];
+
+  const meetings = await repos.meetings.listByGuestAndEvent(viewerId, eventId);
+  if (meetings.length === 0) return [];
+
+  const otherIds = new Set(
+    meetings.map((m) =>
+      m.requesterId === viewerId ? m.recipientId : m.requesterId
+    )
+  );
+  // Loaded once for everyone involved: a guest's schedule is several queries,
+  // and the same person may appear in several of these meetings.
+  const schedules = await loadGuestSchedules(eventId, [viewerId, ...otherIds]);
+  const byGuest = new Map(schedules.map((s) => [s.guestId, s]));
+
+  const zoned = (date: Date) =>
+    DateTime.fromJSDate(date).setZone(event.timezone);
+
+  return meetings.map((meeting) => {
+    const otherId =
+      meeting.requesterId === viewerId
+        ? meeting.recipientId
+        : meeting.requesterId;
+    const involved = [byGuest.get(viewerId), byGuest.get(otherId)].filter(
+      (schedule) => schedule !== undefined
+    );
+    const clashes = clashesForInterval(involved, {
+      eventId,
+      start: meeting.slotStart,
+      end: meeting.slotEnd,
+      breakMinutes: event.breakMinutes,
+      // An accepted meeting counts as busy, so without this every one of them
+      // would report itself as its own clash.
+      excludeMeetingId: meeting.id,
+    });
+    return {
+      id: meeting.id,
+      status:
+        meeting.status === "pending" &&
+        meeting.slotStart.getTime() <= now.getTime()
+          ? "expired"
+          : meeting.status,
+      role: meeting.requesterId === viewerId ? "requester" : "recipient",
+      otherName: byGuest.get(otherId)?.guestName ?? "Someone",
+      slotStart: meeting.slotStart.toISOString(),
+      slotEnd: meeting.slotEnd.toISOString(),
+      dayLabel: zoned(meeting.slotStart).toFormat("EEE d LLL"),
+      timeLabel: `${zoned(meeting.slotStart).toFormat("HH:mm")} – ${zoned(
+        meeting.slotEnd
+      ).toFormat("HH:mm")}`,
+      meetingPoint: meeting.meetingPoint,
+      message: meeting.message,
+      clashes: clashes.map(({ guestId, guestName, kind, title }) => ({
+        guestName,
+        kind,
+        title,
+        isViewer: guestId === viewerId,
+      })),
+    };
+  });
+}

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -3,6 +3,7 @@ import { getRepositories } from "@/db/container";
 import type {
   Comment,
   EmailSettings,
+  Meeting,
   Session,
 } from "@/db/repositories/interfaces";
 import { sendMail, type EmailMessage } from "@/utils/mailer";
@@ -15,6 +16,13 @@ import {
   commentEmail,
   commentNoticeText,
 } from "@/emails/comment";
+import {
+  type MeetingOutcome,
+  meetingOutcomeEmail,
+  meetingOutcomeNoticeText,
+  meetingRequestEmail,
+  meetingRequestNoticeText,
+} from "@/emails/meeting";
 import { getStartTimePlusBreak } from "@/utils/utils";
 
 // One line in the past tense, where it happened, and when — `at` comes from
@@ -528,6 +536,114 @@ export async function notifyProfileCommented({
       path: `/guests/${profileId}#comment-${comment.id}`,
     });
   });
+}
+
+// Tell the recipient that someone has asked them for a 1-on-1.
+//
+// Never throws: a notification failure must not make a request that was
+// stored look like it failed.
+export async function notifyMeetingRequested({
+  meeting,
+  now,
+}: {
+  meeting: Meeting;
+  now: Date;
+}): Promise<void> {
+  try {
+    const context = await meetingContext(meeting);
+    if (!context) return;
+    const { time, path } = context;
+    const requesterName = await guestName(meeting.requesterId);
+    await notifyGuest(
+      meeting.recipientId,
+      "meetingRequest",
+      meetingRequestEmail({
+        requesterName,
+        time,
+        meetingPoint: meeting.meetingPoint,
+        url: emailBase() + path,
+      }),
+      {
+        text: meetingRequestNoticeText(requesterName, time),
+        url: path,
+        at: now,
+      }
+    );
+  } catch (err) {
+    console.error("Failed to send meeting-request notification:", err);
+  }
+}
+
+// Tell the other party that a 1-on-1 was accepted, declined or canceled.
+// `actorId` is whoever answered, so they are not told about their own click —
+// either party can cancel, which is what decides who is left to tell.
+//
+// Never throws: as above, the state change is already committed.
+export async function notifyMeetingOutcome({
+  meeting,
+  outcome,
+  actorId,
+  now,
+}: {
+  meeting: Meeting;
+  outcome: MeetingOutcome;
+  actorId: string;
+  now: Date;
+}): Promise<void> {
+  try {
+    const context = await meetingContext(meeting);
+    if (!context) return;
+    const { time, path } = context;
+    const otherId =
+      actorId === meeting.requesterId
+        ? meeting.recipientId
+        : meeting.requesterId;
+    const actorName = await guestName(actorId);
+    await notifyGuest(
+      otherId,
+      "meetingResponse",
+      meetingOutcomeEmail({
+        actorName,
+        outcome,
+        time,
+        meetingPoint: meeting.meetingPoint,
+        url: emailBase() + path,
+      }),
+      {
+        text: meetingOutcomeNoticeText(actorName, outcome, time),
+        url: path,
+        at: now,
+      }
+    );
+  } catch (err) {
+    console.error("Failed to send meeting-outcome notification:", err);
+  }
+}
+
+// The event-dependent half of a meeting notification: when it is, in the
+// event's zone, and where it lives. Undefined once the event is gone, which
+// leaves nothing worth linking to.
+async function meetingContext(
+  meeting: Meeting
+): Promise<{ time: string; path: string } | undefined> {
+  const event = await getRepositories().events.findById(meeting.eventId);
+  if (!event) return undefined;
+  const start = DateTime.fromJSDate(meeting.slotStart).setZone(event.timezone);
+  const end = DateTime.fromJSDate(meeting.slotEnd).setZone(event.timezone);
+  return {
+    time: `${start.toFormat("cccc d LLLL, HH:mm")}–${end.toFormat("HH:mm")}`,
+    // The meetings page rather than the schedule: the schedule only exists in
+    // the scheduling phase, and a request made before it starts would land on
+    // a redirect to the proposals.
+    path: `/${event.slug}/meetings?viewMeeting=${meeting.id}`,
+  };
+}
+
+// A deleted guest still has a meeting to answer about, and "Someone" is a
+// better line than a crash.
+async function guestName(guestId: string): Promise<string> {
+  const guest = await getRepositories().guests.findById(guestId);
+  return guest?.name ?? "Someone";
 }
 
 // Deep link to the comment inside the proposal modal, same shape as


### PR DESCRIPTION
Fifth of the PRs for schellingboard/schellingboard#392 (1-on-1 meetings), following the
[design approved on the issue](https://github.com/LWCW-Europe/schellingboard/issues/392#issuecomment-5470900325).

**Stacked on schellingboard/schellingboard-legacy#940** — bases move down the chain as each lands. The tip commit of
schellingboard/schellingboard-legacy#940 is schellingboard/schellingboard-legacy#938's nav fix, which disappears when that merges.

## What's here

Answering a request. The person asked gets a notification — in the app, and by mail
unless they have turned that off — carrying who, when, where and the line of context,
and answers it in a modal with **Accept** and **Decline**. The requester is told either
way. Both mails ride on the `notifyGuest` fan-out schellingboard/schellingboard#750 added, under the two settings the
schema already carried (`emailOnMeetingRequest` / `emailOnMeetingResponse`, both on by
default); the settings page now lists them.

## Three things worth a reviewer's attention

**The notification links to `/<event>/meetings`, not the schedule.** The schedule page
only exists in the scheduling phase and redirects to the proposals before it, so a
request made while an event is still collecting them would have landed on a dead link.
The modal reads `?viewMeeting=` from the URL itself rather than taking it as a prop, so
it opens on either page.

**Answering is refused once the slot has begun.** Expiry is derived on read rather than
swept by a timer (design 2.4), so the same rule has to hold here: accepting a request
whose slot has passed would agree to a meeting in the past. `updateStatus` only moves a
pending row, so the second of two tabs is told the first already answered rather than
overwriting it.

**Both parties' clashes are computed server-side** and shown to whoever opens the
meeting, under the same privacy rule the slot picker relies on: a hosted session is
named, an RSVP or another 1-on-1 only reports "busy". The meeting is excluded from its
own clash check — an accepted 1-on-1 counts as busy, so without that every confirmed
meeting would warn about itself.

The viewer's meetings reach the browser through `/api/meetings`, which serves the caller
their own and nobody else's: a meeting is as private as an RSVP, so there is no id
parameter to ask about someone else's.

## Testing

`make precommit` green: 1753 unit/integration, 154 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
