### PR TITLE
feat: say why, when you call a 1-on-1 off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   1-on-1s and open requests. Hover for what it clashes with, tap to open or cancel it
 - **Arrange a 1-on-1 straight from the schedule** (#945): tapping an empty slot in your 1-on-1
   column lists who is free then, profile links included, and the request form follows on
+- **Say why, when you call a 1-on-1 off** (#946): cancelling takes an optional note, which the
+  other person reads on the meeting itself
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
   beside Session host and Has profile. It covers every event on the site, not only this one
 

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -13,6 +13,7 @@ import {
   PRIMARY_BUTTON,
   SECONDARY_BUTTON,
 } from "@/app/components/buttons";
+import { Input } from "@/app/input";
 import { EventContext } from "@/app/(site)/context";
 import { clashLines } from "@/utils/meeting-clash-text";
 import { canCancel, statusLine } from "@/utils/meeting-rules";
@@ -43,6 +44,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
   const { meetings, reload } = useMyMeetings();
   const [error, setError] = useState<string | null>(null);
   const [confirmingCancel, setConfirmingCancel] = useState(false);
+  const [cancelNote, setCancelNote] = useState("");
   const [isAnswering, startAnswer] = useTransition();
 
   // Duplication, anchor: waggHhba
@@ -66,6 +68,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
   const act = (run: () => Promise<MeetingActionResult>) => {
     setError(null);
     setConfirmingCancel(false);
+    setCancelNote("");
     startAnswer(async () => {
       try {
         const result = await run();
@@ -146,6 +149,14 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
               </p>
             )}
 
+            {/* A canceled meeting drops off the schedule column, so this modal
+                -- reached from the notification -- is where the note is read. */}
+            {meeting.cancelNote && (
+              <p className="text-sm rounded-md bg-surface-sunken p-3 text-fg">
+                {meeting.cancelNote}
+              </p>
+            )}
+
             {/* The requester saw only that the slot was taken; the person
                 answering sees what it is, so they can weigh it against the
                 request (issue #392, section 1.4). */}
@@ -195,11 +206,29 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                   <p className="text-sm text-fg">
                     {meeting.otherName} will be told. Cancel it?
                   </p>
+                  {/* Optional, and the one place in the feature where a word
+                      of explanation is worth something: calling off something
+                      the other person had agreed to. */}
+                  <label
+                    htmlFor="cancel-note"
+                    className="text-sm font-medium text-fg-muted"
+                  >
+                    Say why, if you like (optional)
+                  </label>
+                  <Input
+                    id="cancel-note"
+                    value={cancelNote}
+                    onChange={(e) => setCancelNote(e.target.value)}
+                    placeholder="Sorry — my session moved…"
+                    className="w-full h-10"
+                  />
                   <div className="flex gap-2">
                     <button
                       type="button"
                       onClick={() =>
-                        act(() => cancelMeetingAction({ meetingId }))
+                        act(() =>
+                          cancelMeetingAction({ meetingId, note: cancelNote })
+                        )
                       }
                       disabled={isAnswering}
                       className={DANGER_BUTTON}

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -149,10 +149,13 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
               </p>
             )}
 
-            {/* A canceled meeting drops off the schedule column, so this modal
-                -- reached from the notification -- is where the note is read. */}
+            {/* A canceled meeting leaves the column, so this modal is where the
+                note is read -- named, since the message above is a box like it. */}
             {meeting.cancelNote && (
               <p className="text-sm rounded-md bg-surface-sunken p-3 text-fg">
+                <span className="font-medium text-fg-muted">
+                  Why it was called off:{" "}
+                </span>
                 {meeting.cancelNote}
               </p>
             )}
@@ -206,22 +209,21 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                   <p className="text-sm text-fg">
                     {meeting.otherName} will be told. Cancel it?
                   </p>
-                  {/* Optional, and the one place in the feature where a word
-                      of explanation is worth something: calling off something
-                      the other person had agreed to. */}
-                  <label
-                    htmlFor="cancel-note"
-                    className="text-sm font-medium text-fg-muted"
-                  >
-                    Say why, if you like (optional)
-                  </label>
-                  <Input
-                    id="cancel-note"
-                    value={cancelNote}
-                    onChange={(e) => setCancelNote(e.target.value)}
-                    placeholder="Sorry — my session moved…"
-                    className="w-full h-10"
-                  />
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="cancel-note"
+                      className="text-sm font-medium text-fg-muted"
+                    >
+                      Say why, if you like (optional)
+                    </label>
+                    <Input
+                      id="cancel-note"
+                      value={cancelNote}
+                      onChange={(e) => setCancelNote(e.target.value)}
+                      placeholder="Sorry — my session moved…"
+                      className="w-full h-10"
+                    />
+                  </div>
                   <div className="flex gap-2">
                     <button
                       type="button"

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -38,7 +38,10 @@ const respondSchema = z.object({
   response: z.enum(["accept", "decline"]),
 });
 
-const cancelSchema = z.object({ meetingId: z.string() });
+const cancelSchema = z.object({
+  meetingId: z.string(),
+  note: z.string().max(2000).optional(),
+});
 
 const availabilitySchema = z.object({
   eventId: z.string(),
@@ -265,11 +268,15 @@ export async function cancelMeetingAction(
   const from: MeetingStatus[] = isRequester
     ? ["pending", "accepted"]
     : ["accepted"];
+  // The note goes in with the status change rather than after it: a cancel
+  // the compare-and-set refuses is one that did not happen, and it must not
+  // leave a word about it on a meeting that still stands.
   const canceled = await repos.meetings.updateStatus(
     meeting.id,
     "canceled",
     now,
-    from
+    from,
+    input.note?.trim() ?? ""
   );
   if (!canceled) {
     return { ok: false, error: "There is nothing left to cancel" };

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -268,9 +268,8 @@ export async function cancelMeetingAction(
   const from: MeetingStatus[] = isRequester
     ? ["pending", "accepted"]
     : ["accepted"];
-  // The note goes in with the status change rather than after it: a cancel
-  // the compare-and-set refuses is one that did not happen, and it must not
-  // leave a word about it on a meeting that still stands.
+  // The note goes in with the status change: a cancel the compare-and-set
+  // refuses must leave no word about it on a meeting that still stands.
   const canceled = await repos.meetings.updateStatus(
     meeting.id,
     "canceled",

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -870,6 +870,8 @@ export type Meeting = {
   /** Where to meet, as agreed at request time. Never empty. */
   meetingPoint: string;
   message: string;
+  /** What the canceller said, if anything. Empty on a meeting still standing. */
+  cancelNote: string;
   status: MeetingStatus;
   createdAt: Date;
   respondedAt?: Date;
@@ -877,6 +879,16 @@ export type Meeting = {
 
 export type MeetingRequestOutcome =
   { meeting: Meeting } | { refused: "cap" | "duplicate" };
+
+/**
+ * A meeting as it is asked for. Everything a request carries; the rest of a
+ * meeting is what happens to it afterwards — its status, when it was answered,
+ * and a note from whoever called it off.
+ */
+export type MeetingCreateInput = Omit<
+  Meeting,
+  "id" | "status" | "respondedAt" | "cancelNote"
+>;
 
 export interface MeetingsRepository {
   findById(id: string): Promise<Meeting | undefined>;
@@ -902,9 +914,7 @@ export interface MeetingsRepository {
     eventId: string,
     now: Date
   ): Promise<number>;
-  create(
-    data: Omit<Meeting, "id" | "status" | "respondedAt">
-  ): Promise<Meeting>;
+  create(data: MeetingCreateInput): Promise<Meeting>;
   /**
    * Both refusals and the insert in one transaction. Two separate awaits leave
    * a window a double submit walks straight through — the same hazard
@@ -917,7 +927,7 @@ export interface MeetingsRepository {
    * they had earlier passed on.
    */
   createIfAllowed(
-    data: Omit<Meeting, "id" | "status" | "respondedAt">,
+    data: MeetingCreateInput,
     cap: number,
     now: Date
   ): Promise<MeetingRequestOutcome>;
@@ -926,11 +936,17 @@ export interface MeetingsRepository {
    * when it is in some other state, which is how a caller learns that someone
    * (a cancelling requester, a second tab) got there first.
    */
+  /**
+   * Moves the meeting, but only from one of `from` — the compare-and-set that
+   * decides which of two tabs wins. `cancelNote` rides along in the same
+   * statement, so a note is stored only where the move it explains happened.
+   */
   updateStatus(
     id: string,
     status: MeetingStatus,
     respondedAt: Date,
-    from: MeetingStatus[]
+    from: MeetingStatus[],
+    cancelNote?: string
   ): Promise<Meeting | undefined>;
 }
 

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -935,11 +935,9 @@ export interface MeetingsRepository {
    * Moves the meeting to `status`, but only from one of `from` — undefined
    * when it is in some other state, which is how a caller learns that someone
    * (a cancelling requester, a second tab) got there first.
-   */
-  /**
-   * Moves the meeting, but only from one of `from` — the compare-and-set that
-   * decides which of two tabs wins. `cancelNote` rides along in the same
-   * statement, so a note is stored only where the move it explains happened.
+   *
+   * `cancelNote` rides along in the same statement, so a note is stored only
+   * where the move it explains happened.
    */
   updateStatus(
     id: string,

--- a/db/repositories/sqlite/meetings.ts
+++ b/db/repositories/sqlite/meetings.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import * as schema from "../../schema";
 import type {
   Meeting,
+  MeetingCreateInput,
   MeetingRequestOutcome,
   MeetingStatus,
   MeetingsRepository,
@@ -21,6 +22,7 @@ function rowToMeeting(row: typeof schema.meetings.$inferSelect): Meeting {
     slotEnd: new Date(row.slotEnd),
     meetingPoint: row.meetingPoint,
     message: row.message,
+    cancelNote: row.cancelNote,
     status: row.status,
     createdAt: new Date(row.createdAt),
     respondedAt: row.respondedAt ? new Date(row.respondedAt) : undefined,
@@ -30,7 +32,7 @@ function rowToMeeting(row: typeof schema.meetings.$inferSelect): Meeting {
 // Instants are stored as ISO-8601 in UTC and nowhere else formatted, which is
 // what makes ordering by the text column chronological and what lets a
 // meeting's slot be compared with an availability row's.
-function toRow(data: Omit<Meeting, "id" | "status" | "respondedAt">) {
+function toRow(data: MeetingCreateInput) {
   return {
     id: nanoid(),
     eventId: data.eventId,
@@ -40,6 +42,7 @@ function toRow(data: Omit<Meeting, "id" | "status" | "respondedAt">) {
     slotEnd: data.slotEnd.toISOString(),
     meetingPoint: data.meetingPoint,
     message: data.message,
+    cancelNote: "",
     status: "pending" as const,
     createdAt: data.createdAt.toISOString(),
     respondedAt: null,
@@ -102,16 +105,14 @@ export class SqliteMeetingsRepository implements MeetingsRepository {
     return this.countOpen(this.db, requesterId, eventId, now);
   }
 
-  async create(
-    data: Omit<Meeting, "id" | "status" | "respondedAt">
-  ): Promise<Meeting> {
+  async create(data: MeetingCreateInput): Promise<Meeting> {
     const row = toRow(data);
     this.db.insert(schema.meetings).values(row).run();
     return rowToMeeting(row);
   }
 
   async createIfAllowed(
-    data: Omit<Meeting, "id" | "status" | "respondedAt">,
+    data: MeetingCreateInput,
     cap: number,
     now: Date
   ): Promise<MeetingRequestOutcome> {
@@ -130,11 +131,16 @@ export class SqliteMeetingsRepository implements MeetingsRepository {
     id: string,
     status: MeetingStatus,
     respondedAt: Date,
-    from: MeetingStatus[]
+    from: MeetingStatus[],
+    cancelNote?: string
   ): Promise<Meeting | undefined> {
     const result = this.db
       .update(schema.meetings)
-      .set({ status, respondedAt: respondedAt.toISOString() })
+      .set({
+        status,
+        respondedAt: respondedAt.toISOString(),
+        ...(cancelNote === undefined ? {} : { cancelNote }),
+      })
       .where(
         and(eq(schema.meetings.id, id), inArray(schema.meetings.status, from))
       )

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -463,6 +463,10 @@ export const meetings = sqliteTable(
     // organizer renames or removes a suggestion.
     meetingPoint: text("meeting_point").notNull(),
     message: text("message").notNull().default(""),
+    // What the canceller said, if anything. Its own column rather than
+    // reusing `message`: that one is the requester's line of context, and a
+    // meeting can carry both.
+    cancelNote: text("cancel_note").notNull().default(""),
     // Not "expired": a request whose slot has passed is expired by definition,
     // so it is derived on read rather than swept by a job the app has no
     // scheduler to run.

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -463,9 +463,8 @@ export const meetings = sqliteTable(
     // organizer renames or removes a suggestion.
     meetingPoint: text("meeting_point").notNull(),
     message: text("message").notNull().default(""),
-    // What the canceller said, if anything. Its own column rather than
-    // reusing `message`: that one is the requester's line of context, and a
-    // meeting can carry both.
+    // Its own column rather than reusing `message`: that one is the
+    // requester's line of context, and a meeting can carry both.
     cancelNote: text("cancel_note").notNull().default(""),
     // Not "expired": a request whose slot has passed is expired by definition,
     // so it is derived on read rather than swept by a job the app has no

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -269,6 +269,12 @@ context, and anything it clashes with. Tap one to open it. That is also where
 either of you can **cancel** a 1-on-1 you had agreed, or take back a request
 nobody has answered yet, up until the slot begins; the other person is told.
 
+You can add a line saying why. It is optional — nobody owes an explanation for
+calling something off — and it reaches the other person on the meeting itself
+rather than in the email, the same as the line of context on a request. A
+canceled 1-on-1 leaves the schedule, so their notification is how they get back
+to it.
+
 ### Arrange one from the schedule
 
 Tapping an **empty slot** in that column asks the question a profile cannot:

--- a/drizzle/0033_meeting_cancel_note.sql
+++ b/drizzle/0033_meeting_cancel_note.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `meetings` ADD `cancel_note` text DEFAULT '' NOT NULL;

--- a/drizzle/meta/0033_snapshot.json
+++ b/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,1944 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "68d938a4-d53a-4811-b3d9-46cde9e4d5a9",
+  "prevId": "c6e25533-512c-4187-bc35-1235a0272685",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meetings_enabled": {
+          "name": "meetings_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "meeting_slot_minutes": {
+          "name": "meeting_slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "meeting_day_start": {
+          "name": "meeting_day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_day_end": {
+          "name": "meeting_day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_open_meeting_requests": {
+          "name": "max_open_meeting_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_session_comment": {
+          "name": "email_on_session_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_profile_comment": {
+          "name": "email_on_profile_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_on_meeting_request": {
+          "name": "email_on_meeting_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_meeting_response": {
+          "name": "email_on_meeting_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_availability": {
+      "name": "meeting_availability",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_availability_slot_idx": {
+          "name": "meeting_availability_slot_idx",
+          "columns": ["event_id", "slot_start"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_availability_event_id_events_id_fk": {
+          "name": "meeting_availability_event_id_events_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_availability_guest_id_guests_id_fk": {
+          "name": "meeting_availability_guest_id_guests_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meeting_availability_event_id_guest_id_slot_start_pk": {
+          "columns": ["event_id", "guest_id", "slot_start"],
+          "name": "meeting_availability_event_id_guest_id_slot_start_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_points": {
+      "name": "meeting_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "meeting_points_event_idx": {
+          "name": "meeting_points_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_points_event_id_events_id_fk": {
+          "name": "meeting_points_event_id_events_id_fk",
+          "tableFrom": "meeting_points",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_end": {
+          "name": "slot_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_point": {
+          "name": "meeting_point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cancel_note": {
+          "name": "cancel_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meetings_event_requester_idx": {
+          "name": "meetings_event_requester_idx",
+          "columns": ["event_id", "requester_id"],
+          "isUnique": false
+        },
+        "meetings_event_recipient_idx": {
+          "name": "meetings_event_recipient_idx",
+          "columns": ["event_id", "recipient_id"],
+          "isUnique": false
+        },
+        "meetings_no_duplicate_request": {
+          "name": "meetings_no_duplicate_request",
+          "columns": ["event_id", "requester_id", "recipient_id", "slot_start"],
+          "isUnique": true,
+          "where": "\"meetings\".\"status\" in ('pending', 'accepted')"
+        }
+      },
+      "foreignKeys": {
+        "meetings_event_id_events_id_fk": {
+          "name": "meetings_event_id_events_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_requester_id_guests_id_fk": {
+          "name": "meetings_requester_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_recipient_id_guests_id_fk": {
+          "name": "meetings_recipient_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_guest_created_idx": {
+          "name": "notifications_guest_created_idx",
+          "columns": ["guest_id", "created_at"],
+          "isUnique": false
+        },
+        "notifications_guest_read_idx": {
+          "name": "notifications_guest_read_idx",
+          "columns": ["guest_id", "read_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_guest_id_guests_id_fk": {
+          "name": "notifications_guest_id_guests_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_comments": {
+      "name": "profile_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_comments_profile_idx": {
+          "name": "profile_comments_profile_idx",
+          "columns": ["profile_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_comments_comment_id_comments_id_fk": {
+          "name": "profile_comments_comment_id_comments_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_comments_profile_id_guests_id_fk": {
+          "name": "profile_comments_profile_id_guests_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "guests",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_keys": {
+      "name": "push_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "columns": ["endpoint"],
+          "isUnique": true
+        },
+        "push_subscriptions_guest_idx": {
+          "name": "push_subscriptions_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_guest_id_guests_id_fk": {
+          "name": "push_subscriptions_guest_id_guests_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1788594330660,
       "tag": "0032_acoustic_madelyne_pryor",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1788697709228,
+      "tag": "0033_meeting_cancel_note",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -450,10 +450,8 @@ test.describe("1-on-1 meetings", () => {
       .fill("sorry, my session moved");
     await confirmed.getByRole("button", { name: "Yes, cancel it" }).click();
     await expect(confirmed.getByText(/was canceled/)).toBeVisible();
-    // The note is on the meeting from here on, which is where the other one
-    // reads it too -- their notification is what takes them back to it, since
-    // a canceled 1-on-1 has left the column. That half is covered where it is
-    // cheap: meeting-views carries it, and the action stores it.
+    // The other party reads it here too, reached from their notification --
+    // that half is covered where it is cheap, in meeting-views.
     await expect(confirmed.getByText("sorry, my session moved")).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -445,8 +445,16 @@ test.describe("1-on-1 meetings", () => {
     await page.getByRole("link", { name: new RegExp(askee) }).click();
     const confirmed = page.getByRole("dialog", { name: "1-on-1 details" });
     await confirmed.getByRole("button", { name: "Cancel 1-on-1" }).click();
+    await confirmed
+      .getByLabel(/Say why, if you like/)
+      .fill("sorry, my session moved");
     await confirmed.getByRole("button", { name: "Yes, cancel it" }).click();
     await expect(confirmed.getByText(/was canceled/)).toBeVisible();
+    // The note is on the meeting from here on, which is where the other one
+    // reads it too -- their notification is what takes them back to it, since
+    // a canceled 1-on-1 has left the column. That half is covered where it is
+    // cheap: meeting-views carries it, and the action stores it.
+    await expect(confirmed.getByText("sorry, my session moved")).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(
       page.getByRole("link", { name: new RegExp(askee) })

--- a/tests/integration/meeting-respond-action.test.ts
+++ b/tests/integration/meeting-respond-action.test.ts
@@ -33,6 +33,7 @@ import { siteAuthenticate } from "../helpers/site-auth";
 import { createEvent, createGuest } from "../helpers/factories";
 import { GUEST_COOKIE_NAME, verifiedGuestValue } from "../helpers/guest-cookie";
 import { getRepositories } from "@/db/container";
+import { sendMail } from "@/utils/mailer";
 import {
   cancelMeetingAction,
   respondToMeetingAction,
@@ -288,6 +289,73 @@ describe("cancelMeetingAction", () => {
       requester.id
     );
     expect(notification.text).toMatch(/canceled/);
+  });
+
+  // Calling a meeting off is the one point in the feature where a word of
+  // explanation is worth something, so the note rides with the status change.
+  it("keeps the note the canceller left, trimmed", async () => {
+    const { requester, meeting } = await scenario();
+    await signIn(requester.id);
+
+    const result = await cancelMeetingAction({
+      meetingId: meeting.id,
+      note: "  sorry, my session moved  ",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.cancelNote
+    ).toBe("sorry, my session moved");
+  });
+
+  it("takes no note at all, as it always could", async () => {
+    const { requester, meeting } = await scenario();
+    await signIn(requester.id);
+
+    await cancelMeetingAction({ meetingId: meeting.id });
+
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.cancelNote
+    ).toBe("");
+  });
+
+  // The note is part of the cancellation, not a message of its own: a refused
+  // cancel leaves the meeting exactly as it was.
+  it("writes no note when there is nothing left to cancel", async () => {
+    const { requester, meeting } = await scenario();
+    await signIn(requester.id);
+    await cancelMeetingAction({ meetingId: meeting.id, note: "first" });
+
+    const again = await cancelMeetingAction({
+      meetingId: meeting.id,
+      note: "second",
+    });
+
+    expect(again.ok).toBe(false);
+    expect(
+      (await getRepositories().meetings.findById(meeting.id))?.cancelNote
+    ).toBe("first");
+  });
+
+  // What guests write to each other stays in the app, the same call the
+  // request's line of context already makes (emails/meeting.tsx).
+  it("keeps the note out of the notification and the mail", async () => {
+    const { requester, recipient, meeting } = await scenario();
+    await signIn(requester.id);
+
+    await cancelMeetingAction({
+      meetingId: meeting.id,
+      note: "my session moved",
+    });
+
+    const [notification] = await getRepositories().notifications.listByGuest(
+      recipient.id
+    );
+    expect(notification.text).toMatch(/canceled/);
+    expect(notification.text).not.toMatch(/my session moved/);
+    expect(JSON.stringify(vi.mocked(sendMail).mock.calls)).not.toContain(
+      "my session moved"
+    );
   });
 
   // While it is pending, the person asked has Decline: cancelling it on the

--- a/tests/integration/meeting-views.test.ts
+++ b/tests/integration/meeting-views.test.ts
@@ -171,6 +171,25 @@ describe("meetingViewsFor", () => {
     ]);
   });
 
+  // Where the other party reads it: a canceled meeting drops off the column,
+  // so the modal a notification opens is the only place the note is seen.
+  it("carries the note the canceller left", async () => {
+    const { event, requester, recipient } = await scenario();
+    const meeting = await meetingBetween(event, requester, recipient);
+    await getRepositories().meetings.updateStatus(
+      meeting.id,
+      "canceled",
+      BEFORE,
+      ["pending"],
+      "sorry, my session moved"
+    );
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.status).toBe("canceled");
+    expect(view.cancelNote).toBe("sorry, my session moved");
+  });
+
   // The same privacy rule the slot picker relies on: an RSVP is reported as
   // "busy" with no title, so one attendee never learns another's plans.
   it("reports the other party's RSVP without naming the session", async () => {

--- a/tests/unit/meeting-column.test.ts
+++ b/tests/unit/meeting-column.test.ts
@@ -29,6 +29,7 @@ function meeting(minutesIn: number, patch?: Partial<MeetingView>): MeetingView {
     timeLabel: "09:00 – 09:30",
     meetingPoint: "Coffee bar",
     message: "",
+    cancelNote: "",
     clashes: [],
     ...patch,
   };

--- a/utils/meeting-views.ts
+++ b/utils/meeting-views.ts
@@ -27,6 +27,8 @@ export type MeetingView = {
   timeLabel: string;
   meetingPoint: string;
   message: string;
+  /** What the canceller said, if anything; empty on anything else. */
+  cancelNote: string;
   /** Either party's commitments in the slot, so both can weigh the clash. */
   clashes: MeetingClash[];
 };
@@ -110,6 +112,7 @@ export async function meetingViewsFor(
       ).toFormat("HH:mm")}`,
       meetingPoint: meeting.meetingPoint,
       message: meeting.message,
+      cancelNote: meeting.cancelNote,
       clashes: toMeetingClashes(clashes, viewerId),
     };
   });


### PR DESCRIPTION
Closes schellingboard/schellingboard#946, from @omarkohl's UX notes on schellingboard/schellingboard-legacy#943.

**Stacked on schellingboard/schellingboard-legacy#970** — the base moves down the chain as each lands.

## What's here

Cancelling something the other person had agreed to is the one point in the feature where a
word of explanation is worth something. The confirm step now takes an optional line — "Say why,
if you like" — and the other party reads it on the meeting itself.

## Decisions worth a reviewer's attention

**A column of its own, not `message`.** That one is the requester's line of context, and a
meeting can carry both: a request explaining why it was asked and a cancellation explaining why
it is off.

**The note is written by the compare-and-set that moves the status**, as a fifth argument to
`updateStatus` rather than a second write. A cancel the other tab already won is one that did
not happen, and it must not leave a word about itself on a meeting that still stands. There is a
test for exactly that.

**It does not go in the email.** Same call `emails/meeting.tsx` already makes for the request's
line of context: the mail says a 1-on-1 was canceled and links to it, and what guests write to
each other need not go to their email providers. Easy to reverse if you would rather it were in
the mail — it is the one decision here I would call arguable.

**Where it is read.** A canceled 1-on-1 drops off the schedule column, so the modal their
notification opens is the only place it is seen — which is why the note renders where the
request's message does, for both parties.

Migration `0032` adds `meetings.cancel_note` (text, default `''`).

## Testing

`make test` green, including the note stored and trimmed, absent when not given, and *not*
written when the cancel is refused. The E2E journey fills the note when it cancels and reads it
back off the meeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
