### PR TITLE
fix: stop a deep-linked comment stranding the profile modal

### DIFF
--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -350,10 +350,17 @@ export function ProfileModal({
         {/* touch-pan-y hands vertical scrolling to the browser and keeps
             horizontal panning — the back gesture included — for this handler.
             It has to be CSS: React listens for touchmove passively, so
-            preventDefault is not available to decide it per gesture. */}
+            preventDefault is not available to decide it per gesture.
+
+            overflow-clip, not -hidden: a hidden box is still a scroll
+            container, and Firefox credits this one with the profile's whole
+            height even though the panel inside it does the scrolling. Landing
+            on a comment then parked it partway down, where no scrollbar or
+            wheel could bring it back and the profile stayed cut off under its
+            own header (#930). A clipped box cannot hold an offset at all. */}
         <div
           ref={viewport}
-          className="flex min-h-0 flex-1 flex-col overflow-hidden touch-pan-y"
+          className="flex min-h-0 flex-1 flex-col overflow-clip touch-pan-y"
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           onTouchEnd={endTouch}


### PR DESCRIPTION
The box that clips the swiping panels was overflow-hidden, which is still a
scroll container, and Firefox credits it with the whole profile's height even
though the panel inside it does the scrolling. Scrolling to the linked comment
parked it partway down, where no wheel or scrollbar could bring it back, and
the profile stayed cut off under its own header. A clipped box cannot hold an
offset at all.

The earlier attempt only stopped the browser making that jump on its own; the
section's own scroll to the comment did the same thing.

fixes schellingboard/schellingboard#930

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=cf7d641bb185f2a47f5aa85c648b6ec6e36727f4 -->