### PR TITLE
feat: show the current-time line on every schedule, not just kiosks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **The schedule shows where you are in the day** (#863): a red line marks the current
+  time and a "Now" button jumps to it, both while the event is running — until now the line
+  was only drawn on kiosks
 - **In-app notifications** (#750): a bell in the header counts what is waiting, and the
   notifications page lists everything newest first. Anything that emails you appears here
   too, so an event with no email set up still reaches its attendees

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { useSearchParams } from "next/navigation";
 import { TIME_FORMAT } from "@/utils/utils";
 import { getNumSlots, getNowOffsetPx } from "@/utils/slots";
-import { useKioskMode } from "./kiosk";
+import { NowLine } from "./now-line";
 import { useContext } from "react";
 import Image from "next/image";
 import { isUnoptimized } from "@/utils/image-loader";
@@ -46,13 +46,12 @@ export function DayGrid(props: {
   const hasImages = firstImageIndex !== -1;
   const date = DateTime.fromJSDate(day.start).setZone(timezone);
 
-  // Kiosk mode: a red line across the day at the current time. `now` comes from
-  // EventContext so it honours the dev fake clock (and ticks live) rather than
-  // reading the real wall clock — time-travelling with ?dev=1 must move the
-  // line too. SSR and hydration share the server-seeded value, so they agree.
-  const nowOffsetPx = useKioskMode()
-    ? getNowOffsetPx(day, now, slotIncrement)
-    : null;
+  // A red line across the day at the current time, null on any day that isn't
+  // today. `now` comes from EventContext so it honours the dev fake clock (and
+  // ticks live) rather than reading the real wall clock — time-travelling with
+  // ?dev=1 must move the line too. SSR and hydration share the server-seeded
+  // value, so they agree.
+  const nowOffsetPx = getNowOffsetPx(day, now, slotIncrement);
 
   return (
     <div
@@ -161,14 +160,7 @@ export function DayGrid(props: {
               .toFormat(TIME_FORMAT)}
           </div>
         ))}
-        {nowOffsetPx !== null && (
-          <div
-            data-testid="now-line"
-            aria-hidden="true"
-            className="absolute inset-x-0 z-10 h-0.5 bg-danger pointer-events-none"
-            style={{ top: nowOffsetPx }}
-          />
-        )}
+        {nowOffsetPx !== null && <NowLine offsetPx={nowOffsetPx} anchor />}
       </div>
       {includedLocations.map((location) => (
         <LocationCol

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -7,8 +7,9 @@ import { useSearchParams } from "next/navigation";
 import { DayText } from "./day-text";
 import { Input } from "@/app/input";
 import { useState, useContext, useRef } from "react";
-import { EventContext } from "../context";
+import { EventContext, useSlotIncrement } from "../context";
 import { getDefaultFoldedDayIds } from "@/utils/schedule-fold";
+import { getNowOffsetPx } from "@/utils/slots";
 import { KioskController, useKioskMode } from "./kiosk";
 import { SessionModal } from "./session-modal";
 import { MeetingModalFromUrl } from "./meeting-modal";
@@ -28,6 +29,7 @@ export function EventDisplay() {
     () => new Set()
   );
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const slotIncrement = useSlotIncrement();
   useDragToPan(scrollerRef, view === "grid");
 
   if (!event) return <div>No event data available</div>;
@@ -45,7 +47,18 @@ export function EventDisplay() {
     });
   const locationsForEvent = locations;
 
-  const toolbar = <ScheduleToolbar event={event} />;
+  // "Now" only makes sense while the event is running, and only in the grid:
+  // it scrolls to the now line, which is drawn there and only on a day the
+  // current moment falls inside.
+  const nowIsOnSchedule = daysForEvent.some(
+    (day) => getNowOffsetPx(day, now, slotIncrement) !== null
+  );
+  const toolbar = (
+    <ScheduleToolbar
+      event={event}
+      showJumpToNow={view === "grid" && nowIsOnSchedule}
+    />
+  );
 
   // Both views own the viewport below the nav bar via the same fixed frame, so
   // the toolbar rests in the same spot and doesn't jump when switching views.

--- a/app/(site)/[eventSlug]/kiosk.tsx
+++ b/app/(site)/[eventSlug]/kiosk.tsx
@@ -1,11 +1,13 @@
 "use client";
 import { useEffect, useSyncExternalStore } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { scrollNowLineIntoView } from "./now-line";
 
-// Kiosk mode (?kiosk=1) is for unattended large screens at the venue: a red
-// line marks the current time on the grid and is scrolled into view at
-// regular intervals. All normal interaction stays available so visitors
-// without a phone can still RSVP or add sessions from the display.
+// Kiosk mode (?kiosk=1) is for unattended large screens at the venue: the now
+// line every schedule draws is scrolled back into view at regular intervals,
+// so nobody has to touch the display for it to show what is on. All normal
+// interaction stays available so visitors without a phone can still RSVP or
+// add sessions from the display.
 
 /** How often the schedule is scrolled back to the now line. */
 const SCROLL_INTERVAL_MS = 3 * 60 * 1000;
@@ -104,10 +106,9 @@ export function KioskController() {
     };
   }, []);
 
-  // Periodically bring the now line back into view: scroll the grid — pinned
-  // below the toolbar, it is the page's only scroll surface — so the line
-  // sits a third from the top. Paused while someone is interacting with the
-  // display.
+  // Periodically bring the now line back into view, the same jump the
+  // toolbar's "Now" button makes. Paused while someone is interacting with
+  // the display.
   useEffect(() => {
     let lastInteraction = -Infinity;
     const markInteraction = () => {
@@ -125,20 +126,7 @@ export function KioskController() {
 
     const scrollToNow = () => {
       if (performance.now() - lastInteraction < INTERACTION_IDLE_MS) return;
-      const container = document.querySelector(
-        '[data-testid="schedule-scroll"]'
-      );
-      const line = document.querySelector('[data-testid="now-line"]');
-      if (!container || !line) return;
-      const containerTop = container.getBoundingClientRect().top;
-      container.scrollTo({
-        top:
-          container.scrollTop +
-          line.getBoundingClientRect().top -
-          containerTop -
-          container.clientHeight / 3,
-        behavior: "smooth",
-      });
+      scrollNowLineIntoView();
     };
 
     const initial = setTimeout(scrollToNow, INITIAL_SCROLL_DELAY_MS);

--- a/app/(site)/[eventSlug]/location-col.tsx
+++ b/app/(site)/[eventSlug]/location-col.tsx
@@ -2,6 +2,7 @@ import type { Session, Location, Guest } from "@/db/repositories/interfaces";
 import type { DayWithSessions } from "@/app/(site)/context";
 import { useSlotIncrement } from "@/app/(site)/context";
 import { SessionBlock } from "./session-block";
+import { NowLine } from "./now-line";
 import { getNumSlots } from "@/utils/slots";
 import clsx from "clsx";
 
@@ -10,7 +11,7 @@ export function LocationCol(props: {
   location: Location;
   day: DayWithSessions;
   guests: Guest[];
-  /** Kiosk now-line offset from the top of the slot grid; null hides it. */
+  /** Now-line offset from the top of the slot grid; null hides it. */
   nowOffsetPx?: number | null;
 }) {
   const { sessions, location, day, guests, nowOffsetPx } = props;
@@ -34,16 +35,10 @@ export function LocationCol(props: {
           );
         })}
       </div>
-      {/* Each column draws its own segment of the kiosk now line; together
-          with the gutter's segment (see DayGrid) they form one continuous
-          line across the day. */}
-      {nowOffsetPx != null && (
-        <div
-          aria-hidden="true"
-          className="absolute inset-x-0 z-10 h-0.5 bg-danger pointer-events-none"
-          style={{ top: nowOffsetPx }}
-        />
-      )}
+      {/* Each column draws its own segment of the now line; together with the
+          gutter's segment (see DayGrid) they form one continuous line across
+          the day. */}
+      {nowOffsetPx != null && <NowLine offsetPx={nowOffsetPx} />}
     </div>
   );
 }

--- a/app/(site)/[eventSlug]/now-line.tsx
+++ b/app/(site)/[eventSlug]/now-line.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+// The red line marking the current time on the schedule grid. A day draws one
+// segment per grid column — the time gutter plus every location — which line
+// up into a single line across the day.
+
+export function NowLine(props: {
+  /** Offset from the top of the day's slot grid, from `getNowOffsetPx`. */
+  offsetPx: number;
+  /**
+   * Marks the gutter's segment: the one "jump to now" scrolls to, and the one
+   * tests address. The gutter sticks to the left edge, so that segment is on
+   * screen however far the grid is scrolled sideways — and being the only one
+   * carrying the test id keeps the target unambiguous.
+   */
+  anchor?: boolean;
+}) {
+  return (
+    <div
+      data-testid={props.anchor ? "now-line" : undefined}
+      aria-hidden="true"
+      className="absolute inset-x-0 z-10 h-0.5 bg-danger pointer-events-none"
+      style={{ top: props.offsetPx }}
+    />
+  );
+}
+
+/**
+ * Scrolls the schedule so the now line sits a third from the top — far enough
+ * down to keep the last session or two in sight, high enough for what is still
+ * to come. A no-op when the line isn't rendered (the event isn't running) or
+ * the schedule isn't the current view.
+ */
+export function scrollNowLineIntoView() {
+  // The frame's inner container is the page's only scroll surface, toolbar
+  // and all — see EventDisplay.
+  const container = document.querySelector('[data-testid="schedule-scroll"]');
+  const line = document.querySelector('[data-testid="now-line"]');
+  if (!container || !line) return;
+  const containerTop = container.getBoundingClientRect().top;
+  container.scrollTo({
+    top:
+      container.scrollTop +
+      line.getBoundingClientRect().top -
+      containerTop -
+      container.clientHeight / 3,
+    behavior: "smooth",
+  });
+}

--- a/app/(site)/[eventSlug]/schedule-toolbar.tsx
+++ b/app/(site)/[eventSlug]/schedule-toolbar.tsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import {
   CalendarIcon,
   ClipboardDocumentListIcon,
+  ClockIcon,
   DocumentTextIcon,
   FlagIcon,
   InformationCircleIcon,
@@ -17,14 +18,23 @@ import Link from "next/link";
 import { Modal } from "@/app/components/modal";
 import { Markdown } from "@/app/(site)/markdown";
 import { hasPhases } from "@/app/(site)/utils/events";
+import { scrollNowLineIntoView } from "./now-line";
 import type { Event } from "@/db/repositories/interfaces";
 
+const ITEM_CLASS =
+  "flex items-center gap-1 rounded-md py-1.5 px-1 text-xs sm:text-sm text-fg-subtle hover:text-brand-fg focus:outline-none focus:ring-2 focus:ring-brand-accent";
+
 // Slim single-row (wrapping on mobile) header for the schedule views. The view
-// toggle (Grid/Text/RSVP'd) sits next to two distinct navigation links —
-// "Event details" (opens a popup with dates/description) and "Proposals". The
-// event name is intentionally omitted: the site header already shows it.
-export function ScheduleToolbar(props: { event: Event }) {
-  const { event } = props;
+// toggle (Grid/Text/RSVP'd) sits next to "Now", which jumps the grid to the
+// current time, and two distinct navigation links — "Event details" (opens a
+// popup with dates/description) and "Proposals". The event name is
+// intentionally omitted: the site header already shows it.
+export function ScheduleToolbar(props: {
+  event: Event;
+  /** Whether to offer "Now" — only while the grid has a line to jump to. */
+  showJumpToNow?: boolean;
+}) {
+  const { event, showJumpToNow } = props;
   const [detailsOpen, setDetailsOpen] = useState(false);
   return (
     // The outer div spans the (possibly horizontally overflowing) grid width;
@@ -37,27 +47,28 @@ export function ScheduleToolbar(props: { event: Event }) {
             navigation links that follow. */}
         <span className="hidden h-5 w-px bg-line-subtle sm:block" aria-hidden />
         <div className="flex items-center gap-x-4 gap-y-1">
-          <button
-            onClick={() => setDetailsOpen(true)}
-            className="flex items-center gap-1 rounded-md py-1.5 px-1 text-xs sm:text-sm text-fg-subtle hover:text-brand-fg focus:outline-none focus:ring-2 focus:ring-brand-accent"
-          >
+          {showJumpToNow && (
+            <button
+              onClick={scrollNowLineIntoView}
+              title="Jump to the current time"
+              className={ITEM_CLASS}
+            >
+              <ClockIcon className="h-4 w-4 stroke-2" />
+              Now
+            </button>
+          )}
+          <button onClick={() => setDetailsOpen(true)} className={ITEM_CLASS}>
             <InformationCircleIcon className="h-4 w-4 stroke-2" />
             Event details
           </button>
           {hasPhases(event) && (
-            <Link
-              href={`/${event.slug}/proposals`}
-              className="flex items-center gap-1 rounded-md py-1.5 px-1 text-xs sm:text-sm text-fg-subtle hover:text-brand-fg focus:outline-none focus:ring-2 focus:ring-brand-accent"
-            >
+            <Link href={`/${event.slug}/proposals`} className={ITEM_CLASS}>
               <ClipboardDocumentListIcon className="h-4 w-4 stroke-2" />
               Proposals
             </Link>
           )}
           {event.meetingsEnabled && (
-            <Link
-              href={`/${event.slug}/meetings`}
-              className="flex items-center gap-1 rounded-md py-1.5 px-1 text-xs sm:text-sm text-fg-subtle hover:text-brand-fg focus:outline-none focus:ring-2 focus:ring-brand-accent"
-            >
+            <Link href={`/${event.slug}/meetings`} className={ITEM_CLASS}>
               <UserGroupIcon className="h-4 w-4 stroke-2" />
               1-on-1s
             </Link>

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -48,6 +48,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Notifications in the app**: a bell in the header counts what is waiting, and clicking one takes you to it. Everything that emails you appears here too, even where email is not set up.",
       "**1-on-1 meetings**: organizers switch them on for an event and suggest where to meet; attendees mark when they are free, ask someone from their profile, and accept or decline.",
       "**Picking your name works however many events a site runs**: past about seven, the header's event links crowded the name chip off the row and left no way to say who you are.",
+      '**The schedule shows where you are in the day**: a red line marks the current time while the event is running, and a "Now" button jumps to it.',
     ],
   },
   {

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -112,6 +112,9 @@ Proposing and voting close.
 A room name with an **ⓘ** next to it has more to say — tap it (or hover it)
 to read what the room offers: projector, whiteboard, the kind of seating.
 
+While the event is running, a red line across the grid marks the current time,
+and **"Now"** at the top of the schedule jumps straight to it.
+
 ### Put a proposal on the schedule
 
 Two ways, whichever you find first:

--- a/docs/public/organizers/how-it-works.md
+++ b/docs/public/organizers/how-it-works.md
@@ -94,9 +94,10 @@ and is far from settled.
 
 ## Kiosk mode
 
-Append `?kiosk=1` to a schedule URL for an unattended screen at the venue: a
-red line marks the current time, the view auto-scrolls back to it after a
-minute of no interaction, the screen is kept awake, and the page refreshes
+Append `?kiosk=1` to a schedule URL for an unattended screen at the venue: the
+view auto-scrolls back to the red current-time line after a minute of no
+interaction (everyone else gets that line too, plus a "Now" button to jump to
+it, but no auto-scrolling), the screen is kept awake, and the page refreshes
 periodically. It stays fully interactive, and sticks as visitors browse the
 site until you turn it off with `?kiosk=0`. Add `&loc=Main+Hall` (repeatable)
 to show only specific locations — handy for a kiosk in one room, or a

--- a/tests/e2e/helpers/dev-clock.ts
+++ b/tests/e2e/helpers/dev-clock.ts
@@ -1,0 +1,67 @@
+import { Page } from "@playwright/test";
+import { expect } from "./fixtures";
+import { DateTime } from "luxon";
+import { login } from "./auth";
+
+// Time travel for specs that need the app to think an event is running right
+// now. It goes through the dev fake clock (?dev=1), not the browser clock:
+// anything derived from "now" follows the app's simulated instant
+// (server-seeded, cookie-driven — see docs/dev/adr/0004-dev-fake-clock.md),
+// which a browser-only clock jump wouldn't move.
+
+/**
+ * 16:00 Berlin on Conference Gamma's first event day (seeded at today+14,
+ * running 09:00–18:00 Europe/Berlin — see scripts/seed/seed-database.ts). Late
+ * enough in the day that the now line starts outside the visible schedule
+ * area, so only scrolling brings it into view.
+ *
+ * Specs using this must run in Europe/Berlin (`test.use({ timezoneId })`), so
+ * the toolbar's datetime-local picker maps 16:00 to 16:00 Berlin.
+ */
+export const duringGammaDayOne = DateTime.now()
+  .setZone("Europe/Berlin")
+  .plus({ days: 14 })
+  .set({ hour: 16, minute: 0, second: 0, millisecond: 0 });
+
+/**
+ * Move the dev fake clock to `target` via the toolbar's datetime picker, then
+ * wait for the simulated date to show so the override cookie is committed.
+ */
+export async function setDevClock(page: Page, target: DateTime) {
+  await expect(page.getByText("Dev clock")).toBeVisible();
+  // Applying the clock triggers a router.refresh(); a navigation started while
+  // its RSC payload is still streaming aborts it, which logs an RSC-payload
+  // error the console guard fails on. So wait for that very response, body and
+  // all — "networkidle" is both later and less certain, since Next goes on
+  // prefetching in the background. A refresh asks for RSC without the
+  // prefetch header, which is what tells it apart from those prefetches.
+  const [refreshed] = await Promise.all([
+    page.waitForResponse(
+      (res) =>
+        res.ok() &&
+        res.request().headers()["rsc"] === "1" &&
+        !res.request().headers()["next-router-prefetch"]
+    ),
+    page
+      .getByLabel("Pick date and time")
+      .fill(target.toFormat("yyyy-MM-dd'T'HH:mm")),
+  ]);
+  // The toolbar prints the simulated instant in UTC; the calendar date is the
+  // same as Berlin's for a 16:00 target, so match on the date alone.
+  await expect(page.getByText(target.toFormat("yyyy-MM-dd"))).toBeVisible();
+  await refreshed.finished();
+}
+
+/**
+ * Land the browser on `path` with the fake clock already inside Gamma's first
+ * day, so anything keyed to "now" is present from first paint. The clock is
+ * set first, then a reload replays the page with the override cookie in place
+ * — a full navigation, so it can't abort an in-flight refresh.
+ */
+export async function openGammaScheduleDuringEvent(page: Page, path: string) {
+  await login(page);
+  const url = path.includes("?") ? `${path}&dev=1` : `${path}?dev=1`;
+  await page.goto(url);
+  await setDevClock(page, duringGammaDayOne);
+  await page.reload();
+}

--- a/tests/e2e/kiosk.spec.ts
+++ b/tests/e2e/kiosk.spec.ts
@@ -1,79 +1,18 @@
-import { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
-import { login } from "./helpers/auth";
-import { DateTime } from "luxon";
+import { openGammaScheduleDuringEvent } from "./helpers/dev-clock";
 
-// Kiosk mode (?kiosk=1) is meant for large screens at the venue: it draws a
-// red line across the grid at the current time and keeps it scrolled into
-// view. The seeded events lie ~2 weeks in the future (see
-// scripts/seed/seed-database.ts: Conference Gamma's first day is today+14, running
-// 09:00–18:00 Europe/Berlin), so the tests time-travel to a moment within that
-// first day to make the now line appear.
-//
-// Time travel goes through the dev fake clock (?dev=1), not the browser clock:
-// the now line follows the app's simulated "now" (server-seeded, cookie-driven
-// — see docs/dev/adr/0004-dev-fake-clock.md), which a browser-only clock jump wouldn't move.
-// Berlin timezone so the toolbar's datetime-local picker maps 16:00 to 16:00
-// Berlin, squarely inside Gamma's first day.
+// Kiosk mode (?kiosk=1) is meant for large screens at the venue. The now line
+// itself is drawn on every schedule (see now-line.spec.ts); what kiosk mode
+// adds is keeping it scrolled into view, and sticking across navigation. The
+// tests time-travel into Conference Gamma's first day so there is a line to
+// scroll to — see helpers/dev-clock.ts, which the timezone below comes from.
+// That the line follows the fake clock rather than the real one is asserted by
+// the same time travel: without it no line exists to be in the viewport.
 test.use({ timezoneId: "Europe/Berlin" });
 
-// 16:00 Berlin on Gamma's first event day — late enough in the day that the
-// line starts outside the visible schedule area and only auto-scrolling
-// brings it into view.
-const duringGammaDayOne = DateTime.now()
-  .setZone("Europe/Berlin")
-  .plus({ days: 14 })
-  .set({ hour: 16, minute: 0, second: 0, millisecond: 0 });
-
-// Move the dev fake clock to `target` via the toolbar's datetime picker, then
-// wait for the simulated date to show so the override cookie is committed.
-async function setDevClock(page: Page, target: DateTime) {
-  await expect(page.getByText("Dev clock")).toBeVisible();
-  // Applying the clock triggers a router.refresh(); a navigation started while
-  // its RSC payload is still streaming aborts it, which logs an RSC-payload
-  // error the console guard fails on. So wait for that very response, body and
-  // all — "networkidle" is both later and less certain, since Next goes on
-  // prefetching in the background. A refresh asks for RSC without the
-  // prefetch header, which is what tells it apart from those prefetches.
-  const [refreshed] = await Promise.all([
-    page.waitForResponse(
-      (res) =>
-        res.ok() &&
-        res.request().headers()["rsc"] === "1" &&
-        !res.request().headers()["next-router-prefetch"]
-    ),
-    page
-      .getByLabel("Pick date and time")
-      .fill(target.toFormat("yyyy-MM-dd'T'HH:mm")),
-  ]);
-  // The toolbar prints the simulated instant in UTC; the calendar date is the
-  // same as Berlin's for a 16:00 target, so match on the date alone.
-  await expect(page.getByText(target.toFormat("yyyy-MM-dd"))).toBeVisible();
-  await refreshed.finished();
-}
-
-// Land the browser on `path` with the fake clock already inside Gamma's first
-// day, so the now line is present from first paint (and thus auto-scrolled).
-// The clock is set first, then a reload replays the page with the override
-// cookie in place — a full navigation, so it can't abort an in-flight refresh.
-async function openGammaScheduleDuringEvent(page: Page, path: string) {
-  await login(page);
-  const url = path.includes("?") ? `${path}&dev=1` : `${path}?dev=1`;
-  await page.goto(url);
-  await setDevClock(page, duringGammaDayOne);
-  await page.reload();
-}
-
-test("kiosk mode draws a now line and auto-scrolls it into view", async ({
-  page,
-}) => {
+test("kiosk mode auto-scrolls the now line into view", async ({ page }) => {
   await openGammaScheduleDuringEvent(page, "/Conference-Gamma?kiosk=1");
   await expect(page.getByTestId("now-line")).toBeInViewport();
-});
-
-test("without the kiosk parameter there is no now line", async ({ page }) => {
-  await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
-  await expect(page.getByTestId("now-line")).toHaveCount(0);
 });
 
 test("kiosk mode persists via cookie after navigating without the parameter", async ({
@@ -83,7 +22,8 @@ test("kiosk mode persists via cookie after navigating without the parameter", as
   await expect(page.getByTestId("now-line")).toBeInViewport();
 
   // Neither link below carries ?kiosk=1, yet the display should stay in
-  // kiosk mode: the cookie set on the first load should carry it through.
+  // kiosk mode: the cookie set on the first load should carry it through, so
+  // the now line is scrolled to again rather than left where the day starts.
   await page.getByRole("link", { name: "Proposals" }).click();
   await page.getByRole("link", { name: "View Schedule" }).click();
   await expect(page).toHaveURL(/\/Conference-Gamma$/);
@@ -104,39 +44,19 @@ test("?kiosk=0 clears the cookie and leaves kiosk mode", async ({ page }) => {
     page.getByRole("heading", { name: /Session Proposals/ })
   ).toBeVisible();
   await page.goto("/Conference-Gamma?kiosk=0");
-  await expect(page.getByTestId("now-line")).toHaveCount(0);
 
-  // ?kiosk=0 hides the now line from the server render alone, so the check
-  // above says nothing about hydration — while the cookie is cleared by an
-  // effect that only runs once the page has hydrated. Navigating away before
-  // that lands leaves the cookie behind, and the next page is in kiosk mode
-  // again.
+  // The cookie is cleared by an effect that only runs once the page has
+  // hydrated. Navigating away before that lands would leave the cookie behind,
+  // and the next page would be in kiosk mode again.
   await expect
     .poll(async () =>
       (await page.context().cookies()).map((cookie) => cookie.name)
     )
     .not.toContain("kiosk");
 
-  // A plain reload (no parameter at all) should stay out of kiosk mode too:
-  // the poll above proves the cookie is gone, this that nothing else puts the
-  // display back into kiosk mode once it is.
+  // Nothing outside kiosk mode brings the now line into view, so the schedule
+  // now opens at the start of the day and stays there.
   await page.goto("/Conference-Gamma");
-  await expect(page.getByTestId("now-line")).toHaveCount(0);
-});
-
-// The now line must follow the fake clock, not the real one: without this the
-// display stays blank when organizers time-travel to preview the kiosk.
-test("kiosk now line follows the dev fake clock, not the real clock", async ({
-  page,
-}) => {
-  await login(page);
-  await page.goto("/Conference-Gamma?kiosk=1&dev=1");
-
-  // The real clock is not inside any event day, so nothing is drawn yet.
-  await expect(page.getByText("Dev clock")).toBeVisible();
-  await expect(page.getByTestId("now-line")).toHaveCount(0);
-
-  // Time-travelling into the event makes the now line appear.
-  await setDevClock(page, duringGammaDayOne);
-  await expect(page.getByTestId("now-line")).toBeVisible();
+  await page.waitForTimeout(2000);
+  await expect(page.getByTestId("now-line")).not.toBeInViewport();
 });

--- a/tests/e2e/now-line.spec.ts
+++ b/tests/e2e/now-line.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import {
+  duringGammaDayOne,
+  openGammaScheduleDuringEvent,
+  setDevClock,
+} from "./helpers/dev-clock";
+
+// The red now line and the toolbar's "Now" button are for everyone, not just
+// kiosk displays (see kiosk.spec.ts for what kiosk mode adds on top). The
+// seeded events lie ~2 weeks out, so these time-travel with the dev fake clock
+// to a moment inside Conference Gamma's first day.
+test.use({ timezoneId: "Europe/Berlin" });
+
+test("the Now button jumps to the current time on the schedule", async ({
+  page,
+}) => {
+  await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
+
+  const nowLine = page.getByTestId("now-line");
+  await expect(nowLine).toBeAttached();
+
+  // 16:00 is far enough down Gamma's day that the line starts off screen, and
+  // nothing outside kiosk mode should scroll it into view on its own. Waiting
+  // out kiosk's initial auto-scroll delay is what makes that meaningful — a
+  // plain negative assertion would pass before any scroll could have happened.
+  // It doubles as the hydration wait the click below needs.
+  await page.waitForTimeout(2000);
+  await expect(nowLine).not.toBeInViewport();
+
+  await page.getByRole("button", { name: "Now" }).click();
+  await expect(nowLine).toBeInViewport();
+});
+
+test("no now line or Now button outside the event's days", async ({ page }) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+
+  // The real clock is two weeks before the event starts.
+  await expect(page.getByRole("button", { name: "Grid" })).toBeVisible();
+  await expect(page.getByTestId("now-line")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Now" })).toHaveCount(0);
+});
+
+test("the Now button is only offered by the grid view", async ({ page }) => {
+  await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
+  await expect(page.getByRole("button", { name: "Now" })).toBeVisible();
+
+  // The text view has no grid to jump around in. The toggle is server-rendered,
+  // so a click can land before React has attached its handler and be dropped —
+  // retry until the view has actually switched (docs/dev/testing.md § E2E
+  // conventions). Re-clicking the active view is a no-op, so this is safe.
+  await expect(async () => {
+    await page.getByRole("button", { name: "Text" }).click();
+    await expect(page.getByPlaceholder("Search sessions")).toBeVisible({
+      timeout: 2000,
+    });
+  }).toPass();
+  await expect(page.getByRole("button", { name: "Now" })).toHaveCount(0);
+});
+
+test("the now line follows the dev fake clock, not the real clock", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma?dev=1");
+
+  await expect(page.getByText("Dev clock")).toBeVisible();
+  await expect(page.getByTestId("now-line")).toHaveCount(0);
+
+  await setDevClock(page, duringGammaDayOne);
+  await expect(page.getByTestId("now-line")).toBeAttached();
+});

--- a/utils/slots.ts
+++ b/utils/slots.ts
@@ -35,7 +35,7 @@ export function getNumSlots(
 }
 
 /**
- * Vertical pixel offset of `now` from the top of a day's slot grid (kiosk
+ * Vertical pixel offset of `now` from the top of a day's slot grid (the
  * now-line), or null when `now` falls outside [start, end).
  */
 export function getNowOffsetPx(


### PR DESCRIPTION
The red now line was gated behind kiosk mode, but knowing where the day
is up to is as useful on a phone as on a wall display. Draw it always,
and add a "Now" button that jumps to it — both only while the event is
actually running.

fixes schellingboard/schellingboard#863

<!-- jip:pushed-commit=5c3d1c7e6b1b22d401923f0624b4947d91acc13c -->