### PR TITLE
docs: cap changelog and release-note verbosity, and prune what is unreleased

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,59 @@ Next.js scheduling app for managing conference/event sessions with three phases:
 
 ## Changelog
 
-Update `CHANGELOG.md` under `[Unreleased]` for any user-facing change — audience is event organizers, so keep it non-technical. Dev-only changes go under `Internal`. See [CONTRIBUTING.md § Changelog](CONTRIBUTING.md#changelog) for section types and conventions.
+Update `CHANGELOG.md` under `[Unreleased]` for any user-facing change. The audience is
+event organizers and attendees, so keep it non-technical. Dev-only changes go under
+`Internal`. See [CONTRIBUTING.md § Changelog](CONTRIBUTING.md#changelog) for the section
+types.
 
-**Be brief**: a bold lead phrase plus one to three sentences. Say what changed and,
-where it isn't obvious, what was wrong before. Leave out rationale, edge cases,
-future plans and implementation detail — those belong in the docs, an ADR or the
-commit message.
+**Format**: `- **Bold lead phrase** (#123): what changed, and — only where it isn't
+obvious — what was wrong before.`
+
+**Hard limits** — limits, not targets:
+
+- One bullet per change. **Two lines of prose, ~40 words, maximum.** No sub-bullets, no
+  second paragraph. If it doesn't fit, you are explaining too much.
+- Reference the GitHub issue where one exists — `(#123)`, straight after the lead
+  phrase. Take the number from the commit's `fixes #123` / `issue #123` footer, never
+  from the PR number GitHub appends to a squashed subject. No issue, no reference.
+- Several commits that together deliver one feature get **one** bullet, not one each.
+- `Internal` is **not a second commit history** — git already has that, in more detail
+  and better indexed. It lists only internal changes that are particularly valuable,
+  disruptive, or otherwise a highlight of the release: roughly **3 entries per release,
+  one line each (~25 words)**. Everything else — test and flake fixes, refactors,
+  dependency bumps, perf tweaks, lint config, tidy-ups — gets **no entry at all**. If
+  you are unsure whether it qualifies, it doesn't.
+
+**Never in the changelog**: rationale and trade-offs; how it was implemented; file,
+function, library or framework names (outside `Internal`); edge cases; the story of how
+a bug was found; future plans; anything the lead phrase already said. Those belong in
+the commit message, an ADR or `docs/dev/`.
+
+```
+Bad  - **Interrupting a profile slide no longer restarts it**: pressing Next or Prev
+       (or swiping again) while a profile was still sliding used to snap the card back
+       to the start and replay the whole slide, putting off the arrival a little more
+       with every press. Repeated presses in the same direction now let the first slide
+       finish, a press the other way turns the card around from wherever it is, and
+       catching a sliding card with a finger picks it up where it is.
+Good - **Interrupting a profile slide no longer restarts it** (#123): pressing Next or
+       Prev mid-slide used to replay the animation from the start.
+```
+
+## In-app release notes
+
+`app/release-notes.ts` backs the footer's version button. Its first entry is the release
+being prepared, and it holds **3–5 highlights of that release — no more**.
+
+- A highlight is something a reader would want announced. If it wouldn't open a release
+  announcement, it doesn't belong: bug fixes, polish and internal work almost never do.
+- One sentence each, ~25 words, `**bold lead phrase**` first. No issue references.
+- **The list is not append-only.** Add yours when the change lands, knowing what else is
+  coming may displace it; when it is full, replace the weakest highlight rather than
+  adding a sixth.
+- Before finalizing a release, read the entry against `CHANGELOG.md` and check these
+  really are the release's most representative changes for attendees and organizers.
+  See [docs/dev/releasing.md](docs/dev/releasing.md).
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,90 +4,52 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-> **Developers**: Remember to update [`app/release-notes.ts`](app/release-notes.ts)
-> — a sentence or two for the changes an organizer or attendee cares about.
+> **Developers**: keep entries short — see [AGENTS.md § Changelog](AGENTS.md#changelog).
+> If the change is a highlight of the coming release, it also belongs in
+> [`app/release-notes.ts`](app/release-notes.ts), which holds 3-5 of them.
 
 ## [Unreleased]
 
 ### Added
 
 - **In-app notifications** (#750): a bell in the header counts what is waiting, and the
-  notifications page lists everything newest first. Clicking one marks it read and opens what
-  happened. Everything that emails you appears here too, and the email settings now govern email
-  alone — so an event with no email set up still reaches its attendees
-- **Meetings, set up by the organizer**: an event's Config tab has a new Meetings section — switch
-  1-on-1 meetings on, list the places you suggest people meet, and cap how many unanswered requests
-  one attendee may have outstanding at a time. Meeting slots follow the event's schedule increment,
-  so changing that asks attendees to choose their availability again
-- **Say when you're free to meet**: with meetings switched on, the schedule toolbar gains a
-  **1-on-1s** link where attendees turn on "I'm open to 1-on-1 meetings at this event" and clear the
-  slots they want kept free. Turning it on marks every slot free, and turning it back off clears the
-  lot — nobody can book you while it's off
-- **Ask an attendee for a 1-on-1, and answer the ones you get**: their profile gains a **Schedule a
-  meeting** button — pick one of the slots they're open for, say where to meet and add a line of
-  context. A slot where either of you is hosting or has RSVP'd is still bookable, with a warning;
-  only the slots they cleared are off limits. The person asked gets a notification with **Accept**
-  and **Decline**, and hears about their own clashes before they answer; the asker is told either
-  way. A request nobody answers before its slot begins simply lapses
+  notifications page lists everything newest first. Anything that emails you appears here
+  too, so an event with no email set up still reaches its attendees
+- **1-on-1 meetings, set up by the organizer** (#392): an event's Config tab gains a
+  Meetings section — switch 1-on-1s on, list the places you suggest people meet, and cap
+  how many unanswered requests one attendee may have out at a time
+- **Asking an attendee for a 1-on-1** (#392): attendees mark the slots they are free for
+  on the new 1-on-1s page, ask someone from their profile, and accept or decline what they
+  are asked. Both sides are told the outcome; an unanswered request lapses at its slot
 
 ### Changed
 
-- **Session save confirmations clear themselves**: the message confirming a session was added,
-  updated or deleted used to stay on screen until you closed it. It now goes away on its own
-  after ten seconds, though the close button still works
+- **Session save confirmations clear themselves** (#859): the message confirming a session
+  was added, updated or deleted now goes after ten seconds instead of waiting to be closed
 
 ### Fixed
 
-- **Event names that a site page would hide are rejected**: an event named "Guests", "Settings" or
-  "Notifications" got a web address the site's own page of that name already answers, so the event
-  could never be opened. Creating one now fails with the same message other reserved names give
-- **Picking your name works however many events a site runs**: the header lists every event, and
-  from about seven onwards the links crowded the name chip beside them off the row, leaving no way
-  to say who you are. The links now scroll instead of pushing
-- **Picking your name is less fiddly** (#777): the search box is focused as soon as the "My name is"
-  box opens, so you can type straight away, and erasing what you typed no longer closes the box on
-  you
-- **The password prompt now names the account beside the box** (#777): choosing a protected name
-  showed a "Logging in as" field only to password managers, leaving a blank password box with
-  nothing but a sentence above it to say whose password it wanted
-- **Account settings now says why enabling protection failed** (#716): on a site with no email set
-  up, "Enable protection" looked like it did nothing at all — the server's explanation was thrown
-  away instead of shown
-- **Opening a comment from an email no longer strands the page it lands on** (#930): a link to a
-  comment on a long profile could leave the profile scrolled partway under its own header, with no
-  way to scroll back up to the person's name and photo
+- **Event names a site page would hide are rejected**: an event named "Guests", "Settings"
+  or "Notifications" got a web address the site's own page of that name answers, so the
+  event could never be opened
+- **Picking your name works however many events a site runs**: from about seven events on,
+  the header's event links crowded the name chip off the row, leaving no way to say who you
+  are. The links now scroll instead of pushing
+- **Picking your name is less fiddly** (#777): the search box is focused as soon as the
+  "My name is" box opens, and erasing what you typed no longer closes the box
+- **The password prompt names the account it is asking about** (#777): choosing a protected
+  name left a blank password box with nothing to say whose password it wanted
+- **Account settings says why enabling protection failed** (#716): on a site with no email
+  set up, "Enable protection" looked like it did nothing at all
+- **A comment opened from an email no longer strands the page it lands on** (#930): a link
+  to a comment on a long profile could leave the profile scrolled under its own header
 
 ### Internal
 
-- **`make arch` checks the module graph** for circular dependencies and layer violations, using
-  dependency-cruiser. It runs as part of `make precommit`; `make arch-graph` renders the dependency
-  graph. See `docs/dev/architecture-rules.md`
-- The login rate limiter's map key no longer embeds a raw NUL byte, which made git and jj
-  treat `utils/login-rate-limit.ts` as a binary file: its diffs read "Binary files differ" and
-  `grep` skipped it
-- **Lint now bans ambient clock reads** in `app/`, `db/`, `emails/`, `model/` and `utils/`: "now"
-  has to come from the request boundary so the dev fake clock can't be silently bypassed. Deliberate
-  exceptions — the clock itself, auth expiry and throttles — are marked line by line with their
-  reason, so the rest of those files stays checked. See ADR 0004
-- Session times that the type allows to be absent now render a placeholder rather than falling back
-  to the current time or the epoch, both of which printed a plausible-looking wrong time
-- **The dev fake clock reaches proposal timestamps and the past-booking check**: a proposal created
-  under a time offset was stamped with real time, so it came out older than the comments on it — and
-  "a session must start in the future" was judged against real time too, letting a time-travelled
-  organizer book into their own past, or refusing a slot the interface still offered
-- The 1-on-1 E2E journey no longer flakes on the console guard. Answering a request refreshes the
-  page behind the modal, and the hard navigation the test made next aborted that fetch — Next then
-  logged the abort and forced a full load back to the meetings page, cancelling the navigation. The
-  test leaves by the header's Attendees link instead, which supersedes the refresh rather than
-  aborting it. The `waitForLoadState("networkidle")` it relied on was never waiting:
-  Playwright arms that event once per document load, and the modal is reached by an in-app
-  navigation
-- The first room photo on the schedule grid is loaded eagerly. It sits above the fold and is usually
-  the page's largest element, so Next warned that the Largest Contentful Paint image was being
-  lazy-loaded
-- **Lint and format skip Claude Code worktrees**: `make precommit` walked into
-  `.claude/worktrees/`, where each worktree's `.next/` produced hundreds of ESLint parsing errors
-  and Prettier rewrote another checkout's build artifacts. Both now ignore that directory
+- **`make arch` checks the module graph** (#965) for circular dependencies and layer
+  violations, and runs as part of `make precommit`. See `docs/dev/architecture-rules.md`
+- **Lint bans ambient clock reads** in `app/`, `db/`, `emails/`, `model/` and `utils/`:
+  "now" comes from the request boundary, so the dev fake clock cannot be bypassed. See ADR 0004
 
 ## [3.5.0] - 2026-08-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,14 +270,17 @@ Update `CHANGELOG.md` under `[Unreleased]` alongside any user-facing change.
 - `Security` — vulnerability fixes
 - `Internal` — dev-only changes (tooling, tests, refactors, CI) with no visible effect on organizers
 
-**Conventions**:
+**Conventions** (the full rules, with limits and examples, are in [AGENTS.md § Changelog](AGENTS.md#changelog)):
 
-- One bullet per change: short **bold** phrase naming the feature/area, then a plain-language explanation
+- One bullet per change, at most two lines: `- **Bold lead phrase** (#123): what changed, and — where it isn't obvious — what was wrong before`
+- Reference the GitHub issue when one exists, taken from the commit's `fixes #123` / `issue #123` footer (not the PR number in a squashed subject)
+- Several commits delivering one feature get one bullet between them
 - Order bullets within a section roughly by importance
 - Breaking changes: `> **Breaking change**: ...` blockquote at the top of the release
-- Skip internal refactors/tests unless they materially affect the dev workflow — then use `Internal`
+- Leave out rationale, implementation, edge cases and how a bug was found — those belong in the commit message, an ADR or `docs/dev/`
+- `Internal` is not a second commit history: only internal changes that are particularly valuable, disruptive or a highlight, around three per release, one line each
 
-The app carries a much shorter version of this: `app/release-notes.ts`, shown when the footer's version is clicked. Highlights are inline markdown, so they take the same **bold** lead phrase as the bullets here. Add yours as the change lands, to the first entry — the undated `"Unreleased"` one, shown like any other, since a deployment built from `main` is running exactly those changes. Finalizing the release only gives that entry its version and date — see [Releasing a new version](docs/dev/releasing.md).
+The app carries a much shorter version of this: `app/release-notes.ts`, shown when the footer's version is clicked. It holds **3-5 highlights** of the coming release — inline markdown, taking the same **bold** lead phrase as the bullets here. Add yours to the first entry — the undated `"Unreleased"` one — as the change lands, and replace a weaker highlight rather than adding a sixth. Finalizing the release gives that entry its version and date, after checking its highlights against this file — see [Releasing a new version](docs/dev/releasing.md).
 
 ## Documentation
 

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -1,7 +1,7 @@
-// What the footer's version button shows: a few plain sentences per recent
+// What the footer's version button shows: the 3-5 highlights of each recent
 // release, for an organizer who wants to know what changed without leaving the
-// app. Written by hand rather than derived from CHANGELOG.md, which is
-// exhaustive and far too long to read in a modal.
+// app. Written by hand rather than derived from CHANGELOG.md, which lists every
+// change and is far too long to read in a modal.
 //
 // Newest first, and one entry per release: the dates are what tells a reader
 // how old the deployment in front of them is, so a release left out makes the
@@ -12,6 +12,11 @@
 // date, written as the changes land. A deployment built from `main` is running
 // exactly those changes, so it is shown like any other entry; cutting the
 // release turns it into one by giving it its version and date.
+//
+// Highlights only, and at most five: what would open a release announcement,
+// not everything that shipped. The list is not append-only — when it is full,
+// replace the weakest highlight rather than adding a sixth, and re-read it
+// against CHANGELOG.md before finalizing the release. See AGENTS.md.
 
 export type ReleaseNote = {
   /**
@@ -41,11 +46,8 @@ export const releaseNotes: ReleaseNote[] = [
     version: "Unreleased",
     highlights: [
       "**Notifications in the app**: a bell in the header counts what is waiting, and clicking one takes you to it. Everything that emails you appears here too, even where email is not set up.",
-      "**Meetings**: an event's Config tab can switch on 1-on-1s between attendees — the places you suggest people meet, and a cap on how many unanswered requests one person may have out.",
-      "**Picking your name** works however many events a site runs: past about seven, the header's event links crowded the name chip off the row and there was no way to say who you are.",
-      "**Session save confirmations clear themselves** after ten seconds instead of waiting to be closed.",
-      "**Say when you're free**: with meetings on, attendees get a 1-on-1s page to mark which slots they're open for. Turning the switch off clears it and keeps them unbookable.",
-      "**Ask for a 1-on-1**: attendees book one of the slots someone is open for from their profile, and say where to meet. The person asked accepts or declines, warned about anything it clashes with.",
+      "**1-on-1 meetings**: organizers switch them on for an event and suggest where to meet; attendees mark when they are free, ask someone from their profile, and accept or decline.",
+      "**Picking your name works however many events a site runs**: past about seven, the header's event links crowded the name chip off the row and left no way to say who you are.",
     ],
   },
   {

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -10,7 +10,9 @@ documentation.
 
 1. **Finalize the changelog** — in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (no `v` prefix in the header), and replace the `[Unreleased]` compare link at the bottom of the file with the new version's, pointing from the previous release's endpoint to the new tag (`vX.Y.Z`). Do _not_ add a fresh `## [Unreleased]` section here — the released tag should carry no empty section, since that is what the documentation site publishes. Step 4 reopens it afterwards.
 
-   **Release the in-app notes in the same commit** — in `app/release-notes.ts`, the first entry of `releaseNotes` is the one being prepared: replace its `version: "Unreleased"` with this version and add the `date`. Nothing else moves. Verify the highlights in fact describe this release; that entry is what the footer's version button has been showing all along, so it is worth re-reading rather than assuming. `make test` fails until the newest release the changelog names has an entry.
+   **Release the in-app notes in the same commit** — in `app/release-notes.ts`, the first entry of `releaseNotes` is the one being prepared: replace its `version: "Unreleased"` with this version and add the `date`. Nothing else moves. `make test` fails until the newest release the changelog names has an entry.
+
+   **Re-read those highlights against the finalized changelog first.** They were written one at a time, before it was known what else the release would hold, so they are a draft, not a record: check that they are still the 3-5 changes an attendee or organizer would call this release's highlights, and rewrite or replace any that are not.
 
    **Record the release's database in the same commit**, so future releases are tested against an upgrade from it:
 


### PR DESCRIPTION
The changelog's Internal section had become a second, worse commit history —
eight entries retelling flake investigations — and the in-app release notes had
grown to six highlights because each change appended one instead of competing
with what was already there.

AGENTS.md now sets hard limits (two lines a bullet, ~3 Internal entries a
release, 3-5 in-app highlights, replace rather than append) and requires the
issue number from the commit footer, so a reader can find the detail that no
longer belongs in the entry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=73a9babe02e79757af4c152eab3ca04ea73b6e8f -->