### PR TITLE
fix: show why enabling account protection failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Picking your name works however many events a site runs**: the header lists every event, and
   from about seven onwards the links crowded the name chip beside them off the row, leaving no way
   to say who you are. The links now scroll instead of pushing
+- **Account settings now says why enabling protection failed** (#716): on a site with no email set
+  up, "Enable protection" looked like it did nothing at all — the server's explanation was thrown
+  away instead of shown
 - **Opening a comment from an email no longer strands the page it lands on** (#930): a link to a
   comment on a long profile could leave the profile scrolled partway under its own header, with no
   way to scroll back up to the person's name and photo

--- a/app/(site)/settings/account-security.tsx
+++ b/app/(site)/settings/account-security.tsx
@@ -164,6 +164,11 @@ export function AccountSecurity({
               {info}
             </p>
           )}
+          {error && (
+            <p role="alert" className="text-sm text-danger-fg">
+              {error}
+            </p>
+          )}
         </div>
       ) : (
         <form


### PR DESCRIPTION
The error state was only rendered inside the password form, so the
buttons that email a link — the only ones visible before protection is
on — swallowed every failure the server reported, most visibly "this
server cannot send email".

fixes schellingboard/schellingboard#716

<!-- jip:pushed-commit=9317db1ee8eb3d05d4633a918ff995c70028de01 -->