### PR TITLE
refactor: return a plain boolean from validateSession

### DIFF
--- a/app/api/session-form-utils.ts
+++ b/app/api/session-form-utils.ts
@@ -71,7 +71,7 @@ export const validateSession = (
   session: SessionCreateInput,
   existingSessions: Session[],
   now: Date
-) => {
+): boolean => {
   const sessionStart = session.startTime ?? new Date(0);
   const sessionEnd = session.endTime ?? new Date(0);
   const sessionStartsBeforeEnds = sessionStart < sessionEnd;
@@ -88,8 +88,8 @@ export const validateSession = (
     sessionStartsBeforeEnds &&
     sessionStartsAfterNow &&
     concurrentSessions.length === 0 &&
-    session.title &&
-    session.locationIds[0] &&
-    session.hostIds[0];
+    !!session.title &&
+    !!session.locationIds[0] &&
+    !!session.hostIds[0];
   return sessionValid;
 };


### PR DESCRIPTION
The &&-chain ended on session.hostIds[0], so the declared return type was
string | boolean | undefined even though every caller only branches on
truthiness. Runtime behaviour is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=2aef0a20382233ff1561ac32a72550858526a922 -->