### PR TITLE
feat: book a 1-on-1 from the schedule grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   asked. Both sides are told the outcome; an unanswered request lapses at its slot
 - **Your 1-on-1s on the schedule** (#392): the grid's first column is yours alone — agreed
   1-on-1s and open requests. Hover for what it clashes with, tap to open or cancel it
+- **Arrange a 1-on-1 straight from the schedule** (#945): tapping an empty slot in your 1-on-1
+  column lists who is free then, profile links included, and the request form follows on
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
   beside Session host and Has profile. It covers every event on the site, not only this one
 

--- a/app/(site)/[eventSlug]/book-meeting.tsx
+++ b/app/(site)/[eventSlug]/book-meeting.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import { requestMeetingAction } from "@/app/actions/meetings";
+import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
+import { Avatar } from "@/app/(site)/guests/avatar";
+import { MeetingRequestFields } from "@/app/components/meeting-request-fields";
+import { Modal } from "@/app/components/modal";
+import Link from "next/link";
+import { clashLines } from "@/utils/meeting-clash-text";
+import type {
+  MeetingCandidate,
+  MeetingCandidates,
+} from "@/utils/meeting-candidates";
+
+/**
+ * Booking a 1-on-1 from the schedule: the slot is known, the person is not.
+ * Two steps in one modal — who is free then, and the usual request form —
+ * which is the profile picker's flow with its two questions the other way
+ * round (issue #945).
+ */
+export function BookMeeting({
+  eventId,
+  slotStart,
+  onClose,
+  onBooked,
+}: {
+  eventId: string;
+  slotStart: string;
+  onClose: () => void;
+  /** Told once a request is sent, so the column can show it straight away. */
+  onBooked: () => void;
+}) {
+  const [found, setFound] = useState<MeetingCandidates | null | "none">(null);
+  const [chosen, setChosen] = useState<MeetingCandidate | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(
+      `/api/meetings/candidates?event=${eventId}&slot=${encodeURIComponent(
+        slotStart
+      )}`,
+      { signal: controller.signal }
+    )
+      .then<MeetingCandidates | "none">((res) =>
+        res.ok ? (res.json() as Promise<MeetingCandidates>) : "none"
+      )
+      .then(setFound)
+      // Closing the modal aborts the request; there is nobody left to tell.
+      .catch(() => undefined);
+    return () => controller.abort();
+  }, [eventId, slotStart]);
+
+  return (
+    <Modal
+      open
+      setOpen={onClose}
+      zIndex="z-[60]"
+      portal
+      maxWidth="sm:max-w-2xl"
+      hideClose
+    >
+      {found === null ? (
+        <p className="text-fg-muted">Loading…</p>
+      ) : found === "none" ? (
+        <div className="flex flex-col gap-4">
+          <p className="text-fg">That slot is no longer open for 1-on-1s.</p>
+          <button type="button" onClick={onClose} className={PRIMARY_BUTTON}>
+            Close
+          </button>
+        </div>
+      ) : chosen ? (
+        <RequestStep
+          eventId={eventId}
+          slotStart={slotStart}
+          found={found}
+          candidate={chosen}
+          onBack={() => setChosen(null)}
+          onBooked={onBooked}
+          onClose={onClose}
+        />
+      ) : (
+        <CandidateStep found={found} onPick={setChosen} onClose={onClose} />
+      )}
+    </Modal>
+  );
+}
+
+function CandidateStep({
+  found,
+  onPick,
+  onClose,
+}: {
+  found: MeetingCandidates;
+  onPick: (candidate: MeetingCandidate) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-xl font-bold text-fg">
+          Who&apos;s free at {found.slotLabel.split(" – ")[0]}?
+        </h2>
+        <span className="block text-sm text-fg-muted">
+          {found.dayLabel}, {found.slotLabel} · {found.eventName}
+        </span>
+      </div>
+
+      {/* Your own commitment, once for the whole screen: it is the same slot
+          whoever you end up asking. */}
+      {found.yourClashes.length > 0 && (
+        <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
+          {clashLines(found.yourClashes)} during this slot — book it anyway?
+        </p>
+      )}
+
+      {found.candidates.length === 0 ? (
+        <p className="text-fg-muted">Nobody has marked this slot free.</p>
+      ) : (
+        // Scrolls rather than growing the modal past the viewport: a popular
+        // slot at a big event is a long list, and Ask has to stay reachable.
+        <ul className="flex flex-col gap-1 max-h-72 overflow-y-auto">
+          {found.candidates.map((candidate) => (
+            <li
+              key={candidate.id}
+              className="flex items-center gap-4 rounded-md p-2 bg-surface-sunken"
+            >
+              <Avatar
+                name={candidate.name}
+                size="sm"
+                image={candidate.avatarUrl ?? undefined}
+              />
+              <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+                <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  {/* Deciding whether to ask someone means reading who they
+                      are, and that must not cost the slot being booked -- so
+                      the profile opens in its own tab, leaving this list
+                      exactly where it was. */}
+                  <Link
+                    href={`/guests/${candidate.id}`}
+                    target="_blank"
+                    rel="noopener"
+                    prefetch={false}
+                    className="font-medium text-brand-fg hover:text-brand-fg-hover"
+                  >
+                    {candidate.name}
+                  </Link>
+                  {candidate.isHost && (
+                    <span className="w-fit rounded-full bg-brand-tint-hover text-brand-fg text-xs font-semibold px-3 py-1">
+                      Session host
+                    </span>
+                  )}
+                </span>
+                {(candidate.pronouns || candidate.basedIn) && (
+                  <span className="text-sm text-fg-subtle line-clamp-1">
+                    {[candidate.pronouns, candidate.basedIn]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </span>
+                )}
+                {/* What they have on is theirs to tell; all this says is that
+                    the hour is taken (see toMeetingClashes). */}
+                {candidate.busy && (
+                  <span className="text-xs text-warning-fg">
+                    Already booked at this time
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => onPick(candidate)}
+                className={SECONDARY_BUTTON}
+              >
+                Ask
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="text-xs text-fg-subtle">
+        Only people who marked this slot free are listed. Nobody is told you
+        looked.
+      </p>
+
+      <button
+        type="button"
+        onClick={onClose}
+        className={`${SECONDARY_BUTTON} self-start`}
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+function RequestStep({
+  eventId,
+  slotStart,
+  found,
+  candidate,
+  onBack,
+  onBooked,
+  onClose,
+}: {
+  eventId: string;
+  slotStart: string;
+  found: MeetingCandidates;
+  candidate: MeetingCandidate;
+  onBack: () => void;
+  onBooked: () => void;
+  onClose: () => void;
+}) {
+  const [meetingPoint, setMeetingPoint] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+  const [isSending, startSend] = useTransition();
+
+  const handleSend = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    startSend(async () => {
+      try {
+        const result = await requestMeetingAction({
+          eventId,
+          recipientId: candidate.id,
+          slotStart,
+          meetingPoint,
+          message,
+        });
+        if (!result.ok) {
+          setError(result.error);
+          return;
+        }
+        setSent(true);
+        onBooked();
+      } catch {
+        setError("Request failed");
+      }
+    });
+  };
+
+  if (sent) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-fg">
+          Asked {candidate.name} for {found.slotLabel} on {found.dayLabel}.
+          You&apos;ll hear when they answer.
+        </p>
+        <button type="button" onClick={onClose} className={PRIMARY_BUTTON}>
+          Done
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSend} className="flex flex-col gap-4">
+      <h2 className="text-xl font-bold text-fg">
+        1-on-1 with {candidate.name}
+        <span className="block text-sm font-normal text-fg-muted">
+          {found.dayLabel}, {found.slotLabel}
+        </span>
+      </h2>
+
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
+
+      {/* A clash is raised, never enforced: the pair decide for themselves. */}
+      {(candidate.busy || found.yourClashes.length > 0) && (
+        <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
+          {[
+            ...(found.yourClashes.length > 0
+              ? [clashLines(found.yourClashes)]
+              : []),
+            ...(candidate.busy ? [`${candidate.name} is already booked`] : []),
+          ].join("; ")}{" "}
+          during this slot — book it anyway?
+        </p>
+      )}
+
+      <MeetingRequestFields
+        meetingPoints={found.meetingPoints}
+        meetingPoint={meetingPoint}
+        onMeetingPoint={setMeetingPoint}
+        message={message}
+        onMessage={setMessage}
+        isSending={isSending}
+        onCancel={onBack}
+        cancelLabel="Someone else"
+      />
+    </form>
+  );
+}

--- a/app/(site)/[eventSlug]/book-meeting.tsx
+++ b/app/(site)/[eventSlug]/book-meeting.tsx
@@ -15,6 +15,14 @@ import type {
 } from "@/utils/meeting-candidates";
 
 /**
+ * Why there is no list to show: the slot is not one this viewer can book at
+ * all, or the answer never arrived. Two different sentences — telling someone
+ * the slot is gone when the network dropped sends them looking for a booking
+ * nobody made.
+ */
+type Failure = "gone" | "failed";
+
+/**
  * Booking a 1-on-1 from the schedule: the slot is known, the person is not.
  * Two steps in one modal — who is free then, and the usual request form —
  * which is the profile picker's flow with its two questions the other way
@@ -32,7 +40,7 @@ export function BookMeeting({
   /** Told once a request is sent, so the column can show it straight away. */
   onBooked: () => void;
 }) {
-  const [found, setFound] = useState<MeetingCandidates | null | "none">(null);
+  const [found, setFound] = useState<MeetingCandidates | null | Failure>(null);
   const [chosen, setChosen] = useState<MeetingCandidate | null>(null);
 
   useEffect(() => {
@@ -43,12 +51,20 @@ export function BookMeeting({
       )}`,
       { signal: controller.signal }
     )
-      .then<MeetingCandidates | "none">((res) =>
-        res.ok ? (res.json() as Promise<MeetingCandidates>) : "none"
+      .then<MeetingCandidates | Failure>((res) =>
+        res.ok
+          ? (res.json() as Promise<MeetingCandidates>)
+          : res.status === 404
+            ? "gone"
+            : "failed"
       )
       .then(setFound)
-      // Closing the modal aborts the request; there is nobody left to tell.
-      .catch(() => undefined);
+      .catch(() => {
+        // Closing the modal aborts the request; there is nobody left to tell.
+        // Anything else has to end the spinner, or the modal never leaves it —
+        // and with no close button of its own, that traps the reader.
+        if (!controller.signal.aborted) setFound("failed");
+      });
     return () => controller.abort();
   }, [eventId, slotStart]);
 
@@ -63,9 +79,13 @@ export function BookMeeting({
     >
       {found === null ? (
         <p className="text-fg-muted">Loading…</p>
-      ) : found === "none" ? (
+      ) : found === "gone" || found === "failed" ? (
         <div className="flex flex-col gap-4">
-          <p className="text-fg">That slot is no longer open for 1-on-1s.</p>
+          <p className="text-fg">
+            {found === "gone"
+              ? "That slot is no longer open for 1-on-1s."
+              : "Couldn't load who is free then. Try the slot again."}
+          </p>
           <button type="button" onClick={onClose} className={PRIMARY_BUTTON}>
             Close
           </button>

--- a/app/(site)/[eventSlug]/book-meeting.tsx
+++ b/app/(site)/[eventSlug]/book-meeting.tsx
@@ -187,9 +187,12 @@ function CandidateStep({
                   </span>
                 )}
               </div>
+              {/* Named, not just "Ask": a rotor or a voice command sees a
+                  column of buttons, and a long list makes them all alike. */}
               <button
                 type="button"
                 onClick={() => onPick(candidate)}
+                aria-label={`Ask ${candidate.name}`}
                 className={SECONDARY_BUTTON}
               >
                 Ask

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -37,7 +37,7 @@ export function DayGrid(props: {
   const { event, now } = useContext(EventContext);
   const timezone = event?.timezone ?? "UTC";
   const searchParams = useSearchParams();
-  const { meetings, availability } = useMyMeetings();
+  const { meetings, availability, reload } = useMyMeetings();
   // Outside the ?loc= filter below: the column is not a location, so narrowing
   // the schedule to one room must not drop it (issue #392, section 2.6). All
   // days or none, so the rooms line up from one day to the next -- and until
@@ -203,6 +203,7 @@ export function DayGrid(props: {
           availability={myAvailability}
           day={day}
           nowOffsetPx={nowOffsetPx}
+          onBooked={reload}
         />
       )}
       {includedLocations.map((location) => (

--- a/app/(site)/[eventSlug]/meetings-col.tsx
+++ b/app/(site)/[eventSlug]/meetings-col.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import clsx from "clsx";
+import { PlusIcon } from "@heroicons/react/24/outline";
+import { DateTime } from "luxon";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 
 import type { MeetingView } from "@/utils/meeting-views";
 import { meetingColumnRows } from "@/utils/meeting-column";
@@ -13,6 +15,7 @@ import { clashLines } from "@/utils/meeting-clash-text";
 import { statusLine } from "@/utils/meeting-rules";
 import { viewMeetingLinkFromOwner } from "./modal-nav";
 import { NowLine } from "./now-line";
+import { BookMeeting } from "./book-meeting";
 import { Tooltip } from "./tooltip";
 
 /** The word of status a block has room for; the tooltip says the rest. */
@@ -21,6 +24,11 @@ function blockStatus(meeting: MeetingView): string {
   return meeting.role === "recipient"
     ? "needs your reply"
     : "waiting for reply";
+}
+
+/** "14:30", in the event's zone, for a control's accessible name. */
+function slotLabel(start: string, timezone: string): string {
+  return DateTime.fromISO(start).setZone(timezone).toFormat("HH:mm");
 }
 
 // What the block has no room for, on hover -- the pattern a session block
@@ -61,6 +69,7 @@ export function MeetingsCol({
   availability,
   day,
   nowOffsetPx,
+  onBooked,
 }: {
   meetings: MeetingView[];
   /** Slot starts the viewer declared themselves open for, as ISO strings. */
@@ -68,12 +77,18 @@ export function MeetingsCol({
   day: DayWithSessions;
   /** Now-line offset from the top of the slot grid; null hides it. */
   nowOffsetPx?: number | null;
+  /** Re-read the viewer's meetings, once a request has been sent. */
+  onBooked: () => void;
 }) {
   const slotIncrement = useSlotIncrement();
   const searchParams = useSearchParams();
   // Never missing here: the column only renders once meetings for this event
   // have been fetched, which takes the event being in context.
-  const eventSlug = useContext(EventContext).event?.slug ?? "";
+  const { event, now } = useContext(EventContext);
+  const eventSlug = event?.slug ?? "";
+  const timezone = event?.timezone ?? "UTC";
+  // Which slot the booking modal is open on, if any.
+  const [booking, setBooking] = useState<string | null>(null);
   const rows = meetingColumnRows({
     meetings,
     availability,
@@ -84,25 +99,37 @@ export function MeetingsCol({
   return (
     <div className="relative px-0.5">
       <div className="grid h-full auto-rows-[44px]">
-        {rows.map(({ row, span, kind, meetings: atRow }) =>
+        {rows.map(({ row, span, start, kind, meetings: atRow }) =>
           kind !== "meetings" ? (
-            <div
+            <button
               key={row}
+              type="button"
               style={{ gridRowStart: row }}
+              // A slot in the past is not bookable, and the request action
+              // refuses one anyway.
+              disabled={new Date(start) <= now}
+              onClick={() => setBooking(start)}
               // Hatched where the viewer cleared the slot: that governs who
               // may book *them*, so it is worth seeing on their own schedule —
-              // but it is no bar to arranging a 1-on-1 there themselves, and
-              // the cell stays as bookable as any other (#945).
-              title={
+              // but it is no bar to arranging a 1-on-1 there themselves, so it
+              // is as bookable as any other.
+              aria-label={
                 kind === "unavailable"
-                  ? "You are not offering this slot — you can still arrange a 1-on-1 in it"
-                  : undefined
+                  ? `Arrange a 1-on-1 at ${slotLabel(start, timezone)} — you are not offering this slot to others`
+                  : `Arrange a 1-on-1 at ${slotLabel(start, timezone)}`
               }
               className={clsx(
-                `row-span-${span} my-0.5 rounded`,
+                `row-span-${span} my-0.5 rounded border border-dashed border-line-subtle text-fg-faint`,
+                "flex items-center justify-center transition-colors",
+                "enabled:hover:border-brand-accent enabled:hover:bg-brand-tint enabled:hover:text-brand-fg",
+                "disabled:border-transparent disabled:cursor-default",
                 kind === "unavailable" && "meetings-col-blocked"
               )}
-            />
+            >
+              {new Date(start) > now && (
+                <PlusIcon className="h-4 w-4" aria-hidden="true" />
+              )}
+            </button>
           ) : (
             <div
               key={row}
@@ -164,6 +191,14 @@ export function MeetingsCol({
           )
         )}
       </div>
+      {booking && event && (
+        <BookMeeting
+          eventId={event.id}
+          slotStart={booking}
+          onClose={() => setBooking(null)}
+          onBooked={onBooked}
+        />
+      )}
       {/* Each column draws its own segment of the now line; see DayGrid. */}
       {nowOffsetPx != null && <NowLine offsetPx={nowOffsetPx} />}
     </div>

--- a/app/(site)/[eventSlug]/meetings-col.tsx
+++ b/app/(site)/[eventSlug]/meetings-col.tsx
@@ -31,6 +31,61 @@ function slotLabel(start: string, timezone: string): string {
   return DateTime.fromISO(start).setZone(timezone).toFormat("HH:mm");
 }
 
+/**
+ * An empty slot of the column, which is a control while it is still ahead.
+ * Once it is past it is plain scenery: the request action refuses a slot that
+ * has begun, so offering it -- even greyed out -- would promise nothing.
+ */
+function SlotCell({
+  row,
+  span,
+  start,
+  blocked,
+  bookable,
+  timezone,
+  onBook,
+}: {
+  row: number;
+  span: number;
+  start: string;
+  /** The viewer cleared this slot, so nobody may book *them* into it. */
+  blocked: boolean;
+  bookable: boolean;
+  timezone: string;
+  onBook: () => void;
+}) {
+  const shape = clsx(
+    `row-span-${span} my-0.5 flex items-center justify-center rounded`,
+    blocked && "meetings-col-blocked"
+  );
+
+  if (!bookable) {
+    return <div style={{ gridRowStart: row }} className={shape} />;
+  }
+
+  return (
+    <button
+      type="button"
+      style={{ gridRowStart: row }}
+      onClick={onBook}
+      // Hatching says who may book *them*; it is no bar to arranging a 1-on-1
+      // there themselves, so the slot stays as bookable as any other.
+      aria-label={
+        blocked
+          ? `Arrange a 1-on-1 at ${slotLabel(start, timezone)} — you are not offering this slot to others`
+          : `Arrange a 1-on-1 at ${slotLabel(start, timezone)}`
+      }
+      className={clsx(
+        shape,
+        "border border-dashed border-line-subtle text-fg-faint transition-colors",
+        "hover:border-brand-accent hover:bg-brand-tint hover:text-brand-fg"
+      )}
+    >
+      <PlusIcon className="h-4 w-4" aria-hidden="true" />
+    </button>
+  );
+}
+
 // What the block has no room for, on hover -- the pattern a session block
 // already follows. A tap still opens the modal, where all of it is anyway.
 function MeetingSummary({ meeting }: { meeting: MeetingView }) {
@@ -101,35 +156,16 @@ export function MeetingsCol({
       <div className="grid h-full auto-rows-[44px]">
         {rows.map(({ row, span, start, kind, meetings: atRow }) =>
           kind !== "meetings" ? (
-            <button
+            <SlotCell
               key={row}
-              type="button"
-              style={{ gridRowStart: row }}
-              // A slot in the past is not bookable, and the request action
-              // refuses one anyway.
-              disabled={new Date(start) <= now}
-              onClick={() => setBooking(start)}
-              // Hatched where the viewer cleared the slot: that governs who
-              // may book *them*, so it is worth seeing on their own schedule —
-              // but it is no bar to arranging a 1-on-1 there themselves, so it
-              // is as bookable as any other.
-              aria-label={
-                kind === "unavailable"
-                  ? `Arrange a 1-on-1 at ${slotLabel(start, timezone)} — you are not offering this slot to others`
-                  : `Arrange a 1-on-1 at ${slotLabel(start, timezone)}`
-              }
-              className={clsx(
-                `row-span-${span} my-0.5 rounded border border-dashed border-line-subtle text-fg-faint`,
-                "flex items-center justify-center transition-colors",
-                "enabled:hover:border-brand-accent enabled:hover:bg-brand-tint enabled:hover:text-brand-fg",
-                "disabled:border-transparent disabled:cursor-default",
-                kind === "unavailable" && "meetings-col-blocked"
-              )}
-            >
-              {new Date(start) > now && (
-                <PlusIcon className="h-4 w-4" aria-hidden="true" />
-              )}
-            </button>
+              row={row}
+              span={span}
+              start={start}
+              blocked={kind === "unavailable"}
+              bookable={new Date(start) > now}
+              timezone={timezone}
+              onBook={() => setBooking(start)}
+            />
           ) : (
             <div
               key={row}

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useTransition } from "react";
 import { Modal } from "@/app/components/modal";
-import { Input } from "@/app/input";
 import { requestMeetingAction } from "@/app/actions/meetings";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
+import { MeetingRequestFields } from "@/app/components/meeting-request-fields";
 import { clashLines } from "@/utils/meeting-clash-text";
 import type { MeetingDayOption, MeetingOption } from "@/utils/meeting-options";
 
@@ -86,10 +86,6 @@ function RequestForm({
     d.slots.some((s) => s.start === slotStart)
   );
   const slot = day?.slots.find((s) => s.start === slotStart);
-  const selectedPoint = option.meetingPoints.find(
-    (p) => p.name === meetingPoint
-  );
-
   const handleSend = (e: React.FormEvent) => {
     e.preventDefault();
     if (!slotStart) return;
@@ -151,76 +147,16 @@ function RequestForm({
         </p>
       )}
 
-      <div className="flex flex-col gap-1">
-        <span className="text-sm font-medium text-fg-muted">Where to meet</span>
-        {option.meetingPoints.length > 0 && (
-          <ul className="flex flex-wrap gap-2 mb-1">
-            {option.meetingPoints.map((point) => (
-              <li key={point.id}>
-                <button
-                  type="button"
-                  aria-pressed={meetingPoint === point.name}
-                  onClick={() => setMeetingPoint(point.name)}
-                  className={`rounded-full border px-3 py-1 text-sm transition-colors ${
-                    meetingPoint === point.name
-                      ? "border-brand bg-brand text-on-brand"
-                      : "border-line bg-surface-raised text-fg hover:bg-surface-hover"
-                  }`}
-                >
-                  {point.name}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-        {/* Below the chips rather than a title= on them: a tooltip is the one
-            place a touch user never reaches, and the description is how the
-            organizer says where the place actually is. */}
-        {selectedPoint?.description && (
-          <p className="mb-1 text-xs text-fg-muted">
-            {selectedPoint.description}
-          </p>
-        )}
-        <Input
-          value={meetingPoint}
-          onChange={(e) => setMeetingPoint(e.target.value)}
-          aria-label="Where to meet"
-          placeholder="or type somewhere else"
-          className="w-full h-10"
-        />
-        <p className="text-xs text-fg-subtle">
-          Nothing is reserved — this is just where to find each other.
-        </p>
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor="meeting-message"
-          className="text-sm font-medium text-fg-muted"
-        >
-          Add a line of context (optional)
-        </label>
-        <Input
-          id="meeting-message"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Would love to talk about…"
-          className="w-full h-10"
-        />
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="submit"
-          disabled={isSending || !slotStart || !meetingPoint.trim()}
-          className={PRIMARY_BUTTON}
-        >
-          {isSending ? "Sending..." : "Send request"}
-        </button>
-        <button type="button" onClick={onDone} className={SECONDARY_BUTTON}>
-          Cancel
-        </button>
-      </div>
+      <MeetingRequestFields
+        meetingPoints={option.meetingPoints}
+        meetingPoint={meetingPoint}
+        onMeetingPoint={setMeetingPoint}
+        message={message}
+        onMessage={setMessage}
+        isSending={isSending}
+        submitDisabled={!slotStart}
+        onCancel={onDone}
+      />
     </form>
   );
 }

--- a/app/api/meetings/candidates/route.ts
+++ b/app/api/meetings/candidates/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
+import { requestNow } from "@/utils/dev-clock";
+import { meetingCandidatesFor } from "@/utils/meeting-candidates";
+
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response and
+// go on offering someone who has since been booked.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
+// Who the caller could ask for a 1-on-1 in one slot. Fetched when the "+" is
+// clicked rather than shipped with the schedule: it is per-viewer, and a whole
+// event's worth of slots is far more than any one of them needs.
+export async function GET(request: NextRequest) {
+  const eventId = request.nextUrl.searchParams.get("event");
+  const slotStart = request.nextUrl.searchParams.get("slot");
+  if (!eventId || !slotStart) {
+    return NextResponse.json(
+      { error: "event and slot parameters are required" },
+      { ...NO_STORE, status: 400 }
+    );
+  }
+
+  // Who is free when is as private as an RSVP, so this answers for the caller
+  // alone: there is no id parameter to ask on anyone else's behalf.
+  const guestId = await verifiedCurrentUser(request.cookies);
+  if (!guestId) {
+    return NextResponse.json(
+      { error: "Select your name to arrange a 1-on-1" },
+      { ...NO_STORE, status: 403 }
+    );
+  }
+
+  try {
+    const found = await meetingCandidatesFor(
+      guestId,
+      eventId,
+      slotStart,
+      requestNow(request)
+    );
+    if (!found) {
+      return NextResponse.json(
+        { error: "That slot is not open for 1-on-1s" },
+        { ...NO_STORE, status: 404 }
+      );
+    }
+    return NextResponse.json(found, NO_STORE);
+  } catch (error) {
+    console.error("Error fetching 1-on-1 candidates:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch the people you could meet" },
+      { ...NO_STORE, status: 500 }
+    );
+  }
+}

--- a/app/components/meeting-request-fields.tsx
+++ b/app/components/meeting-request-fields.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Input } from "@/app/input";
+import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
+import type { MeetingPoint } from "@/db/repositories/interfaces";
+
+/**
+ * The half of a 1-on-1 request that is the same whichever way round it was
+ * reached: where to meet and a line of context. A profile knows the person and
+ * asks for a slot; the schedule's column knows the slot and asks for a person;
+ * from here on the two are one form.
+ */
+export function MeetingRequestFields({
+  meetingPoints,
+  meetingPoint,
+  onMeetingPoint,
+  message,
+  onMessage,
+  isSending,
+  submitDisabled,
+  onCancel,
+  cancelLabel = "Cancel",
+}: {
+  meetingPoints: Pick<MeetingPoint, "id" | "name" | "description">[];
+  meetingPoint: string;
+  onMeetingPoint: (value: string) => void;
+  message: string;
+  onMessage: (value: string) => void;
+  isSending: boolean;
+  /** Extra reasons the caller cannot send yet, beyond an unnamed place. */
+  submitDisabled?: boolean;
+  onCancel: () => void;
+  cancelLabel?: string;
+}) {
+  const selectedPoint = meetingPoints.find((p) => p.name === meetingPoint);
+
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-fg-muted">Where to meet</span>
+        {meetingPoints.length > 0 && (
+          <ul className="flex flex-wrap gap-2 mb-1">
+            {meetingPoints.map((point) => (
+              <li key={point.id}>
+                <button
+                  type="button"
+                  aria-pressed={meetingPoint === point.name}
+                  onClick={() => onMeetingPoint(point.name)}
+                  className={`rounded-full border px-3 py-1 text-sm transition-colors ${
+                    meetingPoint === point.name
+                      ? "border-brand bg-brand text-on-brand"
+                      : "border-line bg-surface-raised text-fg hover:bg-surface-hover"
+                  }`}
+                >
+                  {point.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {/* Below the chips rather than a title= on them: a tooltip is the one
+            place a touch user never reaches, and the description is how the
+            organizer says where the place actually is. */}
+        {selectedPoint?.description && (
+          <p className="mb-1 text-xs text-fg-muted">
+            {selectedPoint.description}
+          </p>
+        )}
+        <Input
+          value={meetingPoint}
+          onChange={(e) => onMeetingPoint(e.target.value)}
+          aria-label="Where to meet"
+          placeholder="or type somewhere else"
+          className="w-full h-10"
+        />
+        <p className="text-xs text-fg-subtle">
+          Nothing is reserved — this is just where to find each other.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="meeting-message"
+          className="text-sm font-medium text-fg-muted"
+        >
+          Add a line of context (optional)
+        </label>
+        <Input
+          id="meeting-message"
+          value={message}
+          onChange={(e) => onMessage(e.target.value)}
+          placeholder="Would love to talk about…"
+          className="w-full h-10"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={isSending || submitDisabled || !meetingPoint.trim()}
+          className={PRIMARY_BUTTON}
+        >
+          {isSending ? "Sending..." : "Send request"}
+        </button>
+        <button type="button" onClick={onCancel} className={SECONDARY_BUTTON}>
+          {cancelLabel}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -48,7 +48,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Install it on your phone**: add the site to your home screen and it opens like an app, in its own window with no address bar.",
       "**Notifications on your phone**: Settings can send the notifications you already get to your phone or laptop, so they arrive while the site is closed. iPhones need it on the home screen first.",
       "**Notifications in the app**: a bell counts what is waiting, and clicking one takes you to it. Tick the ones you are done with to mark them read or delete them. No email set-up needed.",
-      "**1-on-1s**: organizers switch them on and suggest where to meet; attendees mark when they are free, ask someone from their profile, accept or decline, and see them on the schedule.",
+      "**1-on-1s**: organizers switch them on and suggest where to meet; attendees mark when they are free, ask from a profile or an empty slot on the schedule, and accept or decline.",
       '**The schedule shows where you are in the day**: a red line marks the current time while the event is running, and a "Now" button jumps to it.',
     ],
   },

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -816,6 +816,12 @@ export interface MeetingAvailabilityRepository {
    * switched meetings on.
    */
   listByGuestAndEvent(guestId: string, eventId: string): Promise<Date[]>;
+  /**
+   * The guests who declared one particular slot, for "who could I meet at
+   * 14:30?". Ids only: the caller already holds the attendee list it needs to
+   * turn them into people.
+   */
+  listGuestsBySlot(eventId: string, slotStart: Date): Promise<string[]>;
   /** Replaces a guest's whole declared set for the event. */
   replaceForGuest(
     guestId: string,
@@ -864,6 +870,12 @@ export interface MeetingsRepository {
    * accepted, clash detection only accepted.
    */
   listByGuestAndEvent(guestId: string, eventId: string): Promise<Meeting[]>;
+  /**
+   * Every meeting still standing in one slot, whoever it is between: what the
+   * grid's booking flow needs to know who is already taken. Matched on the
+   * slot's start, as availability rows are.
+   */
+  listLiveBySlot(eventId: string, slotStart: Date): Promise<Meeting[]>;
   /**
    * Requests this guest has sent and not heard back on, for the organizer's
    * cap. `now` bounds it: a pending request whose slot has passed is expired

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -300,6 +300,16 @@ export type Attendee = Guest & {
   openToMeetings: boolean;
 };
 
+/**
+ * A guest as one event's list of people shows them. `Attendee`'s
+ * `openToMeetings` is absent on purpose: it is a site-wide question, and
+ * probing it for everyone is most of what makes that query expensive.
+ */
+export type EventAttendee = Pick<
+  Guest,
+  "id" | "name" | "avatarUrl" | "pronouns" | "basedIn"
+> & { isHost: boolean };
+
 export interface GuestsRepository {
   /**
    * Every guest with basic public fields only — no extended profile
@@ -330,6 +340,12 @@ export interface GuestsRepository {
    * slots have all passed leaves nothing anyone can book.
    */
   listAttendees(now: Date): Promise<Attendee[]>;
+  /**
+   * One event's guests, with the profile fields a list of people shows. Scoped
+   * where `listAttendees` is global: a screen describing one event's slot has
+   * no use for a scan of every guest on the site.
+   */
+  listAttendeesByEvent(eventId: string): Promise<EventAttendee[]>;
   /**
    * Assigned events for many guests in one query, ordered by event name.
    * Every requested id is present in the result; guests without assignments

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_EMAIL_SETTINGS,
   type CompleteGuest,
   type EmailSettings,
+  type EventAttendee,
   type EventGuestPage,
   type Guest,
   type GuestAuthCredentials,
@@ -251,6 +252,34 @@ export class SqliteGuestsRepository implements GuestsRepository {
             }) as Attendee
         )
     );
+  }
+
+  async listAttendeesByEvent(eventId: string): Promise<EventAttendee[]> {
+    return this.db
+      .select({
+        id: schema.guests.id,
+        name: schema.guests.name,
+        avatarUrl: schema.guests.avatarUrl,
+        pronouns: schema.guests.pronouns,
+        basedIn: schema.guests.basedIn,
+        // Site-wide, as in listAttendees: hosting is a fact about the person,
+        // not about the event whose list they are being read into.
+        isHost: exists(
+          this.db
+            .select({ one: sql`1` })
+            .from(schema.sessionHosts)
+            .where(eq(schema.sessionHosts.guestId, schema.guests.id))
+        ),
+      })
+      .from(schema.guests)
+      .innerJoin(
+        schema.eventGuests,
+        eq(schema.eventGuests.guestId, schema.guests.id)
+      )
+      .where(eq(schema.eventGuests.eventId, eventId))
+      .orderBy(sql`${schema.guests.name} collate nocase`, schema.guests.id)
+      .all()
+      .map((row) => ({ ...row, isHost: Boolean(row.isHost) }));
   }
 
   async listEventsByGuests(

--- a/db/repositories/sqlite/meeting-availability.ts
+++ b/db/repositories/sqlite/meeting-availability.ts
@@ -23,6 +23,20 @@ export class SqliteMeetingAvailabilityRepository implements MeetingAvailabilityR
       .map((row) => new Date(row.slotStart));
   }
 
+  async listGuestsBySlot(eventId: string, slotStart: Date): Promise<string[]> {
+    return this.db
+      .select({ guestId: schema.meetingAvailability.guestId })
+      .from(schema.meetingAvailability)
+      .where(
+        and(
+          eq(schema.meetingAvailability.eventId, eventId),
+          eq(schema.meetingAvailability.slotStart, slotStart.toISOString())
+        )
+      )
+      .all()
+      .map((row) => row.guestId);
+  }
+
   // Delete-then-insert in one transaction: the form submits the whole set, so
   // a partial write would leave a guest bookable at slots they just cleared.
   async replaceForGuest(

--- a/db/repositories/sqlite/meetings.ts
+++ b/db/repositories/sqlite/meetings.ts
@@ -79,6 +79,21 @@ export class SqliteMeetingsRepository implements MeetingsRepository {
       .map(rowToMeeting);
   }
 
+  async listLiveBySlot(eventId: string, slotStart: Date): Promise<Meeting[]> {
+    return this.db
+      .select()
+      .from(schema.meetings)
+      .where(
+        and(
+          eq(schema.meetings.eventId, eventId),
+          eq(schema.meetings.slotStart, slotStart.toISOString()),
+          inArray(schema.meetings.status, ["pending", "accepted"])
+        )
+      )
+      .all()
+      .map(rowToMeeting);
+  }
+
   async countOpenByRequester(
     requesterId: string,
     eventId: string,

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -269,6 +269,18 @@ context, and anything it clashes with. Tap one to open it. That is also where
 either of you can **cancel** a 1-on-1 you had agreed, or take back a request
 nobody has answered yet, up until the slot begins; the other person is told.
 
+### Arrange one from the schedule
+
+Tapping an **empty slot** in that column asks the question a profile cannot:
+not "when could I meet this person" but **"who could I meet at 14:30"**. It
+lists everyone who marked that slot open — with their name as a link, so you
+can read their profile in another tab without losing your place — and says
+where anyone is already booked, without saying what they are doing. Pick one
+and the usual request form follows: where to meet, and a line of context.
+
+The slots you did not offer to others are bookable this way too. What you
+declare says who may book _you_; whom you ask, and when, is yours to decide.
+
 ## Attendee directory & profiles
 
 The directory lists everyone at the event on a single page — photo and the

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -207,6 +207,74 @@ test.describe("1-on-1 meetings", () => {
     }
   });
 
+  // The other direction: the grid knows the time and asks who is free, which
+  // is the only route that does not start from knowing who you want to meet.
+  test("books a 1-on-1 from the schedule's own column", async ({ page }) => {
+    test.slow();
+
+    const unique = uniqueSuffix();
+    const eventName = `E2E Grid ${unique}`;
+    const asker = `Grid Asker ${unique}`;
+    const askee = `Grid Askee ${unique}`;
+    await createGuests(page, [asker, askee]);
+    leftBehind.guests.push(asker, askee);
+    await meetingsEvent(page, eventName, [asker, askee]);
+    leftBehind.events.push(eventName);
+    const slug = eventName.replace(/ /g, "-");
+
+    // The askee is bookable; the asker is not, which is what makes the column
+    // theirs to book *from* rather than to be booked in.
+    await loginAndGoto(page, "/settings");
+    await actAs(page, new RegExp(askee));
+    await page.goto("/settings");
+    const availability = await openAvailability(page, eventName);
+    await availability.getByLabel(/open to 1-on-1s/).check();
+    await availability
+      .getByRole("button", { name: "Save availability" })
+      .click();
+    await expect(availability.getByText("Saved!")).toBeVisible();
+
+    // The asker declares nothing, so their column is all "not offering" -- and
+    // every slot of it is still a slot they can arrange a 1-on-1 in.
+    await actAs(page, new RegExp(asker));
+    await page.goto("/settings");
+    const mine = await openAvailability(page, eventName);
+    await mine.getByLabel(/open to 1-on-1s/).check();
+    await mine.getByRole("button", { name: "Save availability" }).click();
+    await expect(mine.getByText("Saved!")).toBeVisible();
+
+    await page.goto(`/${slug}`);
+    await page
+      .getByRole("button", { name: /^Arrange a 1-on-1 at 09:00/ })
+      .first()
+      .click();
+
+    const picker = page.getByRole("dialog");
+    await expect(
+      picker.getByRole("heading", { name: /Who's free at 09:00/ })
+    ).toBeVisible();
+    await picker
+      .getByRole("listitem")
+      .filter({ hasText: askee })
+      .getByRole("button", { name: "Ask" })
+      .click();
+
+    await expect(
+      picker.getByRole("heading", { name: new RegExp(`1-on-1 with ${askee}`) })
+    ).toBeVisible();
+    await picker.getByRole("button", { name: "Coffee bar" }).click();
+    await picker.getByRole("button", { name: "Send request" }).click();
+    await expect(picker.getByText(new RegExp(`Asked ${askee}`))).toBeVisible();
+    await picker.getByRole("button", { name: "Done" }).click();
+
+    // The column behind it is already showing the request, without a reload.
+    await expect(
+      page.getByRole("link", { name: new RegExp(askee) })
+    ).toBeVisible();
+    await expect(page.getByText("waiting for reply").first()).toBeVisible();
+    await page.waitForLoadState("networkidle");
+  });
+
   test("books a slot the other attendee declared, and gets an answer", async ({
     page,
   }) => {

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -234,18 +234,22 @@ test.describe("1-on-1 meetings", () => {
       .click();
     await expect(availability.getByText("Saved!")).toBeVisible();
 
-    // The asker declares nothing, so their column is all "not offering" -- and
-    // every slot of it is still a slot they can arrange a 1-on-1 in.
+    // The asker keeps 09:00 off their own offer, so it is hatched on their
+    // column: what you declare says who may book *you*, not whom you may ask.
     await actAs(page, new RegExp(asker));
     await page.goto("/settings");
     const mine = await openAvailability(page, eventName);
     await mine.getByLabel(/open to 1-on-1s/).check();
+    await mine.getByRole("listitem").first().getByRole("checkbox").uncheck();
     await mine.getByRole("button", { name: "Save availability" }).click();
     await expect(mine.getByText("Saved!")).toBeVisible();
 
     await page.goto(`/${slug}`);
+    // The slot they did not offer, which is still a slot they can book in.
     await page
-      .getByRole("button", { name: /^Arrange a 1-on-1 at 09:00/ })
+      .getByRole("button", {
+        name: /^Arrange a 1-on-1 at 09:00 — you are not offering/,
+      })
       .first()
       .click();
 
@@ -253,11 +257,7 @@ test.describe("1-on-1 meetings", () => {
     await expect(
       picker.getByRole("heading", { name: /Who's free at 09:00/ })
     ).toBeVisible();
-    await picker
-      .getByRole("listitem")
-      .filter({ hasText: askee })
-      .getByRole("button", { name: "Ask" })
-      .click();
+    await picker.getByRole("button", { name: `Ask ${askee}` }).click();
 
     await expect(
       picker.getByRole("heading", { name: new RegExp(`1-on-1 with ${askee}`) })

--- a/tests/integration/meeting-candidates-route.test.ts
+++ b/tests/integration/meeting-candidates-route.test.ts
@@ -1,0 +1,114 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createDay } from "../helpers/factories";
+import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import { GET as candidates } from "@/app/api/meetings/candidates/route";
+import type { MeetingCandidates } from "@/utils/meeting-candidates";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+// Well ahead of any real clock: the endpoint refuses a slot that has begun.
+const DAY_START = new Date("2099-10-01T09:00:00.000Z");
+const DAY_END = new Date("2099-10-01T12:00:00.000Z");
+const SLOT = "2099-10-01T10:00:00.000Z";
+
+async function request(
+  params: { event?: string; slot?: string },
+  guestId?: string
+) {
+  const url = new URL("http://test/api/meetings/candidates");
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) url.searchParams.set(key, value);
+  }
+  const req = new NextRequest(url);
+  if (guestId) {
+    req.cookies.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guestId));
+  }
+  return req;
+}
+
+async function scenario() {
+  const repos = getRepositories();
+  const event = await createEvent({ phase: "scheduling" });
+  await repos.events.update(event.id, { meetingsEnabled: true });
+  await createDay(event.id, { start: DAY_START, end: DAY_END });
+  const viewer = await createGuest({ name: "Ada", eventId: event.id });
+  const grace = await createGuest({ name: "Grace", eventId: event.id });
+  await repos.meetingAvailability.replaceForGuest(grace.id, event.id, [
+    new Date(SLOT),
+  ]);
+  return { event, viewer, grace };
+}
+
+describe("the 1-on-1 candidates endpoint", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("serves the people the caller could ask, for that one slot", async () => {
+    const { event, viewer } = await scenario();
+
+    const res = await candidates(
+      await request({ event: event.id, slot: SLOT }, viewer.id)
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MeetingCandidates;
+    expect(body.candidates.map((c) => c.name)).toEqual(["Grace"]);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  // Who is free when is as private as an RSVP: there is no id parameter to ask
+  // on someone else's behalf, and no answer at all without a name selected.
+  it("refuses a caller who has not selected a name", async () => {
+    const { event } = await scenario();
+
+    const res = await candidates(
+      await request({ event: event.id, slot: SLOT })
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("needs both an event and a slot", async () => {
+    const { event, viewer } = await scenario();
+
+    expect(
+      (await candidates(await request({ event: event.id }, viewer.id))).status
+    ).toBe(400);
+    expect(
+      (await candidates(await request({ slot: SLOT }, viewer.id))).status
+    ).toBe(400);
+  });
+
+  // Nothing to offer is not an empty list: the slot is not one this caller can
+  // book at all, and the column says so differently.
+  it("answers not-found for a slot the event does not offer", async () => {
+    const { event, viewer } = await scenario();
+
+    const res = await candidates(
+      await request(
+        { event: event.id, slot: "2099-10-01T10:07:00.000Z" },
+        viewer.id
+      )
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/integration/meeting-candidates.test.ts
+++ b/tests/integration/meeting-candidates.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createDay,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { meetingCandidatesFor } from "@/utils/meeting-candidates";
+import type { Event, Guest } from "@/db/repositories/interfaces";
+
+const DAY_START = new Date("2026-10-01T09:00:00.000Z");
+const DAY_END = new Date("2026-10-01T12:00:00.000Z");
+const SLOT = "2026-10-01T10:00:00.000Z";
+const SLOT_END = new Date("2026-10-01T10:30:00.000Z");
+const BEFORE = new Date("2026-09-30T09:00:00.000Z");
+const AFTER = new Date("2026-10-02T09:00:00.000Z");
+
+async function bookable(event: Event, name: string, slots = [SLOT]) {
+  const guest = await createGuest({ name, eventId: event.id });
+  await getRepositories().meetingAvailability.replaceForGuest(
+    guest.id,
+    event.id,
+    slots.map((s) => new Date(s))
+  );
+  return guest;
+}
+
+async function scenario() {
+  const repos = getRepositories();
+  const event = await createEvent({ phase: "scheduling" });
+  await repos.events.update(event.id, { meetingsEnabled: true });
+  await createDay(event.id, { start: DAY_START, end: DAY_END });
+  const viewer = await createGuest({ name: "Ada", eventId: event.id });
+  const grace = await bookable(event, "Grace");
+  return { event, viewer, grace };
+}
+
+const names = async (event: Event, viewer: Guest, now = BEFORE) =>
+  (await meetingCandidatesFor(viewer.id, event.id, SLOT, now))?.candidates.map(
+    (c) => c.name
+  );
+
+describe("meetingCandidatesFor", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => resetTestDb());
+
+  it("lists everyone who declared that slot, by name", async () => {
+    const { event, viewer } = await scenario();
+    await bookable(event, "Yuki");
+
+    expect(await names(event, viewer)).toEqual(["Grace", "Yuki"]);
+  });
+
+  // The viewer's own availability says who may book them; it has nothing to do
+  // with whom they may ask, and booking yourself is not a thing.
+  it("leaves the viewer out, however they declared", async () => {
+    const { event, viewer } = await scenario();
+    await getRepositories().meetingAvailability.replaceForGuest(
+      viewer.id,
+      event.id,
+      [new Date(SLOT)]
+    );
+
+    expect(await names(event, viewer)).toEqual(["Grace"]);
+  });
+
+  it("leaves out a slot the person never declared", async () => {
+    const { event, viewer } = await scenario();
+    await bookable(event, "Yuki", ["2026-10-01T11:00:00.000Z"]);
+
+    expect(await names(event, viewer)).toEqual(["Grace"]);
+  });
+
+  // Their availability row outlives being taken off the guest list, and the
+  // request action refuses a non-attendee anyway.
+  it("leaves out someone no longer on the guest list", async () => {
+    const { event, viewer, grace } = await scenario();
+    await getRepositories().guests.removeFromEvent(event.id, [grace.id]);
+
+    expect(await names(event, viewer)).toEqual([]);
+  });
+
+  it("leaves out someone the viewer already has a live 1-on-1 with then", async () => {
+    const { event, viewer, grace } = await scenario();
+    const meeting = await getRepositories().meetings.create({
+      eventId: event.id,
+      requesterId: viewer.id,
+      recipientId: grace.id,
+      slotStart: new Date(SLOT),
+      slotEnd: SLOT_END,
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: BEFORE,
+    });
+
+    expect(await names(event, viewer)).toEqual([]);
+
+    // Declined, there is nothing left to answer twice: they can be asked again.
+    await getRepositories().meetings.updateStatus(
+      meeting.id,
+      "declined",
+      BEFORE,
+      ["pending"]
+    );
+    expect(await names(event, viewer)).toEqual(["Grace"]);
+  });
+
+  it("marks a candidate busy without saying what they are doing", async () => {
+    const { event, viewer, grace } = await scenario();
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [grace.id],
+      startTime: new Date(SLOT),
+      endTime: SLOT_END,
+    });
+
+    const found = await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE);
+
+    expect(found?.candidates[0]).toMatchObject({ name: "Grace", busy: true });
+    expect(JSON.stringify(found)).not.toContain("Their talk");
+  });
+
+  // Agreed only, the rule clash detection already follows: a request they have
+  // not answered is not yet a commitment, and treating it as one would let a
+  // stranger's unanswered request make someone look unavailable.
+  it("counts an agreed 1-on-1 of theirs as busy, a pending one not", async () => {
+    const { event, viewer, grace } = await scenario();
+    const third = await createGuest({ name: "Yuki", eventId: event.id });
+    const asked = async () =>
+      getRepositories().meetings.create({
+        eventId: event.id,
+        requesterId: third.id,
+        recipientId: grace.id,
+        slotStart: new Date(SLOT),
+        slotEnd: SLOT_END,
+        meetingPoint: "Coffee bar",
+        message: "",
+        createdAt: BEFORE,
+      });
+    const busyOf = async (name: string) =>
+      (
+        await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE)
+      )?.candidates.find((c) => c.name === name)?.busy;
+
+    const pending = await asked();
+    expect(await busyOf("Grace")).toBe(false);
+
+    await getRepositories().meetings.updateStatus(
+      pending.id,
+      "accepted",
+      BEFORE,
+      ["pending"]
+    );
+    expect(await busyOf("Grace")).toBe(true);
+  });
+
+  // The reader's own commitment is named to them: knowing which of their own
+  // sessions they would be missing is the point of the warning.
+  it("names the viewer's own clash, once for the whole slot", async () => {
+    const { event, viewer } = await scenario();
+    await createSession(event.id, {
+      title: "My own talk",
+      hostIds: [viewer.id],
+      startTime: new Date(SLOT),
+      endTime: SLOT_END,
+    });
+
+    const found = await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE);
+
+    expect(found?.yourClashes).toEqual([
+      {
+        guestName: "Ada",
+        kind: "hosting",
+        title: "My own talk",
+        isViewer: true,
+      },
+    ]);
+  });
+
+  it("carries what the request form needs beside the people", async () => {
+    const { event, viewer } = await scenario();
+    await getRepositories().meetingPoints.create({
+      eventId: event.id,
+      name: "Coffee bar",
+      description: "By reception",
+      sortIndex: 0,
+    });
+
+    const found = await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE);
+
+    expect(found?.eventName).toBe(event.name);
+    expect(found?.meetingPoints.map((p) => p.name)).toEqual(["Coffee bar"]);
+    expect(found?.slotLabel).toBe("10:00 – 10:30");
+  });
+
+  it("refuses a slot that has already begun", async () => {
+    const { event, viewer } = await scenario();
+
+    expect(
+      await meetingCandidatesFor(viewer.id, event.id, SLOT, AFTER)
+    ).toBeNull();
+  });
+
+  it("refuses an instant the event does not offer as a slot", async () => {
+    const { event, viewer } = await scenario();
+
+    expect(
+      await meetingCandidatesFor(
+        viewer.id,
+        event.id,
+        "2026-10-01T10:07:00.000Z",
+        BEFORE
+      )
+    ).toBeNull();
+  });
+
+  it("refuses once the organizer switches meetings off", async () => {
+    const { event, viewer } = await scenario();
+    await getRepositories().events.update(event.id, {
+      meetingsEnabled: false,
+    });
+
+    expect(
+      await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE)
+    ).toBeNull();
+  });
+
+  it("refuses a viewer who is not attending", async () => {
+    const { event, viewer } = await scenario();
+    await getRepositories().guests.removeFromEvent(event.id, [viewer.id]);
+
+    expect(
+      await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE)
+    ).toBeNull();
+  });
+});

--- a/tests/integration/meeting-candidates.test.ts
+++ b/tests/integration/meeting-candidates.test.ts
@@ -181,6 +181,48 @@ describe("meetingCandidatesFor", () => {
     ]);
   });
 
+  // The list is people, not ids: what it says about them has to survive
+  // whichever query supplies it.
+  it("describes each candidate the way a list of people shows them", async () => {
+    const { event, viewer, grace } = await scenario();
+    await getRepositories().guests.updateProfile(
+      grace.id,
+      {
+        name: "Grace",
+        aboutMe: null,
+        avatarUrl: "/uploads/grace.webp",
+        pronouns: "she/her",
+        basedIn: "Lisbon",
+        prompts: null,
+        languages: null,
+        contacts: null,
+      },
+      BEFORE
+    );
+    // Elsewhere in the day: the host pill is a fact about the person, and
+    // must not turn into the busy flag.
+    await createSession(event.id, {
+      title: "Their other talk",
+      hostIds: [grace.id],
+      startTime: new Date("2026-10-01T11:00:00.000Z"),
+      endTime: new Date("2026-10-01T11:30:00.000Z"),
+    });
+
+    const found = await meetingCandidatesFor(viewer.id, event.id, SLOT, BEFORE);
+
+    expect(found?.candidates).toEqual([
+      {
+        id: grace.id,
+        name: "Grace",
+        pronouns: "she/her",
+        basedIn: "Lisbon",
+        avatarUrl: "/uploads/grace.webp",
+        isHost: true,
+        busy: false,
+      },
+    ]);
+  });
+
   it("carries what the request form needs beside the people", async () => {
     const { event, viewer } = await scenario();
     await getRepositories().meetingPoints.create({

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -89,6 +89,7 @@ const OUT_OF_SCOPE_EXACT = new Set(["health"]);
 // Read-only surfaces are exempt from the invariant per CONTRIBUTING.md.
 const READ_ONLY = new Set([
   "meetings",
+  "meetings/candidates",
   "rsvps",
   "votes",
   "session/[sessionId]/comments",

--- a/tests/unit/meeting-column.test.ts
+++ b/tests/unit/meeting-column.test.ts
@@ -131,6 +131,17 @@ describe("meetingColumnRows", () => {
     expect(free.map((r) => r.row)).toEqual([1, 2, 3, 4]);
   });
 
+  // Booking from the grid asks about one slot, so each row carries the instant
+  // it stands for rather than leaving the caller to re-derive it.
+  it("carries the instant each row starts at", () => {
+    expect(rows([meeting(0)], [at(30)]).map((r) => r.start)).toEqual([
+      at(0),
+      at(30),
+      at(60),
+      at(90),
+    ]);
+  });
+
   // A slot the viewer cleared is one nobody may book *them* into -- they can
   // still arrange a 1-on-1 there themselves, so it stays a row of its own
   // rather than merging into an unbookable band.
@@ -138,10 +149,10 @@ describe("meetingColumnRows", () => {
     const declared = rows([], [at(0), at(90)]);
 
     expect(declared).toEqual([
-      { row: 1, span: 1, kind: "free", meetings: [] },
-      { row: 2, span: 1, kind: "unavailable", meetings: [] },
-      { row: 3, span: 1, kind: "unavailable", meetings: [] },
-      { row: 4, span: 1, kind: "free", meetings: [] },
+      { row: 1, span: 1, start: at(0), kind: "free", meetings: [] },
+      { row: 2, span: 1, start: at(30), kind: "unavailable", meetings: [] },
+      { row: 3, span: 1, start: at(60), kind: "unavailable", meetings: [] },
+      { row: 4, span: 1, start: at(90), kind: "free", meetings: [] },
     ]);
   });
 

--- a/utils/meeting-candidates.ts
+++ b/utils/meeting-candidates.ts
@@ -1,0 +1,174 @@
+import { DateTime } from "luxon";
+
+import { getRepositories } from "@/db/container";
+import type { MeetingPoint } from "@/db/repositories/interfaces";
+import { clashesForInterval, loadGuestSchedules } from "@/utils/guest-clashes";
+import {
+  toMeetingClashes,
+  type MeetingClash,
+} from "@/utils/meeting-clash-text";
+import { meetingSlotsForDay } from "@/utils/meeting-slots";
+
+/** One person the viewer could ask for a 1-on-1 in a given slot. */
+export type MeetingCandidate = {
+  id: string;
+  name: string;
+  pronouns: string | null;
+  basedIn: string | null;
+  avatarUrl: string | null;
+  isHost: boolean;
+  /**
+   * They already have something at that hour. Deliberately a flag and not a
+   * description: what it is, is theirs to tell (see `toMeetingClashes`).
+   */
+  busy: boolean;
+};
+
+/** Everything the grid's booking flow needs for one slot. */
+export type MeetingCandidates = {
+  eventName: string;
+  dayLabel: string;
+  slotLabel: string;
+  meetingPoints: Pick<MeetingPoint, "id" | "name" | "description">[];
+  /**
+   * The viewer's own clash with the slot, named — one line for the whole
+   * screen rather than repeated against every candidate.
+   */
+  yourClashes: MeetingClash[];
+  candidates: MeetingCandidate[];
+};
+
+/**
+ * Who the viewer could meet at `slotStart` — the question the profile picker
+ * answers the other way round (`meetingOptionsFor`: when could I meet *them*).
+ *
+ * Null when there is nothing to offer at all: the event is gone or no longer
+ * offers meetings, the viewer is not attending it, or the slot is not one the
+ * event still has ahead of it. An empty candidate list is a different answer,
+ * and the caller says so differently.
+ */
+export async function meetingCandidatesFor(
+  viewerId: string,
+  eventId: string,
+  slotStart: string,
+  now: Date
+): Promise<MeetingCandidates | null> {
+  const repos = getRepositories();
+  const event = await repos.events.findById(eventId);
+  if (!event?.meetingsEnabled) return null;
+
+  const attending = await repos.guests.listEventsByGuests([viewerId]);
+  if (!attending.get(viewerId)?.some((e) => e.id === eventId)) return null;
+
+  const start = new Date(slotStart);
+  // Ahead of now and a slot the event actually offers: the same two checks the
+  // request action makes, so the grid never opens on a booking that would be
+  // refused (issue #392, section 2.1).
+  if (!(start.getTime() > now.getTime())) return null;
+  const days = await repos.days.listByEvent(eventId);
+  const day = days.find((d) => start >= d.start && start < d.end);
+  if (!day) return null;
+  const slot = meetingSlotsForDay(day, event.slotIncrementMinutes).find(
+    (s) => s.start.getTime() === start.getTime()
+  );
+  if (!slot) return null;
+
+  const [declaredIds, eventGuests, attendees, meetingPoints, live] =
+    await Promise.all([
+      repos.meetingAvailability.listGuestsBySlot(eventId, start),
+      repos.guests.listByEvent(eventId),
+      repos.guests.listAttendees(now),
+      repos.meetingPoints.listByEvent(eventId),
+      repos.meetings.listLiveBySlot(eventId, start),
+    ]);
+
+  // Someone the viewer is already meeting then cannot be asked again -- the
+  // request would be refused as a duplicate -- so they are not offered.
+  const withViewer = new Set(
+    live
+      .filter((m) => m.requesterId === viewerId || m.recipientId === viewerId)
+      .map((m) => (m.requesterId === viewerId ? m.recipientId : m.requesterId))
+  );
+  // An agreed 1-on-1 of theirs leaves them busy, without saying so. Only an
+  // agreed one: a request they have not answered is not yet a commitment,
+  // which is the rule clashesForInterval already applies.
+  const inAMeeting = new Set(
+    live
+      .filter((m) => m.status === "accepted")
+      .flatMap((m) => [m.requesterId, m.recipientId])
+  );
+
+  // One pass over the event's sessions rather than a schedule per candidate:
+  // a popular slot at a big event has dozens of them, and loading four
+  // queries per person is what makes a modal take seconds to open.
+  const sessions = await repos.sessions.listScheduledByEvent(eventId);
+  const overlapping = sessions.filter(
+    (session) =>
+      session.startTime != null &&
+      session.endTime != null &&
+      session.startTime < slot.end &&
+      session.endTime > slot.start
+  );
+  const rsvps = await repos.rsvps.listBySessions(overlapping.map((s) => s.id));
+  const engaged = new Set<string>([
+    ...overlapping.flatMap((s) => s.hosts.map((h) => h.id)),
+    ...[...rsvps.values()].flatMap((list) => list.map((r) => r.guestId)),
+  ]);
+
+  const attendee = new Map(attendees.map((a) => [a.id, a]));
+  const onGuestList = new Set(eventGuests.map((g) => g.id));
+  const candidates: MeetingCandidate[] = declaredIds
+    .filter(
+      (id) => id !== viewerId && onGuestList.has(id) && !withViewer.has(id)
+    )
+    .flatMap((id) => {
+      const guest = attendee.get(id);
+      if (!guest) return [];
+      return [
+        {
+          id,
+          name: guest.name,
+          pronouns: guest.pronouns ?? null,
+          basedIn: guest.basedIn ?? null,
+          avatarUrl: guest.avatarUrl ?? null,
+          isHost: guest.isHost,
+          busy: engaged.has(id) || inAMeeting.has(id),
+        },
+      ];
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // The viewer's own schedule is worth the four queries: theirs is the one
+  // clash that may be named, and it is the same line the picker shows.
+  const [mine] = await loadGuestSchedules(eventId, [viewerId]);
+  const yourClashes = mine
+    ? toMeetingClashes(
+        clashesForInterval([mine], {
+          eventId,
+          start: slot.start,
+          end: slot.end,
+          breakMinutes: event.breakMinutes,
+          detailFor: viewerId,
+        }),
+        viewerId
+      )
+    : [];
+
+  const zoned = (date: Date) =>
+    DateTime.fromJSDate(date).setZone(event.timezone);
+
+  return {
+    eventName: event.name,
+    dayLabel: zoned(slot.start).toFormat("EEE d LLL"),
+    slotLabel: `${zoned(slot.start).toFormat("HH:mm")} – ${zoned(
+      slot.end
+    ).toFormat("HH:mm")}`,
+    meetingPoints: meetingPoints.map(({ id, name, description }) => ({
+      id,
+      name,
+      description,
+    })),
+    yourClashes,
+    candidates,
+  };
+}

--- a/utils/meeting-candidates.ts
+++ b/utils/meeting-candidates.ts
@@ -82,8 +82,8 @@ export async function meetingCandidatesFor(
       repos.meetings.listLiveBySlot(eventId, start),
     ]);
 
-  // Someone the viewer is already meeting then cannot be asked again -- the
-  // request would be refused as a duplicate -- so they are not offered.
+  // Nobody already paired with the viewer here: asking again is refused as a
+  // duplicate, and asking back across their open request only crosses it.
   const withViewer = new Set(
     live
       .filter((m) => m.requesterId === viewerId || m.recipientId === viewerId)

--- a/utils/meeting-candidates.ts
+++ b/utils/meeting-candidates.ts
@@ -73,14 +73,12 @@ export async function meetingCandidatesFor(
   );
   if (!slot) return null;
 
-  const [declaredIds, eventGuests, attendees, meetingPoints, live] =
-    await Promise.all([
-      repos.meetingAvailability.listGuestsBySlot(eventId, start),
-      repos.guests.listByEvent(eventId),
-      repos.guests.listAttendees(now),
-      repos.meetingPoints.listByEvent(eventId),
-      repos.meetings.listLiveBySlot(eventId, start),
-    ]);
+  const [declaredIds, eventGuests, meetingPoints, live] = await Promise.all([
+    repos.meetingAvailability.listGuestsBySlot(eventId, start),
+    repos.guests.listAttendeesByEvent(eventId),
+    repos.meetingPoints.listByEvent(eventId),
+    repos.meetings.listLiveBySlot(eventId, start),
+  ]);
 
   // Nobody already paired with the viewer here: asking again is refused as a
   // duplicate, and asking back across their open request only crosses it.
@@ -115,14 +113,13 @@ export async function meetingCandidatesFor(
     ...[...rsvps.values()].flatMap((list) => list.map((r) => r.guestId)),
   ]);
 
-  const attendee = new Map(attendees.map((a) => [a.id, a]));
-  const onGuestList = new Set(eventGuests.map((g) => g.id));
+  // Keyed by the event's own guest list, so an availability row that outlived
+  // its owner's place on the event finds nobody to describe.
+  const onGuestList = new Map(eventGuests.map((g) => [g.id, g]));
   const candidates: MeetingCandidate[] = declaredIds
-    .filter(
-      (id) => id !== viewerId && onGuestList.has(id) && !withViewer.has(id)
-    )
+    .filter((id) => id !== viewerId && !withViewer.has(id))
     .flatMap((id) => {
-      const guest = attendee.get(id);
+      const guest = onGuestList.get(id);
       if (!guest) return [];
       return [
         {

--- a/utils/meeting-column.ts
+++ b/utils/meeting-column.ts
@@ -38,6 +38,8 @@ export type MeetingColumnRow = {
   /** 1-based, matching CSS grid's own row numbering. */
   row: number;
   span: number;
+  /** The slot's start as an ISO string, which is how a booking names it. */
+  start: string;
   kind: "meetings" | "unavailable" | "free";
   /** Empty unless `kind` is "meetings". */
   meetings: MeetingView[];
@@ -104,11 +106,15 @@ export function meetingColumnRows({
 
   const rows: MeetingColumnRow[] = [];
   for (let row = 1; row <= numSlots; row++) {
+    const start = new Date(
+      day.start.getTime() + (row - 1) * slotMs
+    ).toISOString();
     const atRow = byRow.get(row);
     if (atRow) {
       rows.push({
         row,
         span: Math.max(...atRow.map(spanOf)),
+        start,
         kind: "meetings",
         meetings: atRow,
       });
@@ -116,13 +122,12 @@ export function meetingColumnRows({
     }
     if (covered.has(row)) continue;
 
-    const start = new Date(day.start.getTime() + (row - 1) * slotMs);
-    const free = !declaredAnything || declared.has(start.toISOString());
+    const free = !declaredAnything || declared.has(start);
     if (free) {
-      rows.push({ row, span: 1, kind: "free", meetings: [] });
+      rows.push({ row, span: 1, start, kind: "free", meetings: [] });
       continue;
     }
-    rows.push({ row, span: 1, kind: "unavailable", meetings: [] });
+    rows.push({ row, span: 1, start, kind: "unavailable", meetings: [] });
   }
 
   // Nothing declared and nothing booked is not a column at all; the caller


### PR DESCRIPTION
Closes schellingboard/schellingboard#945 — note 3 of @omarkohl's UX notes on schellingboard/schellingboard-legacy#943. **Rewritten as one commit**; the
directory filter that used to travel with it is its own PR now. **Stacked on schellingboard/schellingboard-legacy#985** — the
base moves down the chain as each lands.

## What's here

The grid answers the question a profile cannot. A profile knows the person and asks for a time;
the schedule's own 1-on-1 column knows the time, so tapping an empty slot in it asks **who is
free then**.

The list is everyone who marked that slot open — avatar, name, pronouns and where they are
based, the Session host pill where it applies. It scrolls inside the modal rather than growing
it, because a popular slot at a large event is a long list and **Ask** has to stay reachable. A
name links to that person's profile, opened in its own tab: deciding whether to ask someone
means reading who they are, and that must not cost the slot being booked.

**Ask** leads to the request form we already have — where to meet, and a line of context. It is
literally the same form: `MeetingRequestFields` moved to `app/components` and the profile picker
now renders it too. The slots you did not offer to others are bookable this way too.

## Decisions worth a reviewer's attention

**Who is offered.** Everyone who declared the slot, minus the viewer, minus anyone since taken
off the guest list, minus anyone the viewer already has a live 1-on-1 with then — that request
would be refused as a duplicate, so offering it would be offering a dead end.

**A candidate's clash is a flag, not a description.** `busy` and nothing else: what they have on
at that hour is theirs to tell, the rule `toMeetingClash` already applies. The viewer's own
clash is named, once, above the list — it is the same slot whoever they ask.

**The lookup is flat, not per-candidate.** `loadGuestSchedules` costs four queries a guest,
which at a busy slot is a modal that takes seconds to open. So the slot's availability, its live
1-on-1s and the event's overlapping sessions are each read once for everyone, and only the
viewer's own schedule is loaded the expensive way, because theirs is the one clash that may be
named.

**Fetched on the click, not shipped with the schedule.** `/api/meetings/candidates` is
per-viewer and `no-store`, with no id parameter to ask on anyone else's behalf — who is free
when is as private as an RSVP.

## Testing

`make test` green, including the candidate lookup (attendance, the duplicate case, busy from a
session, an agreed 1-on-1 counting where a pending one does not) and its endpoint. One E2E books
a 1-on-1 from the grid end to end, through the column, the list and the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
