### PR TITLE
Keep the schedule's scroll position across remounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   modal had finished fading in could leave it open with no way out but a reload
 - **Pull to refresh works on the schedule again** (#858): on a phone, pulling down from
   the top reloads it — a deliberate pull, so panning the grid never reloads by accident
+- **The schedule keeps your place** (#860): adding or editing a session, or coming back to
+  the schedule from another page, used to return you to its top-left corner
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -16,6 +16,7 @@ import { MeetingModalFromUrl } from "./meeting-modal";
 import type { DayWithSessions } from "../context";
 import { useDragToPan } from "./use-drag-to-pan";
 import { PullToRefresh } from "./pull-to-refresh";
+import { useScrollRestoration } from "./use-scroll-restoration";
 import Footer from "@/app/footer";
 
 export function EventDisplay() {
@@ -32,6 +33,8 @@ export function EventDisplay() {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const slotIncrement = useSlotIncrement();
   useDragToPan(scrollerRef, view === "grid");
+  // Per view: the grid and the text list have nothing in common to scroll to.
+  useScrollRestoration(scrollerRef, `${event?.slug ?? ""}:${view}`);
 
   if (!event) return <div>No event data available</div>;
 

--- a/app/(site)/[eventSlug]/use-scroll-restoration.ts
+++ b/app/(site)/[eventSlug]/use-scroll-restoration.ts
@@ -1,0 +1,65 @@
+"use client";
+import { useLayoutEffect, type RefObject } from "react";
+
+const STORAGE_PREFIX = "schedule-scroll:";
+
+/**
+ * Keeps a scroll container's position across remounts within the tab. The
+ * schedule unmounts whenever the reader leaves it (to add or edit a session,
+ * say) and mounts fresh on their return, which would otherwise land them at
+ * the top-left corner of a large grid. Restored in a layout effect so the
+ * corner never flashes by. sessionStorage rather than localStorage so a new
+ * tab still starts at the top.
+ */
+export function useScrollRestoration(
+  ref: RefObject<HTMLElement | null>,
+  key: string
+) {
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const storageKey = STORAGE_PREFIX + key;
+
+    const saved = readPosition(storageKey);
+    if (saved) {
+      el.scrollLeft = saved.left;
+      el.scrollTop = saved.top;
+    }
+
+    const onScroll = () =>
+      writePosition(storageKey, { left: el.scrollLeft, top: el.scrollTop });
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [ref, key]);
+}
+
+type Position = { left: number; top: number };
+
+// Storage can be missing or refuse writes (private mode, quota, disabled by
+// policy); losing the reader's place is a fine outcome, throwing is not.
+function readPosition(key: string): Position | null {
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as Position).left === "number" &&
+      typeof (parsed as Position).top === "number"
+    ) {
+      return parsed as Position;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writePosition(key: string, position: Position) {
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(position));
+  } catch {
+    // ignored, see above
+  }
+}

--- a/scripts/seed/data/gamma-schedule.ts
+++ b/scripts/seed/data/gamma-schedule.ts
@@ -6,6 +6,10 @@
 //   day 0: Main Hall 16:00 and Garden Terrace 09:00 (asserted free),
 //   day 2: Workshop Room from 15:00, Garden Terrace from 16:00 and Main Hall
 //          01:00 the following morning (used by tests to create sessions).
+// Two more specs book out of that day 2 Workshop Room window and must not
+// collide: rsvp.spec.ts takes 20:00, schedule-layout.spec.ts 18:00. The latter
+// clicks whichever slot the schedule happens to be scrolled to and then moves
+// the booking, so it can never take a slot another spec needs.
 // rsvp.spec.ts RSVPs Bob Test to the Opening Keynote, so nothing may run in
 // parallel to it and Bob gets no seeded RSVP there (see RSVP seeding).
 export interface GammaSessionConfig {

--- a/tests/e2e/helpers/session-form.ts
+++ b/tests/e2e/helpers/session-form.ts
@@ -1,0 +1,18 @@
+import { Page } from "@playwright/test";
+
+// The session form's labels are not wired to their inputs, so locate each
+// listbox through its labelled section (same approach as the hosts combobox in
+// add-session.spec.ts).
+export function listboxButton(page: Page, section: RegExp) {
+  return page
+    .locator("div")
+    .filter({ hasText: section })
+    .first()
+    .getByRole("button")
+    .first();
+}
+
+export const dayRadios = (page: Page) =>
+  page.getByRole("radio", {
+    name: /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/,
+  });

--- a/tests/e2e/schedule-layout.spec.ts
+++ b/tests/e2e/schedule-layout.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 import { swipe } from "./helpers/touch";
+import { selectUser } from "./helpers/user";
+import { uniqueSuffix } from "./helpers/unique";
+import { dayRadios, listboxButton } from "./helpers/session-form";
 
 // The grid view is an "app frame": below the nav bar a single scroll
 // container owns the viewport, with a slim toolbar as its first row. The
@@ -307,4 +310,88 @@ test.describe("pull to refresh", () => {
     await swipe(scroller, { by: 0, down: 220 });
     await stillThere();
   });
+});
+
+test("the grid keeps its place after a session is added from it", async ({
+  page,
+}) => {
+  // A drag, a form round trip and a re-render, on a phone-sized viewport.
+  test.slow();
+  await selectUser(page, /Alice Test/i);
+  const scroller = page.getByTestId("schedule-scroll");
+  const position = () =>
+    scroller.evaluate((el) => [
+      Math.round(el.scrollLeft),
+      Math.round(el.scrollTop),
+    ]);
+
+  // Pan well into the schedule on both axes by dragging it (see the test
+  // above); unlike wheeling, which Firefox applies asynchronously, the pan
+  // lands as soon as the mouse is released.
+  const frame = (await scroller.boundingBox())!;
+  const right = frame.x + frame.width - 40;
+  const bottom = frame.y + frame.height - 40;
+  await page.mouse.move(right, bottom);
+  await page.mouse.down();
+  await page.mouse.move(right - 240, bottom - 400, { steps: 8 });
+  await page.mouse.up();
+  const before = await position();
+  expect(before[0]).toBeGreaterThan(80);
+  expect(before[1]).toBeGreaterThan(300);
+
+  // Click a slot that is on screen: clicking one out of view would scroll it
+  // in first, and that scroll — not the reader's — is what would then be
+  // brought back. Measured in a single pass inside the page rather than a
+  // boundingBox() round trip per link, of which there are hundreds.
+  const slots = page.getByRole("link", { name: "Add session" });
+  const onScreen = await slots.evaluateAll(
+    (links, f) =>
+      links.findIndex((link) => {
+        const r = link.getBoundingClientRect();
+        return (
+          r.left >= f.x &&
+          r.top >= f.y &&
+          r.right <= f.x + f.width &&
+          r.bottom <= f.y + f.height
+        );
+      }),
+    frame
+  );
+  // Rather than falling back to the first slot, which is off screen: clicking
+  // that scrolls it in, leaving the test asserting that a scroll the reader
+  // never made was restored.
+  expect(onScreen, "no free slot lies wholly inside the grid").toBeGreaterThan(
+    -1
+  );
+  await slots.nth(onScreen).click();
+  await expect(
+    page.getByRole("heading", { name: /Add a session/i })
+  ).toBeVisible();
+  await page
+    .getByRole("textbox")
+    .first()
+    .fill(`E2E Scroll Anchor Session ${uniqueSuffix()}`);
+
+  // Book a slot reserved for this test rather than the one that was clicked:
+  // which slot the drag lands on depends on the layout, while the grid is
+  // shared with the specs that reserve slots in it (see the contract at the
+  // top of scripts/seed/data/gamma-schedule.ts). Only the click had to land on
+  // screen, so moving the booking costs the test nothing — and it keeps the
+  // new session off the stretch of grid whose scroll position is measured.
+  //
+  // 18:00 (offered as "18:10", slot plus break) on the last day: past
+  // scheduling.spec.ts's 15:00 booking in this room and its hour, and still
+  // earlier than rsvp.spec.ts's 20:00 one, whose "the other specs all book
+  // earlier" this must not break.
+  await dayRadios(page).last().check();
+  await listboxButton(page, /^Location/).click();
+  await page.getByRole("option", { name: /Workshop Room/ }).click();
+  await listboxButton(page, /^Start Time/).click();
+  await page.getByRole("option", { name: "18:10", exact: true }).click();
+
+  await page.getByRole("button", { name: "Submit" }).click();
+
+  // Back on the schedule, still looking at the same corner of it.
+  await expect(page.getByRole("button", { name: "Grid" })).toBeVisible();
+  await expect.poll(position).toEqual(before);
 });


### PR DESCRIPTION
Fixes schellingboard/schellingboard#860.

Leaving the schedule for the add/edit-session pages unmounts the grid, and the fresh mount on return started at the top-left corner. The scroll container now saves its position to `sessionStorage` on every scroll and restores it in a layout effect on mount, keyed by event and view, so adding or editing a session (or any other page round trip in the same tab) lands the reader back where they were.

- New `use-scroll-restoration.ts` hook, wired into `EventDisplay`
- E2E test in `schedule-layout.spec.ts`: pans the grid, books an on-screen slot, expects the same position on return (red before the fix)
- Changelog and release-notes entries

Claude wrote this PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
