### PR TITLE
fix: stop the browser hijacking the scroll on a comment permalink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Picking your name works however many events a site runs**: the header lists every event, and
   from about seven onwards the links crowded the name chip beside them off the row, leaving no way
   to say who you are. The links now scroll instead of pushing
+- **Opening a comment from an email no longer strands the page it lands on** (#930): a link to a
+  comment on a long profile could leave the profile scrolled partway under its own header, with no
+  way to scroll back up to the person's name and photo
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/comments-section.tsx
+++ b/app/(site)/[eventSlug]/comments-section.tsx
@@ -87,9 +87,10 @@ export function CommentsSection({
     if (!highlightedId) {
       return;
     }
-    document
-      .getElementById(`comment-${highlightedId}`)
-      ?.scrollIntoView({ block: "center" });
+    const target = document.querySelector<HTMLElement>(
+      `[data-comment="${CSS.escape(highlightedId)}"]`
+    );
+    target?.scrollIntoView({ block: "center" });
   }, [highlightedId, loaded]);
 
   if (comments === "error") {
@@ -217,7 +218,12 @@ function CommentThread({
       }`}
     >
       <div
-        id={`comment-${node.id}`}
+        // data-comment, not id="comment-…": an element the hash names is one
+        // the browser scrolls to itself, and its jump moves every box it can —
+        // the modal's clipped panels included, which nothing can scroll back.
+        // A profile opened at a comment was left stranded partway under its own
+        // header (#930). Scrolling to the comment is the effect above's job.
+        data-comment={node.id}
         className={`rounded ${depth > 0 ? "pl-3 pr-2 py-2" : "px-3 py-2"} ${
           node.id === highlightedId
             ? "relative z-10 ring-2 ring-brand-accent"

--- a/tests/e2e/profile-comments.spec.ts
+++ b/tests/e2e/profile-comments.spec.ts
@@ -92,6 +92,72 @@ test("replies to a profile comment and permalinks to the reply", async ({
   ).toBeVisible();
 });
 
+test("leaves a deep-linked profile scrollable back to its top", async ({
+  page,
+}) => {
+  // Short enough that the profile overflows its panel: the bug needs a profile
+  // with something to scroll.
+  await page.setViewportSize({ width: 800, height: 500 });
+  await login(page);
+  await page.goto("/guests");
+  await actAs(page, /Bob Test/i);
+
+  const profile = await openProfile(page, "Wei Chen");
+  const photo = profile.getByRole("button", {
+    name: "Enlarge photo of Wei Chen",
+  });
+  const top = (await photo.boundingBox())!.y;
+
+  await profile.getByPlaceholder("Add a comment").fill("see you in the hall");
+  // The comment renders as soon as the reloaded thread arrives, while the
+  // action that posted it is still streaming its response. The navigation below
+  // would abort that stream, which Firefox reports as an uncaught NetworkError
+  // the console guard fails on, so wait the stream out. The page's own
+  // "networkidle" has long since fired, so waitForLoadState cannot say this.
+  const posting = page.waitForResponse((r) => r.request().method() === "POST");
+  await profile.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(
+    postedComment(profile, "see you in the hall").first()
+  ).toBeVisible();
+  await (await posting).finished();
+
+  const permalink = await profile
+    .getByRole("link", { name: /^\d/ })
+    .first()
+    .getAttribute("href");
+
+  // Away first, so the permalink arrives as a fresh page load — the way it does
+  // out of a notification mail — and with the photos held open, so the comments
+  // arrive while the page is still loading. That is the window in which the
+  // browser is still trying to jump to the hash itself, which is what a slow
+  // connection buys and what makes this reproducible. Closing rather than
+  // navigating: a push changes the URL without a document load to abort.
+  await page.keyboard.press("Escape");
+  await expect(profile).toBeHidden();
+  let loadPhotos = () => {};
+  const held = new Promise<void>((resolve) => (loadPhotos = resolve));
+  await page.route(/\/(media|_next\/image)/, async (route) => {
+    await held;
+    await route.continue();
+  });
+  await page.goto(permalink!, { waitUntil: "commit" });
+  const opened = page.getByRole("dialog", { name: "Wei Chen" });
+  await expect(
+    postedComment(opened, "see you in the hall").first()
+  ).toBeVisible();
+  loadPhotos();
+
+  // Landing on the comment scrolls the profile down; scrolling back must reach
+  // the photo it started at. That jump used to move the boxes around the
+  // profile as well — the modal's clipped panels, which nothing can scroll
+  // back — stranding the top of the profile out of reach.
+  await page.mouse.move(400, 300);
+  await page.mouse.wheel(0, -5000);
+  await expect
+    .poll(async () => (await photo.boundingBox())?.y)
+    .toBeCloseTo(top, 0);
+});
+
 // A section that can't reach its endpoint used to sit on a "Loading
 // comments..." skeleton forever (profiles) or claim "0 comments" (sessions),
 // both of which say something untrue about the thread.


### PR DESCRIPTION
The comment carried the hash as its element id, so on a cold load the
browser jumped to it on its own — and that jump scrolls every box it can,
including the profile modal's overflow:hidden panels, which nothing can
scroll back. A profile opened from a comment mail was left stranded
partway under its own header. The section already scrolls to the comment
itself, so the id only ever invited a second, worse scroll.

fixes schellingboard/schellingboard#930

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=592326f2ff4ef09eecce145a7a6e6294be983839 -->