### PR TITLE
feat: auto-dismiss session save confirmations after 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   and **Decline**, and hears about their own clashes before they answer; the asker is told either
   way. A request nobody answers before its slot begins simply lapses
 
+### Changed
+
+- **Session save confirmations clear themselves**: the message confirming a session was added,
+  updated or deleted used to stay on screen until you closed it. It now goes away on its own
+  after ten seconds, though the close button still works
+
 ### Fixed
 
 - **Event names that a site page would hide are rejected**: an event named "Guests", "Settings" or

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -37,6 +37,10 @@ import { MarkdownHint } from "@/app/(site)/markdown";
 import { BackLink } from "@/app/components/back-link";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
 
+// A save confirmation is routine news, so it clears itself — but late enough
+// that someone who looked away as the page changed still catches it.
+const CONFIRMATION_MS = 10_000;
+
 interface ErrorResponse {
   error?: string;
 }
@@ -279,7 +283,10 @@ export function SessionForm(props: {
     if (res.ok) {
       const actionType = sessionID ? "updated" : "added";
       await revalidateEvent(event.slug);
-      showToast(`Your session “${title}” has been ${actionType} successfully!`);
+      showToast(
+        `Your session “${title}” has been ${actionType} successfully!`,
+        { autoDismissMs: CONFIRMATION_MS }
+      );
       router.push(`/${event.slug}`);
       console.log(`Session ${actionType} successfully`);
     } else {
@@ -313,7 +320,9 @@ export function SessionForm(props: {
     if (res.ok) {
       console.log("Session deleted successfully");
       await revalidateEvent(event.slug);
-      showToast(`Your session “${title}” has been deleted successfully.`);
+      showToast(`Your session “${title}” has been deleted successfully.`, {
+        autoDismissMs: CONFIRMATION_MS,
+      });
       router.push(`/${event.slug}`);
     } else {
       let errorMessage = "Failed to delete session";

--- a/app/(site)/toast.tsx
+++ b/app/(site)/toast.tsx
@@ -18,9 +18,10 @@ const ToastContext = createContext<ShowToast>(() => {});
 /**
  * Toasts survive client-side navigation because the provider lives in the site
  * layout: a page can show one and immediately `router.push` elsewhere. A
- * confirmation never expires on its own — the message is long enough that a
- * timeout would cut readers off, so dismissal is the reader's choice; short
- * hints can ask for `autoDismissMs` instead.
+ * toast stays until dismissed unless the caller asks for `autoDismissMs`: how
+ * long a message needs on screen depends on what it says, so the caller
+ * decides — a passing hint a few seconds, a routine confirmation longer, a
+ * message the reader must not miss forever.
  *
  * A message already on screen is never shown twice: repeating the action that
  * raised it (tapping one greyed-out button after another) replaces the copy

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -43,6 +43,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Notifications in the app**: a bell in the header counts what is waiting, and clicking one takes you to it. Everything that emails you appears here too, even where email is not set up.",
       "**Meetings**: an event's Config tab can switch on 1-on-1s between attendees — the places you suggest people meet, and a cap on how many unanswered requests one person may have out.",
       "**Picking your name** works however many events a site runs: past about seven, the header's event links crowded the name chip off the row and there was no way to say who you are.",
+      "**Session save confirmations clear themselves** after ten seconds instead of waiting to be closed.",
       "**Say when you're free**: with meetings on, attendees get a 1-on-1s page to mark which slots they're open for. Turning the switch off clears it and keeps them unbookable.",
       "**Ask for a 1-on-1**: attendees book one of the slots someone is open for from their profile, and say where to meet. The person asked accepts or declines, warned about anything it clashes with.",
     ],

--- a/tests/e2e/add-session.spec.ts
+++ b/tests/e2e/add-session.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "./helpers/fixtures";
 import { uniqueSuffix } from "./helpers/unique";
 import { login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
-import { dismissToast, toast } from "./helpers/toast";
+import { toast } from "./helpers/toast";
 
 test("a newly added session appears on the overview and can be opened", async ({
   page,
@@ -38,10 +38,11 @@ test("a newly added session appears on the overview and can be opened", async ({
     /Your session .* has been added successfully/i
   );
 
-  // The toast stays until dismissed by hand — nothing times it out.
+  // A save confirmation is routine, so it clears itself after ten seconds —
+  // but not so soon that a reader who glanced away misses it.
   await page.waitForTimeout(3000);
   await expect(toast(page)).toBeVisible();
-  await dismissToast(page);
+  await expect(toast(page)).toHaveCount(0, { timeout: 15_000 });
 
   // The new session must be visible WITHOUT reloading (see #253).
   const newSessionLink = page.getByRole("link", { name: sessionTitle });

--- a/tests/e2e/helpers/toast.ts
+++ b/tests/e2e/helpers/toast.ts
@@ -4,8 +4,8 @@ export function toast(page: Page): Locator {
   return page.getByRole("status");
 }
 
-// Confirmation toasts never time out, so they sit over the bottom of the page
-// until dismissed — clear them before a test carries on clicking underneath.
+// A toast sits over the bottom of the page for seconds — clear it before a
+// test carries on clicking underneath rather than waiting it out.
 export async function dismissToast(page: Page) {
   await toast(page)
     .getByRole("button", { name: /dismiss/i })


### PR DESCRIPTION
Fixes schellingboard/schellingboard#859.

## What's here

The toast confirming that a session was added or updated stayed on screen until closed by hand.
It now clears itself after ten seconds; the close button still works.

## Decisions worth a reviewer's attention

**The delete confirmation goes the same way.** The issue names the save toast, but "deleted
successfully" is the same kind of routine news and lives in the same form, so leaving it
persisting while "updated" vanished would have looked like an oversight.

**Not a new default.** The issue asks whether every confirmation should follow suit. There is
no other confirmation toast today, so the provider keeps persist-until-dismissed as its
default and the docstring now leaves the lifetime to the caller instead of claiming
confirmations never expire. The one remaining caller with its own timeout, the six-second
disabled-control hint, is untouched.

**Ten seconds, as the issue proposes.** Long enough that someone who looked away as the page
changed under them still catches it; the E2E test checks it is still there at three seconds
and gone by fifteen.

## Testing

TDD: the existing add-session spec asserted the opposite ("nothing times it out"), so flipping
that assertion was the red test — it failed with the toast still present after fifteen
seconds — and passed after the change. `make precommit` is green: 156 E2E passed, 5 skipped
(the mailpit email tests, which I did not have running).

---
*Written by Claude Code, which also made the change.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
