### PR TITLE
fix: a clash of theirs says they are booked, and nothing more

### DIFF
--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -199,9 +199,9 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
               </p>
             )}
 
-            {/* The same fact the requester was shown when they booked it, from
-                the other side: the person answering knows whether their own
-                session matters more (issue #392, section 1.4). */}
+            {/* The requester saw only that the slot was taken; the person
+                answering sees what it is, so they can weigh it against the
+                request (issue #392, section 1.4). */}
             {meeting.clashes.length > 0 && (
               <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
                 {[...new Set(meeting.clashes.map(clashLine))].join("; ")} during

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -218,10 +218,11 @@ Anyone who is open to meetings has a **Schedule a meeting** button on their
 profile. It shows their slots day by day:
 
 - **Available** — tap to pick it.
-- **Busy** — one of you is hosting a session then, has RSVP'd to one, or has
-  already agreed another 1-on-1. Still bookable: you get a warning naming the
-  clash, and decide for yourselves. You are never told which session someone
-  else RSVP'd to, only that they are busy.
+- **Busy** — one of you already has something at that hour: a session you are
+  hosting or have RSVP'd to, or another 1-on-1. Still bookable: you get a
+  warning and decide for yourselves. Your own clash is named — the session, or
+  that it is another 1-on-1 — so you know what you would be missing. Theirs
+  never is: you are only told they are already booked.
 - **Unavailable** — a slot they cleared. That is their decision, and the one
   thing you can't book.
 
@@ -241,7 +242,8 @@ Declining takes no explanation — nobody should feel obliged.
 
 If the slot clashes with something of yours, the request says so before you
 answer: you are the one who knows whether your own session matters more. The
-person who asked was shown the same clash when they booked it.
+person who asked was warned about the same slot, without being told what you
+have on.
 
 You can't change the time or the place — accept it or decline it, and let them
 ask again if it doesn't suit. Either way they are told. A request nobody answers

--- a/tests/integration/meeting-options.test.ts
+++ b/tests/integration/meeting-options.test.ts
@@ -127,7 +127,8 @@ describe("meeting options on a profile", () => {
     expect(slotAt(option, SLOT_B).state).toBe("unavailable");
   });
 
-  it("marks a slot busy when they are hosting, and names the session", async () => {
+  // Not even a session they are hosting in public: the hour is taken, no more.
+  it("marks a slot busy without naming what they are doing", async () => {
     const { event, other } = await scenario();
     await createSession(event.id, {
       title: "Their talk",
@@ -140,8 +141,86 @@ describe("meeting options on a profile", () => {
 
     const slot = slotAt(option, SLOT_A);
     expect(slot.state).toBe("busy");
-    expect(slot.clashes[0].kind).toBe("hosting");
-    expect(slot.clashes[0].title).toBe("Their talk");
+    expect(slot.clashes[0].kind).toBe("busy");
+    expect(slot.clashes[0].title).toBeNull();
+    expect(JSON.stringify(option)).not.toContain("Their talk");
+  });
+
+  // The warning covers either party, and the viewer's own is marked so it can
+  // say "You are hosting" rather than name the reader back to themselves.
+  it("names the viewer's own session and still marks the slot busy", async () => {
+    const { event, viewer, other } = await scenario();
+    await createSession(event.id, {
+      title: "My own talk",
+      hostIds: [viewer.id],
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    const slot = slotAt(option, SLOT_A);
+    expect(slot.state).toBe("busy");
+    expect(slot.clashes[0]).toEqual({
+      guestName: viewer.name,
+      kind: "hosting",
+      title: "My own talk",
+      isViewer: true,
+    });
+  });
+
+  // Your own diary is no third party's secret: you are told what you would be
+  // missing, whether you are hosting it or only going.
+  it("names a session the viewer only RSVP'd to", async () => {
+    const { event, viewer, other } = await scenario();
+    const mine = await createSession(event.id, {
+      title: "My own RSVP",
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+    await getRepositories().rsvps.create({
+      sessionId: mine.id,
+      guestId: viewer.id,
+    });
+
+    const [option] = await listMeetingOptions(other.id);
+
+    const slot = slotAt(option, SLOT_A);
+    expect(slot.state).toBe("busy");
+    expect(slot.clashes[0]).toEqual({
+      guestName: viewer.name,
+      kind: "attending",
+      title: "My own RSVP",
+      isViewer: true,
+    });
+  });
+
+  it("reports the viewer's own 1-on-1 as one, not as bare busy", async () => {
+    const { event, viewer, other } = await scenario();
+    const third = await createGuest({ name: "Kai", eventId: event.id });
+    const repos = getRepositories();
+    const meeting = await repos.meetings.create({
+      eventId: event.id,
+      requesterId: viewer.id,
+      recipientId: third.id,
+      slotStart: new Date(SLOT_A),
+      slotEnd: new Date(SLOT_B),
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: DAY_START,
+    });
+    await repos.meetings.updateStatus(meeting.id, "accepted", DAY_START, [
+      "pending",
+    ]);
+
+    const [option] = await listMeetingOptions(other.id);
+
+    expect(slotAt(option, SLOT_A).clashes[0]).toEqual({
+      guestName: viewer.name,
+      kind: "meeting",
+      title: null,
+      isViewer: true,
+    });
   });
 
   it("never names a session they only RSVP'd to", async () => {
@@ -164,25 +243,6 @@ describe("meeting options on a profile", () => {
     expect(JSON.stringify(option)).not.toContain("Secret RSVP session");
   });
 
-  // The warning covers either party: your own clash matters to you too.
-  it("marks a slot busy when the viewer is the one with the clash", async () => {
-    const { event, viewer, other } = await scenario();
-    await createSession(event.id, {
-      title: "My own talk",
-      hostIds: [viewer.id],
-      startTime: new Date(SLOT_A),
-      endTime: new Date(SLOT_B),
-    });
-
-    const [option] = await listMeetingOptions(other.id);
-
-    const slot = slotAt(option, SLOT_A);
-    expect(slot.state).toBe("busy");
-    // Marked so the warning can say "You are hosting", not name the reader
-    // back to themselves in the third person.
-    expect(slot.clashes[0].isViewer).toBe(true);
-  });
-
   it("does not mark the other party's clash as the viewer's own", async () => {
     const { event, other } = await scenario();
     await createSession(event.id, {
@@ -195,6 +255,37 @@ describe("meeting options on a profile", () => {
     const [option] = await listMeetingOptions(other.id);
 
     expect(slotAt(option, SLOT_A).clashes[0].isViewer).toBe(false);
+  });
+
+  it("collapses everything the other party has on into one entry", async () => {
+    const { event, other } = await scenario();
+    const third = await createGuest({ name: "Kai", eventId: event.id });
+    const repos = getRepositories();
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [other.id],
+      startTime: new Date(SLOT_A),
+      endTime: new Date(SLOT_B),
+    });
+    const meeting = await repos.meetings.create({
+      eventId: event.id,
+      requesterId: other.id,
+      recipientId: third.id,
+      slotStart: new Date(SLOT_A),
+      slotEnd: new Date(SLOT_B),
+      meetingPoint: "Coffee bar",
+      message: "",
+      createdAt: DAY_START,
+    });
+    await repos.meetings.updateStatus(meeting.id, "accepted", DAY_START, [
+      "pending",
+    ]);
+
+    const [option] = await listMeetingOptions(other.id);
+
+    expect(slotAt(option, SLOT_A).clashes).toEqual([
+      { guestName: "Yuki", kind: "busy", title: null, isViewer: false },
+    ]);
   });
 
   it("says nothing when they are open to no slots at all", async () => {

--- a/tests/integration/meeting-views.test.ts
+++ b/tests/integration/meeting-views.test.ts
@@ -99,7 +99,7 @@ describe("meetingViewsFor", () => {
     expect(view.status).toBe("accepted");
   });
 
-  it("names a session either party is hosting in the slot", async () => {
+  it("names a session the viewer is hosting in the slot", async () => {
     const { event, requester, recipient } = await scenario();
     const room = await createLocation({ eventId: event.id });
     await createSession(event.id, {
@@ -117,6 +117,54 @@ describe("meetingViewsFor", () => {
       {
         guestName: "Grace",
         kind: "hosting",
+        title: "Microservices for Dummies",
+        isViewer: true,
+      },
+    ]);
+  });
+
+  // It used to be named here too, on the grounds that the schedule shows it.
+  it("reduces a session the other party is hosting to busy", async () => {
+    const { event, requester, recipient } = await scenario();
+    const room = await createLocation({ eventId: event.id });
+    await createSession(event.id, {
+      title: "Microservices for Dummies",
+      hostIds: [requester.id],
+      locationIds: [room.id],
+      startTime: SLOT_START,
+      endTime: SLOT_END,
+    });
+    await meetingBetween(event, requester, recipient);
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.clashes).toEqual([
+      { guestName: "Ada", kind: "busy", title: null, isViewer: false },
+    ]);
+    expect(JSON.stringify(view)).not.toContain("Microservices for Dummies");
+  });
+
+  it("names a session the viewer only RSVP'd to", async () => {
+    const { event, requester, recipient } = await scenario();
+    const room = await createLocation({ eventId: event.id });
+    const mine = await createSession(event.id, {
+      title: "Microservices for Dummies",
+      locationIds: [room.id],
+      startTime: SLOT_START,
+      endTime: SLOT_END,
+    });
+    await getRepositories().rsvps.create({
+      sessionId: mine.id,
+      guestId: recipient.id,
+    });
+    await meetingBetween(event, requester, recipient);
+
+    const [view] = await meetingViewsFor(recipient.id, event.id, BEFORE);
+
+    expect(view.clashes).toEqual([
+      {
+        guestName: "Grace",
+        kind: "attending",
         title: "Microservices for Dummies",
         isViewer: true,
       },

--- a/tests/unit/meeting-clash-text.test.ts
+++ b/tests/unit/meeting-clash-text.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+
+import { clashLine, toMeetingClashes } from "@/utils/meeting-clash-text";
+
+describe("toMeetingClashes", () => {
+  const hosting = {
+    guestId: "grace",
+    guestName: "Grace",
+    kind: "hosting" as const,
+    title: "Microservices for Dummies",
+  };
+  const meeting = {
+    guestId: "grace",
+    guestName: "Grace",
+    kind: "meeting" as const,
+    title: null,
+  };
+
+  it("keeps the viewer's own commitment, title and all", () => {
+    expect(toMeetingClashes([hosting], "grace")).toEqual([
+      {
+        guestName: "Grace",
+        kind: "hosting",
+        title: "Microservices for Dummies",
+        isViewer: true,
+      },
+    ]);
+  });
+
+  // What someone else has on at that hour is theirs to tell. The browser is
+  // told they are taken and nothing else -- not the session, not whether they
+  // are hosting it, RSVP'd to it or meeting someone else.
+  it("reduces anyone else's to the bare fact that they are taken", () => {
+    expect(toMeetingClashes([hosting], "ada")).toEqual([
+      { guestName: "Grace", kind: "busy", title: null, isViewer: false },
+    ]);
+  });
+
+  // How many things they have on is as much theirs as what those things are.
+  it("collapses what redacts to the same thing", () => {
+    expect(toMeetingClashes([hosting, meeting], "ada")).toEqual([
+      { guestName: "Grace", kind: "busy", title: null, isViewer: false },
+    ]);
+  });
+});
+
+describe("clashLine", () => {
+  it("names the viewer's own session", () => {
+    expect(
+      clashLine({
+        guestName: "Grace",
+        kind: "hosting",
+        title: "Microservices for Dummies",
+        isViewer: true,
+      })
+    ).toBe("You are hosting Microservices for Dummies");
+  });
+
+  it("names a session the viewer only RSVP'd to", () => {
+    expect(
+      clashLine({
+        guestName: "Grace",
+        kind: "attending",
+        title: "Microservices for Dummies",
+        isViewer: true,
+      })
+    ).toBe("You are attending Microservices for Dummies");
+  });
+
+  it("says the viewer's other 1-on-1 is one", () => {
+    expect(
+      clashLine({
+        guestName: "Grace",
+        kind: "meeting",
+        title: null,
+        isViewer: true,
+      })
+    ).toBe("You have another 1-on-1");
+  });
+
+  it("says only that the other person is booked", () => {
+    expect(
+      clashLine({
+        guestName: "Grace",
+        kind: "busy",
+        title: null,
+        isViewer: false,
+      })
+    ).toBe("Grace is already booked");
+  });
+
+  it("says the viewer is busy when there is nothing to name", () => {
+    expect(
+      clashLine({
+        guestName: "Ada",
+        kind: "busy",
+        title: null,
+        isViewer: true,
+      })
+    ).toBe("You are busy");
+  });
+});

--- a/utils/guest-clashes.ts
+++ b/utils/guest-clashes.ts
@@ -3,16 +3,14 @@ import type { Meeting, Session } from "@/db/repositories/interfaces";
 import { newEmptySession, sessionsOverlap } from "@/app/(site)/session_utils";
 import { getStartTimePlusBreak } from "./utils";
 
-// A schedule clash for one guest, computed server-side so their private RSVPs
-// and meetings never reach the client. Hosting a session is public, so those
-// clashes name the session; RSVP'd sessions and agreed 1-on-1s are private, so
-// those only report that the guest is "busy" for the overlapping interval —
-// never which session, or who the meeting is with.
+// A schedule clash for one guest, computed server-side so their RSVPs and
+// meetings never reach the client. Only `detailFor`'s RSVPs and 1-on-1s are
+// described; everyone else's collapse to "busy" with no title.
 export type GuestClash = {
   guestId: string;
   guestName: string;
-  kind: "hosting" | "busy";
-  /** Only set for hosting clashes (public); null for busy/RSVP clashes. */
+  kind: "hosting" | "attending" | "meeting" | "busy";
+  /** The session, for a hosting or attending clash; null otherwise. */
   title: string | null;
   /** ISO strings; `start` is break-adjusted for display, matching the schedule. */
   start: string;
@@ -73,6 +71,9 @@ export function clashesForInterval(
     excludeSessionId?: string | null;
     /** The meeting being examined, which must not clash with itself. */
     excludeMeetingId?: string;
+    /** Whose own diary may be described in full: an RSVP or 1-on-1 of theirs
+        is no secret from them, though it is from everyone else. */
+    detailFor?: string;
   }
 ): GuestClash[] {
   const {
@@ -82,6 +83,7 @@ export function clashesForInterval(
     breakMinutes,
     excludeSessionId,
     excludeMeetingId,
+    detailFor,
   } = opts;
 
   // sessionsOverlap skips a session whose id matches the candidate's, which is
@@ -106,6 +108,7 @@ export function clashesForInterval(
   const clashes: GuestClash[] = [];
 
   for (const schedule of schedules) {
+    const describe = schedule.guestId === detailFor;
     const hostingClashes = schedule.hosted.filter(inEventAndOverlapping);
     const hostingIds = new Set(hostingClashes.map((s) => s.id));
 
@@ -126,8 +129,8 @@ export function clashesForInterval(
       clashes.push({
         guestId: schedule.guestId,
         guestName: schedule.guestName,
-        kind: "busy",
-        title: null,
+        kind: describe ? "attending" : "busy",
+        title: describe ? ses.title : null,
         start: getStartTimePlusBreak(ses.startTime, breakMinutes).toISO()!,
         end: ses.endTime.toISOString(),
       });
@@ -148,7 +151,7 @@ export function clashesForInterval(
       clashes.push({
         guestId: schedule.guestId,
         guestName: schedule.guestName,
-        kind: "busy",
+        kind: describe ? "meeting" : "busy",
         title: null,
         start: meeting.slotStart.toISOString(),
         end: meeting.slotEnd.toISOString(),

--- a/utils/meeting-clash-text.ts
+++ b/utils/meeting-clash-text.ts
@@ -1,22 +1,60 @@
+export type ClashKind = "hosting" | "attending" | "meeting" | "busy";
+
+type GuestClashInput = {
+  guestId: string;
+  guestName: string;
+  kind: ClashKind;
+  title: string | null;
+};
+
 /**
- * A clash as the browser sees one: who is busy and, for a hosted session
- * (public), what with. RSVP'd sessions and agreed 1-on-1s carry no title, so
- * one attendee never learns another's private commitments — see GuestClash.
+ * A clash as the browser sees one: only the reader's own commitment is
+ * described, so anyone else's arrives as the bare fact that they are taken.
  */
 export type MeetingClash = {
   guestName: string;
-  kind: "hosting" | "busy";
+  kind: ClashKind;
   title: string | null;
   /** The viewer's own clash, so the line can say "you" rather than naming
       the reader back to themselves in the third person. */
   isViewer: boolean;
 };
 
-/** "Yuki is hosting Their talk" / "You are busy". */
+/**
+ * Redacted here rather than at render time: a title dropped in the browser
+ * would still have been in the payload. Entries that redact to the same thing
+ * collapse, so the count does not report how many commitments they have.
+ */
+export function toMeetingClashes(
+  clashes: GuestClashInput[],
+  viewerId: string
+): MeetingClash[] {
+  const distinct = new Map<string, MeetingClash>();
+  for (const clash of clashes) {
+    const isViewer = clash.guestId === viewerId;
+    const mapped: MeetingClash = {
+      guestName: clash.guestName,
+      kind: isViewer ? clash.kind : "busy",
+      title: isViewer ? clash.title : null,
+      isViewer,
+    };
+    const key = [
+      mapped.guestName,
+      mapped.kind,
+      mapped.title,
+      mapped.isViewer,
+    ].join("\u0000");
+    if (!distinct.has(key)) distinct.set(key, mapped);
+  }
+  return [...distinct.values()];
+}
+
+/** "You are hosting Their talk" / "Yuki is already booked". */
 export function clashLine(clash: MeetingClash): string {
-  const who = clash.isViewer ? "You" : clash.guestName;
-  const is = clash.isViewer ? "are" : "is";
-  return clash.kind === "hosting" && clash.title
-    ? `${who} ${is} hosting ${clash.title}`
-    : `${who} ${is} busy`;
+  if (!clash.isViewer) return `${clash.guestName} is already booked`;
+  if (clash.kind === "meeting") return "You have another 1-on-1";
+  if (!clash.title) return "You are busy";
+  return clash.kind === "hosting"
+    ? `You are hosting ${clash.title}`
+    : `You are attending ${clash.title}`;
 }

--- a/utils/meeting-options.ts
+++ b/utils/meeting-options.ts
@@ -2,6 +2,7 @@ import { getRepositories } from "@/db/container";
 import { serverNow } from "@/utils/dev-clock-server";
 import { meetingSlotsForDay } from "@/utils/meeting-slots";
 import { clashesForInterval, loadGuestSchedules } from "@/utils/guest-clashes";
+import { toMeetingClashes } from "@/utils/meeting-clash-text";
 import type { MeetingClash } from "@/utils/meeting-clash-text";
 import { DateTime } from "luxon";
 import type { Event, MeetingPoint } from "@/db/repositories/interfaces";
@@ -105,18 +106,14 @@ export async function meetingOptionsFor(
           start: slot.start,
           end: slot.end,
           breakMinutes: event.breakMinutes,
+          detailFor: viewerId,
         });
         slots.push({
           start,
           label,
           // Busy is a warning, never a wall: still selectable.
           state: clashes.length > 0 ? "busy" : "available",
-          clashes: clashes.map(({ guestId, guestName, kind, title }) => ({
-            guestName,
-            kind,
-            title,
-            isViewer: guestId === viewerId,
-          })),
+          clashes: toMeetingClashes(clashes, viewerId),
         });
       }
       if (slots.length > 0) {

--- a/utils/meeting-views.ts
+++ b/utils/meeting-views.ts
@@ -2,6 +2,7 @@ import { DateTime } from "luxon";
 import { getRepositories } from "@/db/container";
 import type { MeetingStatus } from "@/db/repositories/interfaces";
 import { clashesForInterval, loadGuestSchedules } from "@/utils/guest-clashes";
+import { toMeetingClashes } from "@/utils/meeting-clash-text";
 import type { MeetingClash } from "@/utils/meeting-clash-text";
 
 /**
@@ -76,6 +77,7 @@ export async function meetingViewsFor(
       start: meeting.slotStart,
       end: meeting.slotEnd,
       breakMinutes: event.breakMinutes,
+      detailFor: viewerId,
       // An accepted meeting counts as busy, so without this every one of them
       // would report itself as its own clash.
       excludeMeetingId: meeting.id,
@@ -97,12 +99,7 @@ export async function meetingViewsFor(
       ).toFormat("HH:mm")}`,
       meetingPoint: meeting.meetingPoint,
       message: meeting.message,
-      clashes: clashes.map(({ guestId, guestName, kind, title }) => ({
-        guestName,
-        kind,
-        title,
-        isViewer: guestId === viewerId,
-      })),
+      clashes: toMeetingClashes(clashes, viewerId),
     };
   });
 }


### PR DESCRIPTION
Part of schellingboard/schellingboard#392, from the review of schellingboard/schellingboard-legacy#943. Against `main`; nothing else depends on it.

Booking a 1-on-1 warned "Priya is hosting Quiet co-working during this slot", on the grounds
that a hosted session is public anyway. Public in the schedule is not the same as answering
"what is Priya doing at 14:30?" for anyone who opens a slot picker, and the warning only needs
to say the hour is taken.

Anyone but the reader now arrives as "already booked": no title, and the hosting/busy
distinction flattened to busy, done in `toMeetingClash` on the server so the title never
reaches the browser. The reader's own clash keeps its detail — it is their own diary, and
knowing which of their sessions they would be missing is the point of warning them at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
