### PR TITLE
chore: ignore Claude Code worktrees in eslint and prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ tsconfig.json
 # padding would be undone on every regeneration
 docs/dev/attendance-model/attendance-2025.md
 docs/dev/attendance-model/.venv/
+
+# Claude Code worktrees carry their own .next/ and source trees
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The first room photo on the schedule grid is loaded eagerly. It sits above the fold and is usually
   the page's largest element, so Next warned that the Largest Contentful Paint image was being
   lazy-loaded
+- **Lint and format skip Claude Code worktrees**: `make precommit` walked into
+  `.claude/worktrees/`, where each worktree's `.next/` produced hundreds of ESLint parsing errors
+  and Prettier rewrote another checkout's build artifacts. Both now ignore that directory
 
 ## [3.5.0] - 2026-08-30
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,7 @@ export default tseslint.config(
       "test-results/**",
       ".flake-hunt/**",
       ".e2e-docker/**",
+      ".claude/worktrees/**",
     ],
   },
   ...dropTsPlugin(coreWebVitals),


### PR DESCRIPTION
`make precommit` runs ESLint and Prettier over the whole repository. Claude Code creates git worktrees under `.claude/worktrees/<name>/`, each carrying its own `.next/`, `coverage/` and source tree. ESLint then reported hundreds of parsing errors for files under the foreign `.next/` ("was not found by the project service"), and Prettier rewrote build artifacts belonging to another checkout.

This adds `.claude/worktrees/**` to the ESLint `ignores` array and `.claude/worktrees/` to `.prettierignore`. Only the worktrees subdirectory is ignored rather than all of `.claude/`, so the checked-in `.claude/CLAUDE.md` keeps being formatted.

Verified with a throwaway detached worktree containing unformatted files in its `.next/server/` and `app/`: `make lint` exits 0 with no errors from the worktree, and `make format` leaves both files untouched.

Recorded under `### Internal` in the changelog.

Written by Claude Code, which also made the changes described here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
