### PR TITLE
test: the profile-comment notification reads its own row

### DIFF
--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -38,24 +38,34 @@ test("a comment on your profile becomes a notification you can open", async ({
   await actAs(page, /Anna Kowalska/i);
   await commentOnProfile(page, "Isabella Rossi", "great to meet you");
 
+  // Isabella hosts a session other specs comment on, so this test reads its
+  // own row rather than the badge's count: unread is not hers alone.
   await actAs(page, /Isabella Rossi/i);
-  await expect(bell(page)).toHaveAccessibleName(/1 unread/);
+  await expect(bell(page)).toHaveAccessibleName(/unread/);
 
   await bell(page).click();
   await expect(
     page.getByRole("heading", { name: "Notifications" })
   ).toBeVisible();
-  const notification = page.getByRole("button", {
-    name: /Anna Kowalska commented on your profile/,
-  });
+  // .first(): a retry of this test comments a second time, and the earlier
+  // notification is still in the shared database.
+  const notification = page
+    .getByRole("button", { name: /Anna Kowalska commented on your profile/ })
+    .first();
   await expect(notification).toBeVisible();
+  const row = page
+    .getByRole("listitem")
+    .filter({ hasText: "Anna Kowalska commented on your profile" })
+    .first();
 
   // Opening it marks it read and lands on the profile it is about.
   await notification.click();
   await expect(
     page.getByRole("dialog", { name: "Isabella Rossi" })
   ).toBeVisible();
-  await expect(bell(page)).toHaveAccessibleName("Notifications");
+  await expect(row.getByRole("button", { name: "Mark as read" })).toHaveCount(
+    0
+  );
 });
 
 test("marks a notification read without opening it", async ({ page }) => {


### PR DESCRIPTION
Test-only. **Stacked on #979** to keep the chain linear; independent of it.

Isabella hosts a session other specs comment on, so her unread count is not this test's alone —
the same hazard the test below it already works around for Hana. It now asserts that its own
row is there and stops being unread, rather than that the badge says exactly one. The row
locator takes `.first()` as well: a retry comments a second time, and the first notification is
still in the shared database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
