### PR TITLE
fix: stamp proposals and the past-booking check with the request's clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- **The dev fake clock reaches proposal timestamps and the past-booking check**: a proposal created
+  under a time offset was stamped with real time, so it came out older than the comments on it — and
+  "a session must start in the future" was judged against real time too, letting a time-travelled
+  organizer book into their own past, or refusing a slot the interface still offered
 - The first room photo on the schedule grid is loaded eagerly. It sits above the fold and is usually
   the page's largest element, so Next warned that the Largest Contentful Paint image was being
   lazy-loaded

--- a/app/(site)/[eventSlug]/proposals/actions.ts
+++ b/app/(site)/[eventSlug]/proposals/actions.ts
@@ -44,10 +44,11 @@ export async function createProposal(
   } = parseResult;
 
   try {
+    const now = await serverNow();
     // Mirrors the UI: proposals may be added during the proposal and voting
     // phases; once scheduling starts they are closed.
     const event = await getRepositories().events.findById(eventId);
-    if (!event || inSchedPhase(event, await serverNow())) {
+    if (!event || inSchedPhase(event, now)) {
       return { error: "The proposal phase is over" };
     }
 
@@ -73,6 +74,7 @@ export async function createProposal(
       description: description || undefined,
       hostIds,
       durationMinutes,
+      createdTime: now,
     });
     revalidatePath(`/${eventSlug}/proposals`);
   } catch (error) {

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -93,7 +93,7 @@ export async function POST(req: NextRequest) {
   const existingSessions = (await repos.sessions.listScheduled()).filter(
     (s) => s.eventId === input.eventId
   );
-  const sessionValid = validateSession(input, existingSessions);
+  const sessionValid = validateSession(input, existingSessions, now);
   if (sessionValid) {
     let session;
     try {

--- a/app/api/admin/create-proposal/route.ts
+++ b/app/api/admin/create-proposal/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getRepositories } from "@/db/container";
+import { requestNow } from "@/utils/dev-clock";
 import { requireProxyVerifiedAdmin } from "@/utils/auth";
 
 export const dynamic = "force-dynamic";
@@ -90,6 +91,7 @@ export async function POST(req: Request) {
     description: body.description?.trim() || undefined,
     hostIds,
     durationMinutes: duration ?? undefined,
+    createdTime: requestNow(req),
   });
 
   return NextResponse.json({ id: proposal.id }, { status: 201 });

--- a/app/api/session-form-utils.ts
+++ b/app/api/session-form-utils.ts
@@ -64,14 +64,18 @@ export function prepareToInsert(
   };
 }
 
+// `now` is the effective current time (see docs/dev/adr/0004-dev-fake-clock.md),
+// required rather than defaulted so a caller cannot silently bypass the fake
+// clock and judge "in the past" against real time.
 export const validateSession = (
   session: SessionCreateInput,
-  existingSessions: Session[]
+  existingSessions: Session[],
+  now: Date
 ) => {
   const sessionStart = session.startTime ?? new Date(0);
   const sessionEnd = session.endTime ?? new Date(0);
   const sessionStartsBeforeEnds = sessionStart < sessionEnd;
-  const sessionStartsAfterNow = sessionStart > new Date();
+  const sessionStartsAfterNow = sessionStart > now;
   const sessionsHere = existingSessions.filter((s) => {
     return s.locations.some((l) => l.id === session.locationIds[0]);
   });

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
   // RSVP hard limit, so take it from the stored row instead.
   input.capacity = chosen[0].capacity;
   const existingSessions = allSessions.filter((ses) => ses.id !== params.id);
-  const sessionValid = validateSession(input, existingSessions);
+  const sessionValid = validateSession(input, existingSessions, now);
   if (sessionValid) {
     let updated;
     try {

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -667,6 +667,7 @@ export type SessionProposalCreateInput = {
   description?: string;
   hostIds: string[];
   durationMinutes?: number;
+  createdTime: Date;
 };
 
 export type SessionProposalUpdateInput = {

--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -219,7 +219,6 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
 
   async create(data: SessionProposalCreateInput): Promise<SessionProposal> {
     const id = nanoid();
-    const createdTime = new Date().toISOString();
     this.db.transaction((tx) => {
       tx.insert(schema.sessionProposals)
         .values({
@@ -228,7 +227,7 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
           title: data.title,
           description: data.description ?? null,
           durationMinutes: data.durationMinutes ?? null,
-          createdTime,
+          createdTime: data.createdTime.toISOString(),
         })
         .run();
       for (const guestId of data.hostIds) {

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -177,7 +177,12 @@ export function slotStart(day: Day, minutesIn: number): string {
 export async function createProposal(
   eventId: string,
   hostIds: string[],
-  opts?: { title?: string; description?: string; durationMinutes?: number }
+  opts?: {
+    title?: string;
+    description?: string;
+    durationMinutes?: number;
+    createdTime?: Date;
+  }
 ): Promise<SessionProposal> {
   const { sessionProposals } = getRepositories();
   return sessionProposals.create({
@@ -186,6 +191,7 @@ export async function createProposal(
     description: opts?.description,
     hostIds,
     durationMinutes: opts?.durationMinutes,
+    createdTime: opts?.createdTime ?? new Date(),
   });
 }
 

--- a/tests/integration/proposals.test.ts
+++ b/tests/integration/proposals.test.ts
@@ -41,6 +41,7 @@ import {
   createProposal,
   updateProposal,
 } from "@/app/(site)/[eventSlug]/proposals/actions";
+import { TIME_OFFSET_COOKIE } from "@/utils/dev-clock";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef";
 
@@ -200,6 +201,30 @@ describe("createProposal", () => {
       event.id
     );
     expect(proposals).toHaveLength(1);
+  });
+
+  // A proposal's createdTime is shown and sorted next to the comments posted on
+  // it, and those are stamped with serverNow() — so it has to follow the same
+  // clock or a time-travelled session sees the two disagree.
+  it("stamps a proposal with the offset the dev toolbar is holding", async () => {
+    vi.stubEnv("SB_ENABLE_DEV_TOOLS", "1");
+    const event = await createEvent();
+    const threeDays = 3 * 24 * 60 * 60 * 1000;
+    cookieJar.set(TIME_OFFSET_COOKIE, String(threeDays));
+
+    const result = await createProposal({
+      eventId: event.id,
+      eventSlug: "test-event",
+      title: "Time-travelled",
+      hostIds: [],
+    });
+    expect(result).toEqual({ success: true });
+
+    const [proposal] = await getRepositories().sessionProposals.listByEvent(
+      event.id
+    );
+    const shift = proposal.createdTime.getTime() - Date.now();
+    expect(Math.abs(shift - threeDays)).toBeLessThan(60_000);
   });
 });
 

--- a/tests/unit/session-validation.test.ts
+++ b/tests/unit/session-validation.test.ts
@@ -5,8 +5,13 @@ import type { Session, SessionCreateInput } from "@/db/repositories/interfaces";
 const LOC_A = "loc-a";
 const LOC_B = "loc-b";
 
-// minutes from now
-const fromNow = (minutes: number) => new Date(Date.now() + minutes * 60_000);
+// Deliberately behind real time: a session an hour after NOW is in the wall
+// clock's past, so every "accepts" case below fails if the validator ever goes
+// back to reading Date.now() instead of the clock it is handed.
+const NOW = new Date("2026-06-01T10:00:00.000Z");
+
+// minutes from NOW, the clock the validator is handed
+const fromNow = (minutes: number) => new Date(NOW.getTime() + minutes * 60_000);
 
 function makeInput(
   overrides?: Partial<SessionCreateInput>
@@ -51,7 +56,7 @@ function makeExisting(
 
 describe("validateSession", () => {
   it("accepts a valid session with no existing sessions", () => {
-    expect(validateSession(makeInput(), [])).toBeTruthy();
+    expect(validateSession(makeInput(), [], NOW)).toBeTruthy();
   });
 
   it("rejects when start >= end", () => {
@@ -59,13 +64,13 @@ describe("validateSession", () => {
       startTime: fromNow(120),
       endTime: fromNow(60),
     });
-    expect(validateSession(input, [])).toBeFalsy();
+    expect(validateSession(input, [], NOW)).toBeFalsy();
   });
 
   it("rejects when start equals end", () => {
     const t = fromNow(60);
     expect(
-      validateSession(makeInput({ startTime: t, endTime: t }), [])
+      validateSession(makeInput({ startTime: t, endTime: t }), [], NOW)
     ).toBeFalsy();
   });
 
@@ -74,43 +79,58 @@ describe("validateSession", () => {
       startTime: fromNow(-60),
       endTime: fromNow(60),
     });
-    expect(validateSession(input, [])).toBeFalsy();
+    expect(validateSession(input, [], NOW)).toBeFalsy();
+  });
+
+  // The other direction, which the NOW-based cases can't show: a start still in
+  // the wall clock's future, rejected because the caller's clock has travelled
+  // past it. A time-travelled organizer can't book into their own past.
+  it("rejects a start that is past only for the clock it was given", () => {
+    const realFuture = new Date(Date.now() + 60 * 60_000);
+    const input = makeInput({
+      startTime: realFuture,
+      endTime: new Date(realFuture.getTime() + 60 * 60_000),
+    });
+    const travelledPastIt = new Date(realFuture.getTime() + 30 * 60_000);
+    expect(validateSession(input, [], travelledPastIt)).toBeFalsy();
   });
 
   it("rejects when title is missing", () => {
-    expect(validateSession(makeInput({ title: "" }), [])).toBeFalsy();
+    expect(validateSession(makeInput({ title: "" }), [], NOW)).toBeFalsy();
   });
 
   it("rejects when hostIds is empty", () => {
-    expect(validateSession(makeInput({ hostIds: [] }), [])).toBeFalsy();
+    expect(validateSession(makeInput({ hostIds: [] }), [], NOW)).toBeFalsy();
   });
 
   it("rejects when locationIds is empty", () => {
-    expect(validateSession(makeInput({ locationIds: [] }), [])).toBeFalsy();
+    expect(
+      validateSession(makeInput({ locationIds: [] }), [], NOW)
+    ).toBeFalsy();
   });
 
   it("rejects partial overlap in same location (start-overlap)", () => {
     const existing = makeExisting(fromNow(30), fromNow(90));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeFalsy();
+    expect(validateSession(input, [existing], NOW)).toBeFalsy();
   });
 
   it("rejects partial overlap in same location (end-overlap)", () => {
     const existing = makeExisting(fromNow(90), fromNow(150));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeFalsy();
+    expect(validateSession(input, [existing], NOW)).toBeFalsy();
   });
 
   it("rejects when existing session is fully contained within new session", () => {
     const existing = makeExisting(fromNow(70), fromNow(110));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeFalsy();
+    expect(validateSession(input, [existing], NOW)).toBeFalsy();
   });
 
   it("accepts back-to-back sessions in same location", () => {
     const existing = makeExisting(fromNow(0), fromNow(60));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeTruthy();
+    expect(validateSession(input, [existing], NOW)).toBeTruthy();
   });
 
   it("accepts overlapping sessions in different locations", () => {
@@ -120,24 +140,24 @@ describe("validateSession", () => {
       endTime: fromNow(120),
       locationIds: [LOC_A],
     });
-    expect(validateSession(input, [existing])).toBeTruthy();
+    expect(validateSession(input, [existing], NOW)).toBeTruthy();
   });
 
   it("rejects identical interval in same location", () => {
     const existing = makeExisting(fromNow(60), fromNow(120));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeFalsy();
+    expect(validateSession(input, [existing], NOW)).toBeFalsy();
   });
 
   it("rejects same-start longer-end in same location", () => {
     const existing = makeExisting(fromNow(60), fromNow(180));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeFalsy();
+    expect(validateSession(input, [existing], NOW)).toBeFalsy();
   });
 
   it("rejects same-end earlier-start in same location", () => {
     const existing = makeExisting(fromNow(30), fromNow(120));
     const input = makeInput({ startTime: fromNow(60), endTime: fromNow(120) });
-    expect(validateSession(input, [existing])).toBeFalsy();
+    expect(validateSession(input, [existing], NOW)).toBeFalsy();
   });
 });


### PR DESCRIPTION
A proposal's createdTime came from the wall clock while the comments posted
on it come from serverNow(), so under a clock offset a proposal was older
than the comments it carried -- and the column is displayed and sortable.
validateSession judged "starts in the future" the same way, two lines after
its callers had already computed requestNow(req): a time-travelled organizer
could book into their own past, or be refused a slot the UI still offered.

create() now takes createdTime like comments.create does, and validateSession
takes a required now, so the compiler forces every call site to hand over the
effective clock. No DB-layer producer takes time from the wall clock any more.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=dd6e90f9ce0ae85da30b45dac64bdd258eb6faa4 -->