### PR TITLE
feat: your 1-on-1s as a column of the schedule grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Asking an attendee for a 1-on-1** (#392): attendees mark the slots they are free for
   on the new 1-on-1s page, ask someone from their profile, and accept or decline what they
   are asked. Both sides are told the outcome; an unanswered request lapses at its slot
+- **Your 1-on-1s on the schedule** (#392): the grid's first column is yours alone — agreed
+  meetings and open requests, beside whatever they clash with. Tap one to open or cancel it
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
   beside Session host and Has profile. It covers every event on the site, not only this one
 

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -14,6 +14,9 @@ import { DateTime } from "luxon";
 import type { Guest, Location } from "@/db/repositories/interfaces";
 import type { DayWithSessions } from "@/app/(site)/context";
 import { EventContext, useSlotIncrement } from "@/app/(site)/context";
+import { meetingsForDay, takesPartInMeetings } from "@/utils/meeting-column";
+import { MeetingsCol } from "./meetings-col";
+import { useMyMeetings } from "./use-meetings";
 
 // Width of the left time-axis gutter. The body rows show `HH:mm` labels and the
 // header corner shows the day's date, so it has to fit a short date.
@@ -33,6 +36,18 @@ export function DayGrid(props: {
   const { event, now } = useContext(EventContext);
   const timezone = event?.timezone ?? "UTC";
   const searchParams = useSearchParams();
+  const { meetings, availability } = useMyMeetings();
+  // Outside the ?loc= filter below: the column is not a location, so narrowing
+  // the schedule to one room must not drop it (issue #392, section 2.6). All
+  // days or none, so the rooms line up from one day to the next -- and until
+  // the fetch lands, none: reserving the width for a viewer who turns out to
+  // have nothing would shift the grid for the many instead of the few.
+  const showMeetings =
+    meetings !== null &&
+    availability !== null &&
+    takesPartInMeetings(meetings, availability);
+  const myMeetings = meetings ? meetingsForDay(meetings, day) : [];
+  const myAvailability = availability ?? [];
   const locParams = searchParams?.getAll("loc");
   const locationsFromParams = locations.filter((loc) =>
     locParams?.includes(loc.name)
@@ -57,7 +72,14 @@ export function DayGrid(props: {
     <div
       className="grid bg-surface"
       style={{
-        gridTemplateColumns: `${GUTTER} repeat(${numLocations}, minmax(120px, 240px))`,
+        // The 1-on-1 column is a room's width, picture and all, so it reads as
+        // one of them rather than as a margin. It keeps the lower floor for a
+        // grid that is ever squeezed rather than scrolled; today the grid
+        // always lays out at the maximum and scrolls, so this costs the rooms
+        // 80px of that scroll on a phone.
+        gridTemplateColumns: `${GUTTER} ${
+          showMeetings ? "minmax(96px, 240px) " : ""
+        }repeat(${numLocations}, minmax(120px, 240px))`,
       }}
     >
       {/* Row 1 — room-name header, sticky to the top. The corner cell (where no
@@ -69,6 +91,11 @@ export function DayGrid(props: {
           {date.toFormat("MMM d")}
         </span>
       </div>
+      {showMeetings && (
+        <div className="sticky top-0 z-20 bg-surface border-b border-l border-line-subtle p-1">
+          <h3 className="font-semibold text-xs sm:text-sm">1-on-1s</h3>
+        </div>
+      )}
       {includedLocations.map((loc) => (
         <div
           key={loc.name}
@@ -106,6 +133,11 @@ export function DayGrid(props: {
       ))}
       {/* Row 2 — room description */}
       <div className="sticky top-0 z-20 bg-surface border-r border-line-subtle" />
+      {showMeetings && (
+        <div className="border-l border-line-subtle p-1">
+          <p className="text-[10px] text-fg-subtle">Only you see these</p>
+        </div>
+      )}
       {includedLocations.map((loc) => (
         <div key={loc.name} className="border-l border-line-subtle p-1">
           <p className="text-[10px] text-fg-subtle">
@@ -120,6 +152,7 @@ export function DayGrid(props: {
       {hasImages && (
         <>
           <div className="sticky left-0 z-20 bg-surface border-r border-line-subtle" />
+          {showMeetings && <div className="border-l border-line-subtle p-1" />}
           {includedLocations.map((loc, i) => (
             <div key={loc.name} className="border-l border-line-subtle p-1">
               {loc.imageUrl && (
@@ -162,6 +195,14 @@ export function DayGrid(props: {
         ))}
         {nowOffsetPx !== null && <NowLine offsetPx={nowOffsetPx} anchor />}
       </div>
+      {showMeetings && (
+        <MeetingsCol
+          meetings={myMeetings}
+          availability={myAvailability}
+          day={day}
+          nowOffsetPx={nowOffsetPx}
+        />
+      )}
       {includedLocations.map((location) => (
         <LocationCol
           key={location.name}

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -13,6 +13,7 @@ import { getNowOffsetPx } from "@/utils/slots";
 import { KioskController, useKioskMode } from "./kiosk";
 import { SessionModal } from "./session-modal";
 import { MeetingModalFromUrl } from "./meeting-modal";
+import { MeetingsProvider } from "./use-meetings";
 import type { DayWithSessions } from "../context";
 import { useDragToPan } from "./use-drag-to-pan";
 import { PullToRefresh } from "./pull-to-refresh";
@@ -165,7 +166,9 @@ export function EventDisplay() {
     );
 
   return (
-    <>
+    // The grid's 1-on-1 column and the modal it opens share one copy of the
+    // viewer's meetings, so answering one there updates the other.
+    <MeetingsProvider>
       <div
         data-schedule-frame
         className="fixed inset-x-0 top-16 bottom-0 flex flex-col bg-surface"
@@ -180,7 +183,7 @@ export function EventDisplay() {
       )}
       <MeetingModalFromUrl />
       {kiosk && <KioskController nowIsOnSchedule={nowIsOnSchedule} />}
-    </>
+    </MeetingsProvider>
   );
 }
 

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -1,20 +1,24 @@
 "use client";
 
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-  useTransition,
-} from "react";
+import { useContext, useEffect, useState, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { respondToMeetingAction } from "@/app/actions/meetings";
-import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
+import {
+  cancelMeetingAction,
+  respondToMeetingAction,
+  type MeetingActionResult,
+} from "@/app/actions/meetings";
+import {
+  DANGER_BUTTON,
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+} from "@/app/components/buttons";
+import { EventContext } from "@/app/(site)/context";
 import { clashLine } from "@/utils/meeting-clash-text";
+import { canCancel } from "@/utils/meeting-rules";
 import type { MeetingView } from "@/utils/meeting-views";
-import { EventContext } from "../context";
 import { dismissViewMeeting } from "./modal-nav";
+import { useMyMeetings } from "./use-meetings";
 
 /** What has become of the request, in the words of whoever is reading. */
 function statusLine(meeting: MeetingView): string {
@@ -47,7 +51,10 @@ function statusLine(meeting: MeetingView): string {
  */
 export function MeetingModalFromUrl() {
   const meetingId = useSearchParams()?.get("viewMeeting");
-  return meetingId ? <MeetingModal meetingId={meetingId} /> : null;
+  // Keyed so a half-confirmed cancel does not carry over to the next meeting.
+  return meetingId ? (
+    <MeetingModal key={meetingId} meetingId={meetingId} />
+  ) : null;
 }
 
 /**
@@ -55,13 +62,12 @@ export function MeetingModalFromUrl() {
  * buttons.
  */
 function MeetingModal({ meetingId }: { meetingId: string }) {
-  const { event } = useContext(EventContext);
   const router = useRouter();
-  const [meetings, setMeetings] = useState<MeetingView[] | null>(null);
+  const { now } = useContext(EventContext);
+  const { meetings, reload } = useMyMeetings();
   const [error, setError] = useState<string | null>(null);
+  const [confirmingCancel, setConfirmingCancel] = useState(false);
   const [isAnswering, startAnswer] = useTransition();
-
-  const eventId = event?.id;
 
   // Duplication, anchor: waggHhba
   useEffect(() => {
@@ -76,67 +82,32 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
     };
   }, []);
 
-  // Fetched rather than server-rendered: a meeting is private to its two
-  // guests, so it has no place in the schedule's shared render
-  // (issue #392, section 2.6).
-  const load = useCallback(
-    (signal?: AbortSignal) => {
-      if (!eventId) return;
-      void fetch(`/api/meetings?event=${eventId}`, { signal })
-        .then((res) => (res.ok ? (res.json() as Promise<MeetingView[]>) : []))
-        .then(setMeetings)
-        // Closing the modal aborts the request, and leaving the page has the
-        // browser kill it; either way there is nobody left to tell.
-        .catch(() => undefined);
-    },
-    [eventId]
-  );
-
-  // Keyed on the meeting too: an opener that swaps one id for another without
-  // unmounting would otherwise render the second from the first one's answer.
-  useEffect(() => {
-    const controller = new AbortController();
-    load(controller.signal);
-    return () => controller.abort();
-  }, [load, meetingId]);
-
   const meeting = meetings?.find((m) => m.id === meetingId);
 
-  const answer = (response: "accept" | "decline") => {
+  // Every write ends the same way: re-read the meetings, so the modal and the
+  // schedule column behind it agree, and refresh the page, since an accepted
+  // meeting is a commitment other things now clash with.
+  const act = (run: () => Promise<MeetingActionResult>) => {
     setError(null);
+    setConfirmingCancel(false);
     startAnswer(async () => {
       try {
-        const result = await respondToMeetingAction({ meetingId, response });
+        const result = await run();
         if (!result.ok) {
           setError(result.error);
-          // Refused because the meeting has moved on -- answered in another
-          // tab, or its slot has begun -- so the buttons and the status line
-          // are describing a request that no longer exists.
-          load();
+          // The refusal usually means the meeting has moved on -- answered in
+          // another tab, or its slot has begun -- so re-read it rather than
+          // leaving the buttons describing a request that is no longer there.
+          reload();
           return;
         }
-        setMeetings(
-          (current) =>
-            current?.map((m) =>
-              m.id === meetingId
-                ? {
-                    ...m,
-                    status: response === "accept" ? "accepted" : "declined",
-                  }
-                : m
-            ) ?? null
-        );
-        // An accepted meeting is a commitment, so the schedule behind the
-        // modal now has one more thing in it.
+        reload();
         router.refresh();
       } catch {
         setError("Request failed");
       }
     });
   };
-
-  // The modal has no event to ask about; the same guard session-modal.tsx has.
-  if (!event) return null;
 
   return (
     <div
@@ -215,7 +186,11 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
               <div className="flex gap-2">
                 <button
                   type="button"
-                  onClick={() => answer("accept")}
+                  onClick={() =>
+                    act(() =>
+                      respondToMeetingAction({ meetingId, response: "accept" })
+                    )
+                  }
                   disabled={isAnswering}
                   className={PRIMARY_BUTTON}
                 >
@@ -226,7 +201,11 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                     section 1.4). */}
                 <button
                   type="button"
-                  onClick={() => answer("decline")}
+                  onClick={() =>
+                    act(() =>
+                      respondToMeetingAction({ meetingId, response: "decline" })
+                    )
+                  }
                   disabled={isAnswering}
                   className={SECONDARY_BUTTON}
                 >
@@ -234,6 +213,43 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                 </button>
               </div>
             )}
+
+            {canCancel(meeting, now) &&
+              (confirmingCancel ? (
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm text-fg">
+                    {meeting.otherName} will be told. Cancel it?
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        act(() => cancelMeetingAction({ meetingId }))
+                      }
+                      disabled={isAnswering}
+                      className={DANGER_BUTTON}
+                    >
+                      Yes, cancel it
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingCancel(false)}
+                      disabled={isAnswering}
+                      className={SECONDARY_BUTTON}
+                    >
+                      Keep it
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmingCancel(true)}
+                  className={`${SECONDARY_BUTTON} self-start`}
+                >
+                  Cancel meeting
+                </button>
+              ))}
 
             <p className="text-xs text-fg-subtle">
               Nothing is reserved — the meeting point is just where to find each

--- a/app/(site)/[eventSlug]/meetings-col.tsx
+++ b/app/(site)/[eventSlug]/meetings-col.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import clsx from "clsx";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useContext } from "react";
+
+import type { MeetingView } from "@/utils/meeting-views";
+import { meetingColumnRows } from "@/utils/meeting-column";
+import type { DayWithSessions } from "@/app/(site)/context";
+import { EventContext, useSlotIncrement } from "@/app/(site)/context";
+import { viewMeetingLinkFromOwner } from "./modal-nav";
+import { NowLine } from "./now-line";
+
+/**
+ * The viewer's own 1-on-1s for one day, as the grid's first column, beside
+ * the slots they cleared and the ones still open. Personal: never anyone
+ * else's (issue #392, section 1.5).
+ */
+export function MeetingsCol({
+  meetings,
+  availability,
+  day,
+  nowOffsetPx,
+}: {
+  meetings: MeetingView[];
+  /** Slot starts the viewer declared themselves open for, as ISO strings. */
+  availability: string[];
+  day: DayWithSessions;
+  /** Now-line offset from the top of the slot grid; null hides it. */
+  nowOffsetPx?: number | null;
+}) {
+  const slotIncrement = useSlotIncrement();
+  const searchParams = useSearchParams();
+  // Never missing here: the column only renders once meetings for this event
+  // have been fetched, which takes the event being in context.
+  const eventSlug = useContext(EventContext).event?.slug ?? "";
+  const rows = meetingColumnRows({
+    meetings,
+    availability,
+    day,
+    slotIncrement,
+  });
+
+  return (
+    <div className="relative px-0.5">
+      <div className="grid h-full auto-rows-[44px]">
+        {rows.map(({ row, span, kind, meetings: atRow }) =>
+          kind !== "meetings" ? (
+            <div
+              key={row}
+              style={{ gridRowStart: row }}
+              // Hatched where the viewer cleared the slot: that governs who
+              // may book *them*, so it is worth seeing on their own schedule —
+              // but it is no bar to arranging a 1-on-1 there themselves, and
+              // the cell stays as bookable as any other (#945).
+              title={
+                kind === "unavailable"
+                  ? "You are not offering this slot — you can still arrange a 1-on-1 in it"
+                  : undefined
+              }
+              className={clsx(
+                `row-span-${span} my-0.5 rounded`,
+                kind === "unavailable" && "meetings-col-blocked"
+              )}
+            />
+          ) : (
+            <div
+              key={row}
+              // Placed by row rather than in document order, so a gap between
+              // two meetings needs no filler blocks.
+              style={{ gridRowStart: row }}
+              className={`row-span-${span} flex gap-0.5 my-0.5`}
+            >
+              {atRow.map((meeting) => (
+                <Link
+                  key={meeting.id}
+                  {...viewMeetingLinkFromOwner(
+                    searchParams,
+                    eventSlug,
+                    meeting.id
+                  )}
+                  className={clsx(
+                    "flex-1 min-w-0 rounded px-1 py-0.5 overflow-hidden font-roboto",
+                    meeting.status === "accepted"
+                      ? "bg-brand-tint border-2 border-brand-accent"
+                      : // Pending reads as unfinished business, not a plan.
+                        "bg-surface-muted border-2 border-dashed border-line"
+                  )}
+                >
+                  <p className="font-medium text-xs leading-[1.15] line-clamp-1 text-fg">
+                    {meeting.otherName}
+                  </p>
+                  <p className="text-[10px] leading-[1.15] line-clamp-1 text-fg-muted">
+                    {meeting.meetingPoint}
+                  </p>
+                  <p className="text-[10px] leading-[1.15] text-fg-subtle">
+                    {meeting.status === "accepted"
+                      ? "confirmed"
+                      : meeting.role === "recipient"
+                        ? "needs your reply"
+                        : "waiting for reply"}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          )
+        )}
+      </div>
+      {/* Each column draws its own segment of the now line; see DayGrid. */}
+      {nowOffsetPx != null && <NowLine offsetPx={nowOffsetPx} />}
+    </div>
+  );
+}

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/utils/acting-guest";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
 import { MeetingModalFromUrl } from "../meeting-modal";
+import { MeetingsProvider } from "../use-meetings";
 import { AvailabilityForm, type SlotDay } from "./availability-form";
 
 export const dynamic = "force-dynamic";
@@ -40,7 +41,9 @@ export default async function MeetingsPage({
           availability to set — but the ones already arranged are still yours to
           settle.
         </PageNotice>
-        <MeetingModalFromUrl />
+        <MeetingsProvider evenIfMeetingsAreOff>
+          <MeetingModalFromUrl />
+        </MeetingsProvider>
       </>
     );
   }
@@ -127,7 +130,9 @@ export default async function MeetingsPage({
       />
       {/* Where a meeting notification lands: this page is here in every phase,
           while the schedule only exists once scheduling starts. */}
-      <MeetingModalFromUrl />
+      <MeetingsProvider>
+        <MeetingModalFromUrl />
+      </MeetingsProvider>
     </>
   );
 }

--- a/app/(site)/[eventSlug]/modal-nav.ts
+++ b/app/(site)/[eventSlug]/modal-nav.ts
@@ -105,12 +105,36 @@ export function viewProposalLinkFromElsewhere(
 export function openingModalFromRedirect() {
   sessionDismissMode = "replace";
   proposalDismissMode = "replace";
+  meetingDismissMode = "replace";
 }
 
-// Meetings have no in-place opener yet, so a meeting modal is always reached
-// by a link from elsewhere — a notification — where "back" would leave the
-// site rather than the modal.
+export function viewMeetingLinkFromOwner(
+  currentSearchParams: URLSearchParams,
+  eventSlug: string,
+  meetingId: string
+) {
+  const params = new URLSearchParams(currentSearchParams);
+  params.set("viewMeeting", meetingId);
+  const href = `/${eventSlug}?${params.toString()}`;
+  return {
+    href,
+    prefetch: false,
+    scroll: false,
+    onClick: (e: MouseEvent<HTMLAnchorElement>) => {
+      if (!isPlainLeftClick(e)) return;
+      e.preventDefault();
+      // As with the session modal: open it now, without an RSC roundtrip.
+      window.history.pushState(null, "", href);
+      meetingDismissMode = "back";
+    },
+  };
+}
+
 export function dismissViewMeeting() {
+  if (meetingDismissMode === "back") {
+    window.history.back();
+    return;
+  }
   const params = new URLSearchParams(window.location.search);
   params.delete("viewMeeting");
   const query = params.toString();
@@ -172,3 +196,6 @@ export function isPlainLeftClick(e: MouseEvent<HTMLAnchorElement>) {
 // opens, where "replace" is intended.
 let sessionDismissMode: "back" | "replace" = "replace";
 let proposalDismissMode: "back" | "replace" = "replace";
+// A meeting modal is opened in place from the schedule column, and by link
+// from a notification — where "replace" is what keeps Back on the site.
+let meetingDismissMode: "back" | "replace" = "replace";

--- a/app/(site)/[eventSlug]/use-meetings.tsx
+++ b/app/(site)/[eventSlug]/use-meetings.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+import type { MeetingView, MyMeetingsResponse } from "@/utils/meeting-views";
+import { EventContext, UserContext } from "../context";
+
+type MyMeetings = {
+  /** Null while the answer is still on its way, so "none" and "not yet" differ. */
+  meetings: MeetingView[] | null;
+  /** The slots the viewer declared themselves open for; null as above. */
+  availability: string[] | null;
+  reload: () => void;
+};
+
+// Shared so a guest with nothing to fetch gets a stable value rather than a
+// new object on every render.
+const NONE: MyMeetingsResponse = { meetings: [], availability: [] };
+
+const MeetingsContext = createContext<MyMeetings>({
+  meetings: null,
+  availability: null,
+  reload: () => {},
+});
+
+/**
+ * The viewer's own 1-on-1s at the event in context, fetched once for whoever
+ * needs them — the schedule's column and the modal it opens, which must agree
+ * about a meeting the modal has just answered.
+ *
+ * Client-side rather than part of the page's server render: the schedule is
+ * shared by everyone looking at it, and these are private to one guest
+ * (issue #392, section 2.6).
+ */
+export function MeetingsProvider({
+  children,
+  evenIfMeetingsAreOff = false,
+}: {
+  children: ReactNode;
+  /**
+   * A meeting outlives the organizer switching the feature off, and the
+   * notification about it still opens one — so the page that opens it asks
+   * for the viewer's meetings anyway, where the schedule's column does not.
+   */
+  evenIfMeetingsAreOff?: boolean;
+}) {
+  const { event } = useContext(EventContext);
+  const { user } = useContext(UserContext);
+  const [loaded, setLoaded] = useState<
+    ({ key: string } & MyMeetingsResponse) | null
+  >(null);
+  // Bumped by reload() to re-run the fetch below.
+  const [reloads, setReloads] = useState(0);
+
+  const eventId = event?.id;
+  // A kiosk with nobody picked, or an event that never offered meetings:
+  // there is nothing this guest could have.
+  const offered = event?.meetingsEnabled || evenIfMeetingsAreOff;
+  const key = eventId && offered && user ? `${eventId}:${user}` : null;
+
+  useEffect(() => {
+    if (!key) return;
+    const controller = new AbortController();
+    void fetch(`/api/meetings?event=${eventId}`, { signal: controller.signal })
+      .then((res) =>
+        res.ok ? (res.json() as Promise<MyMeetingsResponse>) : NONE
+      )
+      .then((mine) => setLoaded({ key, ...mine }))
+      // Aborted on unmount or on switching names, and the browser kills it
+      // when the page goes; either way there is nobody left to tell.
+      .catch(() => undefined);
+    return () => controller.abort();
+  }, [eventId, key, reloads]);
+
+  const reload = useCallback(() => setReloads((n) => n + 1), []);
+
+  // Keyed rather than cleared in an effect, so switching names never shows
+  // the previous guest's meetings while the new answer is in flight. With
+  // nothing to fetch the answer is "none", not "not yet".
+  const mine = key === null ? NONE : loaded?.key === key ? loaded : null;
+
+  return (
+    <MeetingsContext.Provider
+      value={{
+        meetings: mine?.meetings ?? null,
+        availability: mine?.availability ?? null,
+        reload,
+      }}
+    >
+      {children}
+    </MeetingsContext.Provider>
+  );
+}
+
+export function useMyMeetings(): MyMeetings {
+  return useContext(MeetingsContext);
+}

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -15,7 +15,7 @@ import {
   notifyMeetingOutcome,
   notifyMeetingRequested,
 } from "@/utils/notifications";
-import type { Event } from "@/db/repositories/interfaces";
+import type { Event, MeetingStatus } from "@/db/repositories/interfaces";
 
 export type MeetingActionResult = { ok: true } | { ok: false; error: string };
 
@@ -37,6 +37,8 @@ const respondSchema = z.object({
   meetingId: z.string(),
   response: z.enum(["accept", "decline"]),
 });
+
+const cancelSchema = z.object({ meetingId: z.string() });
 
 const availabilitySchema = z.object({
   eventId: z.string(),
@@ -210,6 +212,72 @@ export async function respondToMeetingAction(
   await notifyMeetingOutcome({
     meeting: answered,
     outcome,
+    actorId: guestId,
+    now,
+  });
+
+  const event = await repos.events.findById(meeting.eventId);
+  if (event) revalidatePath(`/${event.slug}`);
+  return { ok: true };
+}
+
+/**
+ * Calling a meeting off. Either party may cancel one they had agreed; while it
+ * is still pending only the requester may, since the person asked has Decline
+ * — and being told "canceled" where they had declined would misdescribe it.
+ */
+export async function cancelMeetingAction(
+  raw: z.input<typeof cancelSchema>
+): Promise<MeetingActionResult> {
+  await requireSiteAuth();
+
+  const parsed = cancelSchema.safeParse(raw);
+  if (!parsed.success) return { ok: false, error: "Invalid request" };
+  const input = parsed.data;
+
+  const guestId = await verifiedCurrentUser(await cookies());
+  if (!guestId) {
+    return { ok: false, error: "Sign in to cancel a meeting" };
+  }
+
+  const repos = getRepositories();
+  const meeting = await repos.meetings.findById(input.meetingId);
+  if (!meeting) return { ok: false, error: "Meeting not found" };
+  const isRequester = meeting.requesterId === guestId;
+  if (!isRequester && meeting.recipientId !== guestId) {
+    return { ok: false, error: "This isn't your meeting" };
+  }
+
+  const now = await serverNow();
+  // A meeting that has already begun happened or didn't; calling it off after
+  // the fact would only send its other half a notification about the past.
+  if (meeting.slotStart.getTime() <= now.getTime()) {
+    return { ok: false, error: "That slot has already started" };
+  }
+
+  if (!isRequester && meeting.status === "pending") {
+    return {
+      ok: false,
+      error: "You were the one asked — decline it instead",
+    };
+  }
+
+  const from: MeetingStatus[] = isRequester
+    ? ["pending", "accepted"]
+    : ["accepted"];
+  const canceled = await repos.meetings.updateStatus(
+    meeting.id,
+    "canceled",
+    now,
+    from
+  );
+  if (!canceled) {
+    return { ok: false, error: "There is nothing left to cancel" };
+  }
+
+  await notifyMeetingOutcome({
+    meeting: canceled,
+    outcome: "canceled",
     actorId: guestId,
     now,
   });

--- a/app/api/meetings/route.ts
+++ b/app/api/meetings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { requestNow } from "@/utils/dev-clock";
+import { getRepositories } from "@/db/container";
 import { meetingViewsFor } from "@/utils/meeting-views";
 
 export const dynamic = "force-dynamic";
@@ -9,9 +10,10 @@ export const dynamic = "force-dynamic";
 // go on showing a request that has since been answered.
 const NO_STORE = { headers: { "cache-control": "no-store" } };
 
-// The viewer's own 1-on-1s at an event. Always the caller's own: a guest's
-// meetings are as private as their RSVPs, so there is no id parameter to ask
-// about someone else's.
+// The viewer's own 1-on-1s at an event, and the slots they declared
+// themselves open for. Always the caller's own: a guest's meetings are as
+// private as their RSVPs, so there is no id parameter to ask about someone
+// else's.
 export async function GET(request: NextRequest) {
   const eventId = request.nextUrl.searchParams.get("event");
   if (!eventId) {
@@ -30,8 +32,18 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const [meetings, availability] = await Promise.all([
+      meetingViewsFor(guestId, eventId, requestNow(request)),
+      getRepositories().meetingAvailability.listByGuestAndEvent(
+        guestId,
+        eventId
+      ),
+    ]);
     return NextResponse.json(
-      await meetingViewsFor(guestId, eventId, requestNow(request)),
+      {
+        meetings,
+        availability: availability.map((slot) => slot.toISOString()),
+      },
       NO_STORE
     );
   } catch (error) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -384,6 +384,21 @@ html {
   color: color-mix(in oklab, var(--loc) var(--loc-fg-mix), var(--fg));
 }
 
+/*
+ * A slot the viewer cleared in their own 1-on-1 availability. Hatched rather
+ * than filled: it is the one thing in that column nothing can be booked into,
+ * and it has to read as unavailable at a glance beside real blocks.
+ */
+@utility meetings-col-blocked {
+  background-image: repeating-linear-gradient(
+    135deg,
+    var(--surface-sunken),
+    var(--surface-sunken) 5px,
+    var(--surface-muted) 5px,
+    var(--surface-muted) 10px
+  );
+}
+
 /* Admin's colour preview — the hue itself, with no text on it. */
 @utility loc-swatch {
   background-color: var(--loc);

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -48,7 +48,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Install it on your phone**: add the site to your home screen and it opens like an app, in its own window with no address bar.",
       "**Notifications on your phone**: Settings can send the notifications you already get to your phone or laptop, so they arrive while the site is closed. iPhones need it on the home screen first.",
       "**Notifications in the app**: a bell counts what is waiting, and clicking one takes you to it. Tick the ones you are done with to mark them read or delete them. No email set-up needed.",
-      "**1-on-1 meetings**: organizers switch them on for an event and suggest where to meet; attendees mark when they are free, ask someone from their profile, and accept or decline.",
+      "**1-on-1 meetings**: organizers switch them on and suggest where to meet; attendees mark when they are free, ask someone from their profile, accept or decline, and see them on the schedule.",
       '**The schedule shows where you are in the day**: a red line marks the current time while the event is running, and a "Now" button jumps to it.',
     ],
   },

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -249,6 +249,24 @@ You can't change the time or the place — accept it or decline it, and let them
 ask again if it doesn't suit. Either way they are told. A request nobody answers
 before its slot begins simply lapses; nothing is held against you.
 
+### Your meetings on the schedule
+
+Once the event reaches its scheduling phase, your 1-on-1s get the **first
+column of the schedule grid**, before the rooms: the other person's name, where
+you agreed to meet, and whether it is confirmed, waiting for your reply, or
+waiting for theirs. Each sits in its own time slot, next to whatever it would
+clash with.
+
+The column is yours alone — nobody else sees it, and it stays put when you
+filter the schedule down to one room. It is there on every day of the event
+once you take part at all — open to 1-on-1s, or with one arranged — so the
+rooms line up from day to day, and it isn't there at all otherwise. It also
+shows the slots you are not offering. Declined and lapsed requests drop off it.
+
+Tap one to open it. That is also where either of you can **cancel** a meeting
+you had agreed, or take back a request nobody has answered yet, up until the
+slot begins; the other person is told.
+
 ## Attendee directory & profiles
 
 The directory lists everyone at the event on a single page — photo and the

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -98,6 +98,14 @@ async function meetingsEvent(page: Page, eventName: string, names: string[]) {
   await meetings.getByRole("button", { name: "Save meetings" }).click();
   await expect(meetings.getByText("Saved!")).toBeVisible();
 
+  // The 1-on-1s column lives on the schedule, which only exists once the
+  // event is in its scheduling phase.
+  const scheduling = page.getByRole("group", { name: "Scheduling phase" });
+  await scheduling.getByLabel("Start").fill("2026-01-01T00:00");
+  await scheduling.getByLabel("End").fill("2027-01-01T00:00");
+  await page.getByRole("button", { name: "Save phases" }).click();
+  await expect(page.getByText("Saved!").last()).toBeVisible();
+
   await page.getByRole("button", { name: "Add day" }).click();
   await page.getByLabel("Start *").last().fill(`${EVENT_START}T09:00`);
   await page.getByLabel("End *").last().fill(`${EVENT_START}T10:00`);
@@ -280,6 +288,15 @@ test.describe("1-on-1 meetings", () => {
     await meeting.getByRole("button", { name: "Close" }).click();
     await expect(meeting).toBeHidden();
 
+    // It is on their schedule too, in a column only they can see. Left by a
+    // link first, so answering's refresh is superseded rather than raced by
+    // the navigation that follows it (see leaveForAttendees).
+    await leaveForAttendees(page);
+    await page.getByRole("link", { name: eventName }).click();
+    const column = page.getByRole("link", { name: new RegExp(asker) });
+    await expect(column).toBeVisible();
+    await expect(page.getByText("Coffee bar").first()).toBeVisible();
+
     // And the asker hears back, then asks for the day's other slot.
     await leaveForAttendees(page);
     await actAs(page, new RegExp(asker));
@@ -327,5 +344,49 @@ test.describe("1-on-1 meetings", () => {
         name: new RegExp(`${askee} declined your 1-on-1`),
       })
     ).toBeVisible();
+
+    // Opening one from the schedule arms "dismiss by going back" (modal-nav.ts,
+    // anchor MnpjIo7Y). A meeting reached from a notification afterwards must
+    // not inherit it, or closing that one would pop back to the list.
+    await page.goto(`/${slug}`);
+    await page.getByRole("link", { name: new RegExp(askee) }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Meeting details" })
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await page.goto("/notifications");
+    await page
+      .getByRole("button", {
+        name: new RegExp(`${askee} accepted your 1-on-1`),
+      })
+      .click();
+    const fromNotification = page.getByRole("dialog", {
+      name: "Meeting details",
+    });
+    await expect(fromNotification).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByRole("heading", { name: "Notifications" })
+    ).toBeHidden();
+
+    // Either of them can call it off from the block on the schedule.
+    await page.goto(`/${slug}`);
+    await page.getByRole("link", { name: new RegExp(askee) }).click();
+    const confirmed = page.getByRole("dialog", { name: "Meeting details" });
+    await confirmed.getByRole("button", { name: "Cancel meeting" }).click();
+    await confirmed.getByRole("button", { name: "Yes, cancel it" }).click();
+    await expect(confirmed.getByText(/was canceled/)).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByRole("link", { name: new RegExp(askee) })
+    ).toBeHidden();
+
+    // Escape rewrites the URL and cancelling refreshes the schedule behind the
+    // modal, and afterEach navigates the moment this returns -- so wait for the
+    // rewrite, then leave by a link rather than letting the teardown's goto
+    // abort the refresh (see leaveForAttendees).
+    await expect(page).not.toHaveURL(/viewMeeting=/);
+    await leaveForAttendees(page);
   });
 });

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -156,6 +156,10 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       meetingPoint: "Coffee bar",
     });
   },
+  "actions/meetings.ts:cancelMeetingAction": async () => {
+    const { cancelMeetingAction } = await import("@/app/actions/meetings");
+    return cancelMeetingAction({ meetingId: "m" });
+  },
   "actions/meetings.ts:respondToMeetingAction": async () => {
     const { respondToMeetingAction } = await import("@/app/actions/meetings");
     return respondToMeetingAction({ meetingId: "m", response: "accept" });

--- a/tests/integration/meeting-respond-action.test.ts
+++ b/tests/integration/meeting-respond-action.test.ts
@@ -33,7 +33,10 @@ import { siteAuthenticate } from "../helpers/site-auth";
 import { createEvent, createGuest } from "../helpers/factories";
 import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
 import { getRepositories } from "@/db/container";
-import { respondToMeetingAction } from "@/app/actions/meetings";
+import {
+  cancelMeetingAction,
+  respondToMeetingAction,
+} from "@/app/actions/meetings";
 import type { Event, Guest, Meeting } from "@/db/repositories/interfaces";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef";
@@ -228,6 +231,130 @@ describe("respondToMeetingAction", () => {
     const result = await respondToMeetingAction({
       meetingId: meeting.id,
       response: "maybe" as unknown as "accept",
+    });
+
+    expect(result).toEqual({ ok: false, error: "Invalid request" });
+  });
+});
+
+describe("cancelMeetingAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await siteAuthenticate(cookieJar);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  async function accepted() {
+    const scene = await scenario();
+    await respondToMeetingAction({
+      meetingId: scene.meeting.id,
+      response: "accept",
+    });
+    return scene;
+  }
+
+  it("lets the requester take back a request nobody has answered", async () => {
+    const { requester, recipient, meeting } = await scenario();
+    await signIn(requester.id);
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(result.ok).toBe(true);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("canceled");
+    const [notification] = await getRepositories().notifications.listByGuest(
+      recipient.id
+    );
+    expect(notification.text).toMatch(/canceled/);
+  });
+
+  it("lets either party call off a confirmed meeting", async () => {
+    const { requester, meeting } = await accepted();
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(result.ok).toBe(true);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("canceled");
+    // The one who cancelled is the recipient here, so the requester is told.
+    const [notification] = await getRepositories().notifications.listByGuest(
+      requester.id
+    );
+    expect(notification.text).toMatch(/canceled/);
+  });
+
+  // While it is pending, the person asked has Decline: cancelling it on the
+  // requester's behalf would tell them something else happened.
+  it("refuses the recipient a pending request", async () => {
+    const { meeting } = await scenario();
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    // Not "nothing left to cancel": there is, and the real answer is which
+    // button to use.
+    expect(result).toEqual({
+      ok: false,
+      error: "You were the one asked — decline it instead",
+    });
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.status
+    ).toBe("pending");
+  });
+
+  it("refuses anyone who is not part of the meeting", async () => {
+    const { event, meeting } = await accepted();
+    const bystander = await createGuest({ eventId: event.id });
+    await signIn(bystander.id);
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a meeting that is already declined", async () => {
+    const { requester, meeting } = await scenario();
+    await respondToMeetingAction({
+      meetingId: meeting.id,
+      response: "decline",
+    });
+    await signIn(requester.id);
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a meeting whose slot has already started", async () => {
+    const { requester, meeting } = await scenario({ slotStart: PAST_SLOT });
+    await signIn(requester.id);
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses when nobody is signed in", async () => {
+    const { meeting } = await accepted();
+    cookieJar.clear();
+    await siteAuthenticate(cookieJar);
+
+    const result = await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("answers a malformed payload instead of throwing", async () => {
+    await accepted();
+
+    const result = await cancelMeetingAction({
+      meetingId: 42 as unknown as string,
     });
 
     expect(result).toEqual({ ok: false, error: "Invalid request" });

--- a/tests/integration/meetings-page.test.tsx
+++ b/tests/integration/meetings-page.test.tsx
@@ -8,6 +8,7 @@ import {
   vi,
 } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
 
 const cookieJar = new Map<string, string>();
 
@@ -28,6 +29,21 @@ vi.mock("@/app/(site)/[eventSlug]/meetings/availability-form", () => ({
 }));
 vi.mock("@/app/(site)/[eventSlug]/meeting-modal", () => ({
   MeetingModalFromUrl: () => "MEETING_MODAL_STUB",
+}));
+// The modal reads the viewer's meetings from this provider, so where the page
+// renders it says whether it can load one at all.
+vi.mock("@/app/(site)/[eventSlug]/use-meetings", () => ({
+  MeetingsProvider: ({
+    children,
+    evenIfMeetingsAreOff,
+  }: {
+    children: ReactNode;
+    evenIfMeetingsAreOff?: boolean;
+  }) => (
+    <div data-provider-off={String(Boolean(evenIfMeetingsAreOff))}>
+      {children}
+    </div>
+  ),
 }));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
@@ -84,7 +100,12 @@ describe("the meetings page", () => {
 
     const html = await renderPage(event.slug, { viewMeeting: "any-id" });
 
-    expect(html).toMatch(/MEETING_MODAL_STUB/);
+    // Inside the provider, and told to fetch even though the event no longer
+    // offers meetings: outside one, or gated on the switch, the modal has
+    // nothing to show but "Loading...".
+    expect(html).toMatch(
+      /<div data-provider-off="true">MEETING_MODAL_STUB<\/div>/
+    );
     expect(html).not.toMatch(/AVAILABILITY_FORM_STUB/);
   });
 

--- a/tests/integration/meetings-route.test.ts
+++ b/tests/integration/meetings-route.test.ts
@@ -14,7 +14,7 @@ import { createEvent, createGuest } from "../helpers/factories";
 import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
 import { getRepositories } from "@/db/container";
 import { GET as meetings } from "@/app/api/meetings/route";
-import type { MeetingView } from "@/utils/meeting-views";
+import type { MyMeetingsResponse } from "@/utils/meeting-views";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef";
 
@@ -61,10 +61,26 @@ describe("the meetings endpoint", () => {
     const res = await meetings(await asGuest(event.id, recipient.id));
 
     expect(res.status).toBe(200);
-    const views = (await res.json()) as MeetingView[];
+    const { meetings: views } = (await res.json()) as MyMeetingsResponse;
     expect(views).toHaveLength(1);
     expect(views[0].otherName).toBe("Ada");
     expect(views[0].role).toBe("recipient");
+  });
+
+  // The column draws the slots the viewer cleared as well as what is booked
+  // in them, so both halves ride on the one request it makes.
+  it("serves the caller's own declared availability with them", async () => {
+    const { event, recipient } = await withPendingRequest();
+    await getRepositories().meetingAvailability.replaceForGuest(
+      recipient.id,
+      event.id,
+      [SLOT_START]
+    );
+
+    const res = await meetings(await asGuest(event.id, recipient.id));
+
+    const { availability } = (await res.json()) as MyMeetingsResponse;
+    expect(availability).toEqual([SLOT_START.toISOString()]);
   });
 
   // Meetings are as private as RSVPs, so there is no way to ask about

--- a/tests/unit/meeting-column.test.ts
+++ b/tests/unit/meeting-column.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  meetingColumnRows,
+  meetingsForDay,
+  takesPartInMeetings,
+} from "@/utils/meeting-column";
+import type { MeetingView } from "@/utils/meeting-views";
+
+const DAY = {
+  start: new Date("2026-10-01T09:00:00.000Z"),
+  end: new Date("2026-10-01T11:00:00.000Z"),
+};
+const SLOT = 30;
+
+/** Four slots: 09:00, 09:30, 10:00, 10:30. */
+const at = (minutesIn: number) =>
+  new Date(DAY.start.getTime() + minutesIn * 60 * 1000).toISOString();
+
+function meeting(minutesIn: number, patch?: Partial<MeetingView>): MeetingView {
+  return {
+    id: `m-${minutesIn}`,
+    status: "accepted",
+    role: "requester",
+    otherName: "Grace",
+    slotStart: at(minutesIn),
+    slotEnd: at(minutesIn + SLOT),
+    dayLabel: "Thu 1 Oct",
+    timeLabel: "09:00 – 09:30",
+    meetingPoint: "Coffee bar",
+    message: "",
+    clashes: [],
+    ...patch,
+  };
+}
+
+const rows = (
+  meetings: MeetingView[],
+  availability: string[]
+): ReturnType<typeof meetingColumnRows> =>
+  meetingColumnRows({ meetings, availability, day: DAY, slotIncrement: SLOT });
+
+describe("meetingColumnRows", () => {
+  it("places a meeting in the row its slot starts", () => {
+    const booked = rows([meeting(30)], []).filter((r) => r.kind === "meetings");
+
+    expect(booked).toHaveLength(1);
+    expect(booked[0]).toMatchObject({ row: 2, span: 1 });
+    expect(booked[0].meetings).toHaveLength(1);
+  });
+
+  // Nothing stops a guest having an agreed meeting and an unanswered request
+  // in one slot, and two blocks in one grid cell would sit on top of each other.
+  it("groups two meetings that share a slot into one row", () => {
+    const both = rows([meeting(0), meeting(0, { id: "second" })], []).filter(
+      (r) => r.kind === "meetings"
+    );
+
+    expect(both).toHaveLength(1);
+    expect(both[0].meetings).toHaveLength(2);
+  });
+
+  // An event whose slot increment changed leaves older meetings longer than
+  // one row.
+  it("spans a meeting longer than one slot", () => {
+    const [long] = rows([meeting(0, { slotEnd: at(60) })], []);
+
+    expect(long).toMatchObject({ row: 1, span: 2, kind: "meetings" });
+  });
+
+  // A 09:30 meeting on a grid that has since gone hourly: drawn in the row
+  // that contains it, never in a later one asserting a time it does not have.
+  it("draws a meeting off the grid in the row it falls within", () => {
+    const hourly = meetingColumnRows({
+      meetings: [meeting(30), meeting(90, { slotEnd: at(150) })],
+      availability: [],
+      day: {
+        start: DAY.start,
+        end: new Date(DAY.start.getTime() + 3 * 3600e3),
+      },
+      slotIncrement: 60,
+    });
+
+    expect(hourly.filter((r) => r.kind === "meetings")).toEqual([
+      expect.objectContaining({ row: 1, span: 1 }),
+      // 10:30 – 11:30 reaches into the 11:00 row, so it covers both.
+      expect.objectContaining({ row: 2, span: 2 }),
+    ]);
+  });
+
+  // A day whose window is not a whole number of slots: the grid rounds the
+  // leftover up into a row of its own (getNumSlots), so the column has to as
+  // well, or a meeting in it would be missing from a schedule that has a row
+  // for it.
+  it("keeps the row a day's leftover minutes are drawn in", () => {
+    const ragged = meetingColumnRows({
+      meetings: [meeting(120, { slotEnd: at(150) })],
+      availability: [],
+      day: {
+        start: DAY.start,
+        end: new Date(DAY.start.getTime() + 130 * 60e3),
+      },
+      slotIncrement: SLOT,
+    });
+
+    expect(ragged.filter((r) => r.kind === "meetings")).toEqual([
+      expect.objectContaining({ row: 5 }),
+    ]);
+  });
+
+  // A day shortened after the meeting was booked leaves it reaching past the
+  // last row. It stops there: a taller column than the rooms beside it would
+  // stretch the day's grid row and leave them short of its bottom.
+  it("stops a meeting reaching past the day at the last row", () => {
+    const overhang = meetingColumnRows({
+      meetings: [meeting(60, { slotEnd: at(180) })],
+      availability: [],
+      day: { start: DAY.start, end: new Date(DAY.start.getTime() + 90 * 60e3) },
+      slotIncrement: SLOT,
+    });
+
+    expect(overhang.filter((r) => r.kind === "meetings")).toEqual([
+      expect.objectContaining({ row: 3, span: 1 }),
+    ]);
+  });
+
+  it("leaves every free slot its own row, so each is bookable on its own", () => {
+    const free = rows([], [at(0), at(30), at(60), at(90)]);
+
+    expect(free.map((r) => r.kind)).toEqual(["free", "free", "free", "free"]);
+    expect(free.map((r) => r.row)).toEqual([1, 2, 3, 4]);
+  });
+
+  // A slot the viewer cleared is one nobody may book *them* into -- they can
+  // still arrange a 1-on-1 there themselves, so it stays a row of its own
+  // rather than merging into an unbookable band.
+  it("leaves each slot the viewer is not open for bookable on its own", () => {
+    const declared = rows([], [at(0), at(90)]);
+
+    expect(declared).toEqual([
+      { row: 1, span: 1, kind: "free", meetings: [] },
+      { row: 2, span: 1, kind: "unavailable", meetings: [] },
+      { row: 3, span: 1, kind: "unavailable", meetings: [] },
+      { row: 4, span: 1, kind: "free", meetings: [] },
+    ]);
+  });
+
+  it("keeps a meeting in a slot the viewer has since cleared", () => {
+    const mixed = rows([meeting(30)], [at(0)]);
+
+    expect(mixed.map((r) => r.kind)).toEqual([
+      "free",
+      "meetings",
+      "unavailable",
+      "unavailable",
+    ]);
+  });
+
+  // Being asked needs no availability of your own, so a guest can hold
+  // meetings while having declared nothing. Their empty slots are still free
+  // rather than unavailable: what they declared governs who may book *them*,
+  // not whom they may ask.
+  it("paints nothing unavailable for a viewer who declared nothing", () => {
+    const none = rows([meeting(0)], []);
+
+    expect(none.map((r) => r.kind)).toEqual([
+      "meetings",
+      "free",
+      "free",
+      "free",
+    ]);
+  });
+
+  // A day nobody is bookable in and nothing is booked in has no column at all,
+  // so it costs no width on a phone for everyone else.
+  it("has no rows at all for a viewer with neither", () => {
+    expect(rows([], [])).toEqual([]);
+  });
+});
+
+describe("meetingsForDay", () => {
+  const day = { start: DAY.start, end: DAY.end, sessions: [] };
+
+  it("keeps a meeting starting at the day's first instant, not its last", () => {
+    const firstAndLast = [meeting(0), meeting(120)];
+
+    expect(meetingsForDay(firstAndLast, day).map((m) => m.id)).toEqual(["m-0"]);
+  });
+
+  it("keeps what is agreed or still open, and drops the rest", () => {
+    const every = (
+      ["pending", "accepted", "declined", "canceled", "expired"] as const
+    ).map((status) => meeting(0, { id: status, status }));
+
+    expect(meetingsForDay(every, day).map((m) => m.id)).toEqual([
+      "pending",
+      "accepted",
+    ]);
+  });
+});
+
+// Whether the viewer gets the column at all -- and then on every day, so the
+// rooms line up from one day to the next.
+describe("takesPartInMeetings", () => {
+  it("is true for anyone bookable, or with a live meeting anywhere", () => {
+    expect(takesPartInMeetings([], [at(0)])).toBe(true);
+    expect(takesPartInMeetings([meeting(0, { status: "pending" })], [])).toBe(
+      true
+    );
+  });
+
+  it("is false with nothing declared and nothing live", () => {
+    expect(takesPartInMeetings([], [])).toBe(false);
+    expect(takesPartInMeetings([meeting(0, { status: "declined" })], [])).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/meeting-rules.test.ts
+++ b/tests/unit/meeting-rules.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { canCancel } from "@/utils/meeting-rules";
+
+const NOW = new Date("2026-10-01T09:00:00.000Z");
+const LATER = "2026-10-01T10:00:00.000Z";
+const EARLIER = "2026-10-01T08:00:00.000Z";
+
+describe("canCancel", () => {
+  it("lets either party call off a confirmed meeting still to come", () => {
+    for (const role of ["requester", "recipient"] as const) {
+      expect(
+        canCancel({ status: "accepted", role, slotStart: LATER }, NOW)
+      ).toBe(true);
+    }
+  });
+
+  // The person asked has Decline; "canceled" where they declined would
+  // misdescribe what happened.
+  it("lets only the requester take back a pending request", () => {
+    expect(
+      canCancel({ status: "pending", role: "requester", slotStart: LATER }, NOW)
+    ).toBe(true);
+    expect(
+      canCancel({ status: "pending", role: "recipient", slotStart: LATER }, NOW)
+    ).toBe(false);
+  });
+
+  // The server refuses a slot that has begun, and an accepted meeting stays on
+  // the grid after its slot passes -- so without this every past 1-on-1 would
+  // offer a button that can only fail.
+  it("offers nothing once the slot has begun", () => {
+    expect(
+      canCancel(
+        { status: "accepted", role: "requester", slotStart: EARLIER },
+        NOW
+      )
+    ).toBe(false);
+    expect(
+      canCancel(
+        { status: "accepted", role: "requester", slotStart: NOW.toISOString() },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it("offers nothing on a meeting that is already over with", () => {
+    for (const status of ["declined", "canceled", "expired"] as const) {
+      expect(
+        canCancel({ status, role: "requester", slotStart: LATER }, NOW)
+      ).toBe(false);
+    }
+  });
+});

--- a/utils/meeting-column.ts
+++ b/utils/meeting-column.ts
@@ -1,0 +1,131 @@
+import { getNumSlots } from "@/utils/slots";
+import type { MeetingView } from "@/utils/meeting-views";
+
+const LIVE = new Set<MeetingView["status"]>(["pending", "accepted"]);
+
+/**
+ * What the grid shows of one day: what is agreed and what is still waiting.
+ * Declined, canceled and lapsed requests simply drop off it
+ * (issue #392, section 1.5).
+ */
+export function meetingsForDay(
+  meetings: MeetingView[],
+  day: { start: Date; end: Date }
+): MeetingView[] {
+  return meetings.filter((meeting) => {
+    if (!LIVE.has(meeting.status)) return false;
+    const start = new Date(meeting.slotStart).getTime();
+    return start >= day.start.getTime() && start < day.end.getTime();
+  });
+}
+
+/**
+ * Whether the viewer gets the column at all. Decided for the whole event
+ * rather than day by day, so the rooms line up from one day to the next.
+ */
+export function takesPartInMeetings(
+  meetings: MeetingView[],
+  availability: string[]
+): boolean {
+  return availability.length > 0 || meetings.some((m) => LIVE.has(m.status));
+}
+
+/**
+ * One row of the schedule's 1-on-1 column: what the viewer has in that slot,
+ * or why they have nothing there.
+ */
+export type MeetingColumnRow = {
+  /** 1-based, matching CSS grid's own row numbering. */
+  row: number;
+  span: number;
+  kind: "meetings" | "unavailable" | "free";
+  /** Empty unless `kind` is "meetings". */
+  meetings: MeetingView[];
+};
+
+/**
+ * The column's rows for one day, one per slot. Nothing merges: what the
+ * viewer cleared governs who may book *them*, and they can still arrange a
+ * 1-on-1 in it themselves, so every slot stays separately bookable (#945).
+ */
+export function meetingColumnRows({
+  meetings,
+  availability,
+  day,
+  slotIncrement,
+}: {
+  /** The viewer's meetings for this day, already filtered to what it shows. */
+  meetings: MeetingView[];
+  /** Slot starts the viewer declared themselves open for, as ISO strings. */
+  availability: string[];
+  day: { start: Date; end: Date };
+  slotIncrement: number;
+}): MeetingColumnRow[] {
+  const slotMs = slotIncrement * 60 * 1000;
+  const numSlots = getNumSlots(day.start, day.end, slotIncrement);
+  // Floored, not rounded: a meeting booked before the event's increment
+  // changed may no longer start on a row, and the row that contains it is
+  // the one that does not assert a time it does not have.
+  const rowOf = (start: string) =>
+    Math.floor((new Date(start).getTime() - day.start.getTime()) / slotMs) + 1;
+
+  const byRow = new Map<number, MeetingView[]>();
+  for (const meeting of meetings) {
+    const row = rowOf(meeting.slotStart);
+    byRow.set(row, [...(byRow.get(row) ?? []), meeting]);
+  }
+  // Measured from the row's start rather than the meeting's, so one that
+  // starts mid-row and reaches into the next covers both -- and never past the
+  // last row, which a day shortened after the booking would otherwise do,
+  // stretching the day's grid row beyond the rooms beside it.
+  const spanOf = (meeting: MeetingView) => {
+    const row = rowOf(meeting.slotStart);
+    const rowStart = day.start.getTime() + (row - 1) * slotMs;
+    const wanted = Math.ceil(
+      (new Date(meeting.slotEnd).getTime() - rowStart) / slotMs
+    );
+    return Math.min(Math.max(1, wanted), Math.max(1, numSlots - row + 1));
+  };
+  // Rows are keyed by start, so two such meetings of unequal length that
+  // overlap without sharing a row would draw over each other. Knowingly out
+  // of scope: it takes an increment change *and* two bookings athwart it.
+
+  const covered = new Set<number>();
+  for (const [row, atRow] of byRow) {
+    const span = Math.max(...atRow.map(spanOf));
+    for (let i = 0; i < span; i++) covered.add(row + i);
+  }
+
+  // Being asked takes no availability of your own, so a guest can hold
+  // meetings having declared nothing at all -- and painting their whole day
+  // "not free" would be true and useless.
+  const declared = new Set(availability);
+  const declaredAnything = declared.size > 0;
+
+  const rows: MeetingColumnRow[] = [];
+  for (let row = 1; row <= numSlots; row++) {
+    const atRow = byRow.get(row);
+    if (atRow) {
+      rows.push({
+        row,
+        span: Math.max(...atRow.map(spanOf)),
+        kind: "meetings",
+        meetings: atRow,
+      });
+      continue;
+    }
+    if (covered.has(row)) continue;
+
+    const start = new Date(day.start.getTime() + (row - 1) * slotMs);
+    const free = !declaredAnything || declared.has(start.toISOString());
+    if (free) {
+      rows.push({ row, span: 1, kind: "free", meetings: [] });
+      continue;
+    }
+    rows.push({ row, span: 1, kind: "unavailable", meetings: [] });
+  }
+
+  // Nothing declared and nothing booked is not a column at all; the caller
+  // decides that, but it should not have to filter empty "free" rows.
+  return declaredAnything || meetings.length > 0 ? rows : [];
+}

--- a/utils/meeting-rules.ts
+++ b/utils/meeting-rules.ts
@@ -1,0 +1,19 @@
+import type { MeetingView } from "@/utils/meeting-views";
+
+/**
+ * Whether this guest may call the meeting off. A confirmed one is either
+ * party's to cancel; while it is pending only the requester's, since the
+ * person asked has Decline instead. Never once the slot has begun: the server
+ * refuses that, and an accepted meeting stays on the grid after its slot
+ * passes, so the modal has to know before offering the button.
+ */
+export function canCancel(
+  meeting: Pick<MeetingView, "status" | "role" | "slotStart">,
+  now: Date
+): boolean {
+  if (new Date(meeting.slotStart).getTime() <= now.getTime()) return false;
+  return (
+    meeting.status === "accepted" ||
+    (meeting.status === "pending" && meeting.role === "requester")
+  );
+}

--- a/utils/meeting-views.ts
+++ b/utils/meeting-views.ts
@@ -32,6 +32,17 @@ export type MeetingView = {
 };
 
 /**
+ * What /api/meetings answers with: the viewer's own meetings, and the slots
+ * they declared themselves open for. The column draws both, so one request
+ * carries both.
+ */
+export type MyMeetingsResponse = {
+  meetings: MeetingView[];
+  /** ISO slot starts, as `meetingAvailability` stores them. */
+  availability: string[];
+};
+
+/**
  * The viewer's own 1-on-1s at an event, in every state — the caller decides
  * what to show, since the grid drops declined and expired ones while the modal
  * a notification links to must still explain them.


### PR DESCRIPTION
Last of the PRs for schellingboard/schellingboard#392 (1-on-1 meetings), following the
[design approved on the issue](https://github.com/LWCW-Europe/schellingboard/issues/392#issuecomment-5470900325).
Closes it.

**Rewritten as one commit** at @omarkohl's request; the review below is addressed in it, and
the UX notes are stacked on top as their own PRs. **Stacked on schellingboard/schellingboard-legacy#981** — bases move down the
chain as each lands.

## The column

Whenever you take part in 1-on-1s at all — open to them, or with one arranged anywhere in the
event — the **first column of each day**, before the rooms, is yours alone: the meetings you
have agreed, the requests still waiting for an answer, and, hatched, the slots you are not
offering. Each sits in its own slot, beside whatever it would clash with — which is the point
of putting them here rather than on a list of their own. Tapping one opens the modal, where
either party can **cancel** up until the slot begins.

## Decisions worth a reviewer's attention

**The column is per-viewer**, so it is fetched in the browser rather than baked into the
schedule's shared server render, and it sits **outside the `?loc=` filter**: it is not a
location, so narrowing the grid to one room must not drop it. It shows on every day or on none,
so the rooms line up from day to day; the first paint without it is accepted and explained in
the code. Kiosk mode is deliberately not a special case (design 2.6).

**`MeetingsProvider` holds the one copy** of the viewer's meetings and availability that the
column and the modal share. It is keyed by event and guest rather than cleared on change, so
switching names on a shared laptop can never show the previous guest's meetings while the new
request is in flight.

**The row arithmetic lives in `utils/meeting-column.ts`** with unit tests: meetings sharing a
slot, one longer than a slot after the increment changed, one no longer on a slot boundary
(floored into the row that contains it, never rounded later), and the day boundaries. A guest
who declared nothing gets no hatching, and what they declared governs who may book *them*,
never whom they may ask: a slot you are not offering is still one you can book in.

**Cancelling is either party's for a confirmed meeting**; while a request is pending it is the
requester's alone, since the person asked has Decline, and is told so if they try. The rule is
gated on the slot as well as the state, in `utils/meeting-rules.ts` with the clock from
`EventContext`.

## Testing

`make test` green; `make test-e2e` green with the email specs skipped (no mailpit). New
coverage: the column's rows, the cancel rule, cancelling end to end, and a meeting opened from
a notification closing where it opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
