### PR TITLE
fix: the slot picker's buttons line up

### DIFF
--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -22,7 +22,10 @@ function SlotList({
       {days.map((day) => (
         <section key={day.label} aria-label={day.label} className="mb-4">
           <h3 className="text-sm font-semibold text-fg mb-1">{day.label}</h3>
-          <ul className="flex flex-wrap gap-2">
+          {/* Fixed columns rather than a wrapping row: every label is the
+              same shape, so buttons sized to their own text came out a few
+              pixels apart and no two columns lined up. */}
+          <ul className="grid grid-cols-2 gap-2 sm:grid-cols-5">
             {day.slots.map((slot) => {
               const unavailable = slot.state === "unavailable";
               const isSelected = selected === slot.start;
@@ -33,7 +36,7 @@ function SlotList({
                     disabled={unavailable}
                     aria-pressed={isSelected}
                     onClick={() => onSelect(slot.start)}
-                    className={`rounded-md border px-2 py-1 text-sm transition-colors ${
+                    className={`flex h-full min-h-12 w-full flex-col items-center justify-center rounded-md border px-1 py-1 text-sm tabular-nums transition-colors ${
                       isSelected
                         ? "border-brand bg-brand text-on-brand"
                         : unavailable
@@ -43,7 +46,7 @@ function SlotList({
                             : "border-line bg-surface-raised text-fg hover:bg-surface-hover"
                     }`}
                   >
-                    {slot.label}
+                    <span className="whitespace-nowrap">{slot.label}</span>
                     {unavailable && (
                       <span className="block text-xs">Unavailable</span>
                     )}


### PR DESCRIPTION
Part of schellingboard/schellingboard#392. **Stacked on schellingboard/schellingboard-legacy#978** only to keep the chain linear; independent of it.

Each slot button in the profile's slot picker was sized to its own label, and in a proportional
face "10:00 – 10:30" and "11:00 – 11:30" are not the same width — so the rows came out ragged,
and an available slot, with no second line, was shorter than the busy one beside it. The slots
are now a grid of fixed columns, five wide and two on a phone, every button full width and the
height of its row, with tabular digits and the time kept on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
