### PR TITLE
fix: stop the 1-on-1 E2E journey racing the modal's refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   under a time offset was stamped with real time, so it came out older than the comments on it — and
   "a session must start in the future" was judged against real time too, letting a time-travelled
   organizer book into their own past, or refusing a slot the interface still offered
+- The 1-on-1 E2E journey no longer flakes on the console guard. Answering a request refreshes the
+  page behind the modal, and the hard navigation the test made next aborted that fetch — Next then
+  logged the abort and forced a full load back to the meetings page, cancelling the navigation. The
+  test leaves by the header's Attendees link instead, which supersedes the refresh rather than
+  aborting it. The `waitForLoadState("networkidle")` it relied on was never waiting:
+  Playwright arms that event once per document load, and the modal is reached by an in-app
+  navigation
 - The first room photo on the schedule grid is loaded eagerly. It sits above the fold and is usually
   the page's largest element, so Next warned that the Largest Contentful Paint image was being
   lazy-loaded

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -127,6 +127,25 @@ async function actAs(page: Page, name: RegExp) {
   await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
 }
 
+/**
+ * Answering a request refreshes the page behind the modal, and a hard
+ * navigation started while that refresh's RSC fetch is in flight aborts it --
+ * whereupon Next logs the abort and forces a full load back to the page it was
+ * refreshing, which cancels the navigation that aborted it. Leaving by the
+ * header link is a React transition instead, so it supersedes the pending
+ * refresh rather than aborting it; rsvp.spec.ts leaves a saved admin form the
+ * same way.
+ *
+ * waitForLoadState("networkidle") is no substitute: Playwright arms
+ * networkidle once per document *load*, and the modal is reached by an in-app
+ * navigation -- so the event had long since fired, and the wait returned in a
+ * millisecond without waiting for anything at all.
+ */
+async function leaveForAttendees(page: Page) {
+  await page.getByRole("link", { name: "Attendees" }).click();
+  await expect(page.getByRole("heading", { name: "Attendees" })).toBeVisible();
+}
+
 // Each directory row is a link whose name is the whole row, so the name alone
 // never matches exactly.
 async function openProfile(page: Page, name: string) {
@@ -261,13 +280,8 @@ test.describe("1-on-1 meetings", () => {
     await meeting.getByRole("button", { name: "Close" }).click();
     await expect(meeting).toBeHidden();
 
-    // Answering refreshes the page behind the modal. Navigating away while
-    // that RSC fetch is in flight aborts it, and Next reports the abort on the
-    // console -- which the console guard fails the test for.
-    await page.waitForLoadState("networkidle");
-
     // And the asker hears back, then asks for the day's other slot.
-    await page.goto("/guests");
+    await leaveForAttendees(page);
     await actAs(page, new RegExp(asker));
     await page.getByRole("link", { name: /^Notifications/ }).click();
     await expect(
@@ -302,9 +316,10 @@ test.describe("1-on-1 meetings", () => {
     await expect(meeting).toBeVisible();
     await meeting.getByRole("button", { name: "Decline" }).click();
     await expect(meeting.getByText("You declined this.")).toBeVisible();
-    await page.waitForLoadState("networkidle");
+    await meeting.getByRole("button", { name: "Close" }).click();
+    await expect(meeting).toBeHidden();
 
-    await page.goto("/guests");
+    await leaveForAttendees(page);
     await actAs(page, new RegExp(asker));
     await page.getByRole("link", { name: /^Notifications/ }).click();
     await expect(


### PR DESCRIPTION
Fixes the flake in `meetings-request.spec.ts` — "books a slot the other attendee declared,
and gets an answer" — which failed at roughly one run in three locally, landing on `main`
with schellingboard/schellingboard-legacy#942. Part of schellingboard/schellingboard#392.

## What was happening

One race, producing both halves of the failure.

Answering a request calls `router.refresh()` behind the modal, and Next fetches the RSC
payload for the page it is on — `/<event>/meetings`, still carrying `?viewMeeting=`. The
test's next step was `page.goto("/guests")`, which tears the document down and aborts that
fetch. Next answers an aborted refresh by logging it and **forcing a full load back to the
page it was refreshing**, and that load supersedes the goto. Hence:

```
Error: page.goto: NS_BINDING_ABORTED
Error: browser console.error during test
+ "Failed to fetch RSC payload for .../meetings?viewMeeting=... Falling back to browser navigation."
```

**The guard already standing there was doing nothing.** Playwright arms `networkidle` once
per document *load*, and the modal is reached by an in-app navigation — the notification's
server-action redirect — so the event had fired long before. Instrumented, the wait
returned in **1–2 ms** with the refresh plainly in flight. (The three `networkidle` waits in
`view-session.spec.ts` each follow a real `goto`/`reload` and were measured genuinely
waiting ~580 ms, so those are fine and untouched.)

## The fix

The one `rsvp.spec.ts` already documents for the same failure: leave by a link rather than a
hard navigation. A client-side navigation is a React transition, so it supersedes the
pending refresh instead of aborting it — and clicking the header's **Attendees** link is
closer to how a reader would leave anyway. The decline path now closes the modal first, as
the accept path already did.

**No `ALLOWED_CONSOLE_PATTERNS` entry.** The abort is avoidable, so nothing new is excused
on the console.

## Measured

Same machine, repeating the test under load:

| | before | after |
|---|---|---|
| `--workers=8 --repeat-each=8` | 7 failed, 4 with the RSC-abort signature | 0 RSC aborts |
| `--workers=5 --repeat-each=10` | 7 failed, 2 RSC aborts | 1 failed, 0 RSC aborts |
| `--workers=3 --repeat-each=12` | 2 in 6 failed (reported rate) | 12 passed |

The RSC abort is gone from every run rather than merely rarer. The failures left at
workers=5–8 are plain 90 s timeouts that hit unrelated specs (kiosk, admin, notifications)
identically — the host sat at load 27–49 throughout.

Holding the refresh's response back with `page.route` for three seconds fails the old test
every time and passes the new one, which is how the mechanism was confirmed rather than
guessed.

`make precommit` green on this base: 156 E2E passed, 0 failed, 0 flaky.

## Note for the other open PRs

Both touch this spec and neither is based on current `main`:

- **#943 `meetings-grid`** branched before the schellingboard/schellingboard-legacy#942 squash, still carries all three
  `waitForLoadState("networkidle")` calls and adds ~94 lines here. Rebasing onto `main`
  will conflict in this file; keep this version.
- **#958 `pwa-push`** predates the answer flow entirely, so a rebase just picks the fixed
  file up.

## Aside, not fixed here

The same chain applies to a real user on Firefox: accept a 1-on-1, then click a link within
the few milliseconds the refresh is in flight, and Next cancels the navigation and drops
them back on the meetings page. The window is tiny, and the refresh is pointless on the
meetings page anyway — nothing there renders meetings. Happy to open an issue if it seems
worth it.

Written by Claude Code, which diagnosed the flake and made the change described here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
