### PR TITLE
fix: make the name picker less fiddly to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Picking your name works however many events a site runs**: the header lists every event, and
   from about seven onwards the links crowded the name chip beside them off the row, leaving no way
   to say who you are. The links now scroll instead of pushing
+- **Picking your name is less fiddly** (#777): the search box is focused as soon as the "My name is"
+  box opens, so you can type straight away, and erasing what you typed no longer closes the box on
+  you
+- **The password prompt now names the account beside the box** (#777): choosing a protected name
+  showed a "Logging in as" field only to password managers, leaving a blank password box with
+  nothing but a sentence above it to say whose password it wanted
 - **Account settings now says why enabling protection failed** (#716): on a site with no email set
   up, "Enable protection" looked like it did nothing at all — the server's explanation was thrown
   away instead of shown

--- a/app/(site)/guest-login-form.tsx
+++ b/app/(site)/guest-login-form.tsx
@@ -5,7 +5,6 @@ import {
   requestLoginCodeAction,
   requestPasswordLinkAction,
 } from "@/app/actions/user-auth";
-import { PasswordManagerHint } from "@/app/password-manager-hint";
 
 // Credential prompt for switching to a protected guest: accepts either the
 // permanent password or an emailed single-use login code in one field, with a
@@ -97,10 +96,29 @@ export function GuestLoginForm({
       }}
     >
       <p className="text-sm text-fg-muted">
-        {guestName} has protected their account. Enter their password, or use a
+        This user has protected their account. Enter their password, or use a
         single-use code emailed to them. Forgot the password? Reset it instead.
       </p>
-      <PasswordManagerHint username={guestName} />
+      <label
+        htmlFor="guest-login-username"
+        className="text-sm font-medium text-fg-muted"
+      >
+        Logging in as
+      </label>
+      {/* A visible field rather than the hidden PasswordManagerHint: it is the
+          only thing naming the account the credential below belongs to, which
+          an empty password box on its own left the user guessing. It still
+          carries the autocomplete wiring the hint existed for — see
+          password-manager-hint.tsx for why a username field has to be here. */}
+      <input
+        id="guest-login-username"
+        name="username"
+        type="text"
+        autoComplete="username"
+        value={guestName}
+        readOnly
+        className="rounded-md border border-line bg-surface-muted px-3 py-2 text-sm text-fg-muted outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent"
+      />
       <label
         htmlFor="guest-credential"
         className="text-sm font-medium text-fg-muted"

--- a/app/(site)/header-user-select.tsx
+++ b/app/(site)/header-user-select.tsx
@@ -55,7 +55,7 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
       <label htmlFor="user-selection" className="text-fg-subtle">
         My name is:
       </label>
-      <UserSelect guests={guests} onSelect={() => setOpen(false)} />
+      <UserSelect guests={guests} onSelect={() => setOpen(false)} autoFocus />
     </Modal>
   );
 

--- a/app/(site)/user-select.tsx
+++ b/app/(site)/user-select.tsx
@@ -9,10 +9,12 @@ export function UserSelect({
   guests,
   showOnlyWhenUserSet,
   onSelect,
+  autoFocus,
 }: {
   guests: Guest[];
   showOnlyWhenUserSet?: boolean;
   onSelect?: () => void;
+  autoFocus?: boolean;
 }) {
   const { user: currentUser, switchUser, applyUser } = useContext(UserContext);
   // Set when a protected guest was picked and credentials are needed.
@@ -50,6 +52,7 @@ export function UserSelect({
           }}
           selectMany={false}
           showProtected
+          autoFocus={autoFocus}
         />
         {error && <p className="text-sm text-danger-fg">{error}</p>}
         {pendingGuest && (

--- a/app/select-hosts.tsx
+++ b/app/select-hosts.tsx
@@ -20,8 +20,10 @@ export function SelectHosts<
   // one flow that then asks for a password or code; in co-host pickers the
   // indicator would wrongly imply credentials are needed to add someone.
   showProtected?: boolean;
+  autoFocus?: boolean;
 }) {
-  const { guests, hosts, setHosts, id, selectMany, showProtected } = props;
+  const { guests, hosts, setHosts, id, selectMany, showProtected, autoFocus } =
+    props;
   const [query, setQuery] = useState("");
   const filteredGuests = guests
     .filter((guest) => containsIgnoringAccents(guest.name, query))
@@ -57,6 +59,7 @@ export function SelectHosts<
           )}
           <Combobox.Input
             id={id}
+            autoFocus={autoFocus}
             onChange={(event) => setQuery(event.target.value)}
             value={query}
             className="border-none focus:ring-0 px-0 py-1 text-sm flex-1 min-w-8 bg-transparent placeholder:text-fg-subtle outline-none"
@@ -142,8 +145,15 @@ export function SelectHosts<
         <Combobox
           value={hosts[0] ?? null}
           by="id"
-          onChange={(newHosts) => {
-            setHosts(newHosts ? [newHosts] : []);
+          // A single-select combobox reports an emptied input as onChange(null).
+          // That is the user erasing their search, not unpicking the selection —
+          // treating it as a deselection would fire the caller's "nothing is
+          // selected any more" path (and, in the name switcher, close the modal)
+          // on the way to typing a different name. Removal stays with the chip's
+          // explicit "Remove <name>" button.
+          onChange={(newHost) => {
+            if (!newHost) return;
+            setHosts([newHost]);
             setQuery("");
           }}
           immediate

--- a/tests/e2e/helpers/user.ts
+++ b/tests/e2e/helpers/user.ts
@@ -9,7 +9,10 @@ import { login } from "./auth";
 // already opened: that would toggle the menu shut again, and with the modal it
 // would hang outright, since the dialog's backdrop makes the chip unclickable
 // and nothing bounds a click's actionability wait.
-async function tapUntilOpen(trigger: Locator, opened: Locator): Promise<void> {
+export async function tapUntilOpen(
+  trigger: Locator,
+  opened: Locator
+): Promise<void> {
   await expect(async () => {
     if (!(await opened.isVisible())) {
       await trigger.click();

--- a/tests/e2e/user-auth.spec.ts
+++ b/tests/e2e/user-auth.spec.ts
@@ -1,7 +1,7 @@
 import { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
-import { openNameSwitcher, selectUser } from "./helpers/user";
+import { openNameSwitcher, selectUser, tapUntilOpen } from "./helpers/user";
 import {
   getMessage,
   newestBySubjectTo,
@@ -106,6 +106,40 @@ async function logInAs(page: Page, credential: string) {
   await page.getByRole("button", { name: "Log in" }).click();
 }
 
+test("the name switcher focuses its search, and clearing it keeps the modal open", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/");
+
+  // Not openNameSwitcher: that helper clicks the search box, which would
+  // focus it and hide the very thing under test. Opening by hand still needs
+  // tapUntilOpen for the hydration race.
+  const nameBox = page.getByLabel("My name is:");
+  await tapUntilOpen(
+    page.getByRole("button", { name: "Your name", exact: true }),
+    nameBox
+  );
+  await expect(nameBox).toBeFocused();
+
+  await nameBox.pressSequentially("Bob");
+  await expect(page.getByRole("option", { name: /Bob Test/i })).toBeVisible();
+  await nameBox.press("Backspace");
+  await nameBox.press("Backspace");
+  await nameBox.press("Backspace");
+  await expect(nameBox).toHaveValue("");
+
+  // Emptying the search is not a deselection: the modal is still there and
+  // still picks a name. A deselection reaches the server (selectUserAction)
+  // before it closes the modal, so let that round trip drain first —
+  // asserting straight after the last Backspace passes even when the bug is
+  // there.
+  await page.waitForLoadState("networkidle");
+  await expect(nameBox).toBeVisible();
+  await page.getByRole("option", { name: /Bob Test/i }).click();
+  await expect(headerChip(page, "Bob Test")).toBeVisible();
+});
+
 test("logging out from the chip menu clears the selected name", async ({
   page,
 }) => {
@@ -177,6 +211,8 @@ test("protect a name via emailed link, then log in with password and single-use 
   ).toBeVisible();
   await priyaOption.click();
   await expect(page.getByText(/has protected their account/i)).toBeVisible();
+  // The credential field says whose credential it wants.
+  await expect(page.getByLabel("Logging in as")).toHaveValue("Priya Sharma");
   await logInAs(page, "not-the-password");
   await expect(page.getByText(/wrong password or code/i)).toBeVisible();
   await logInAs(page, PRIYA_PASSWORD);


### PR DESCRIPTION
Clearing the search text dismissed the whole modal: a single-select
combobox reports an emptied input as onChange(null), which the picker
took for a deselection. The search box also had to be tapped before it
could be typed into, and the credential prompt for a protected name kept
the account it belongs to in a sentence above the blank password box,
while the "Logging in as" field right beside it was hidden for password
managers.

fixes schellingboard/schellingboard#777

<!-- jip:pushed-commit=f0534ae4ff0aa97c8232af086d5008b31c0f53d5 -->