### PR TITLE
feat: find the attendees who are open to 1-on-1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Asking an attendee for a 1-on-1** (#392): attendees mark the slots they are free for
   on the new 1-on-1s page, ask someone from their profile, and accept or decline what they
   are asked. Both sides are told the outcome; an unanswered request lapses at its slot
+- **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
+  beside Session host and Has profile. It covers every event on the site, not only this one
 
 ### Changed
 

--- a/app/(site)/guests/(directory)/layout.tsx
+++ b/app/(site)/guests/(directory)/layout.tsx
@@ -19,8 +19,8 @@ export default async function AttendeeDirectoryLayout({
   // happen in the browser (see directory-view.ts). `listAttendees` returns
   // public profile fields only — `Attendee` has no `info`, so no email can
   // reach the client payload this way.
-  const attendees = await getRepositories().guests.listAttendees();
   const now = await serverNow();
+  const attendees = await getRepositories().guests.listAttendees(now);
   const cookieStore = await cookies();
   const currentUser = await verifiedCurrentUser(cookieStore);
 

--- a/app/(site)/guests/directory-view.ts
+++ b/app/(site)/guests/directory-view.ts
@@ -73,7 +73,8 @@ export function useDirectoryView(attendees: Attendee[], now: Date) {
     const scoped = cards.filter(
       (card) =>
         (!filters.includes("isHost") || card.isHost) &&
-        (!filters.includes("hasProfile") || card.hasProfile)
+        (!filters.includes("hasProfile") || card.hasProfile) &&
+        (!filters.includes("openToMeetings") || card.openToMeetings)
     );
     return searchAttendees(scoped, query, sort);
   }, [cards, filters, query, sort]);

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -296,6 +296,8 @@ export type GuestPage = {
 /** A guest with information used in the attendees list */
 export type Attendee = Guest & {
   isHost: boolean;
+  /** Bookable for 1-on-1s somewhere on the site — the directory is global. */
+  openToMeetings: boolean;
 };
 
 export interface GuestsRepository {
@@ -324,9 +326,10 @@ export interface GuestsRepository {
    * session), ordered by name with id tiebreaker. Search, filtering, sorting
    * and pagination all happen in memory on top of this, in the browser (see
    * app/(site)/guests/directory-view.ts): attendee counts don't warrant a SQL
-   * or persisted search index.
+   * or persisted search index. `now` bounds `openToMeetings`: availability whose
+   * slots have all passed leaves nothing anyone can book.
    */
-  listAttendees(): Promise<Attendee[]>;
+  listAttendees(now: Date): Promise<Attendee[]>;
   /**
    * Assigned events for many guests in one query, ordered by event name.
    * Every requested id is present in the result; guests without assignments

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -2,6 +2,7 @@ import {
   and,
   eq,
   exists,
+  gt,
   inArray,
   isNotNull,
   isNull,
@@ -181,12 +182,39 @@ export class SqliteGuestsRepository implements GuestsRepository {
     return { rows, total: totalRow?.count ?? 0 };
   }
 
-  async listAttendees(): Promise<Attendee[]> {
+  async listAttendees(now: Date): Promise<Attendee[]> {
     const isHostExpr = exists(
       this.db
         .select({ one: sql`1` })
         .from(schema.sessionHosts)
         .where(eq(schema.sessionHosts.guestId, schema.guests.id))
+    );
+
+    // Someone a viewer could actually ask, not someone who once said yes:
+    // declared rows outlive the organizer's switch, the guest's place on the
+    // event, and the slots themselves.
+    const openToMeetingsExpr = exists(
+      this.db
+        .select({ one: sql`1` })
+        .from(schema.meetingAvailability)
+        .innerJoin(
+          schema.events,
+          eq(schema.events.id, schema.meetingAvailability.eventId)
+        )
+        .innerJoin(
+          schema.eventGuests,
+          and(
+            eq(schema.eventGuests.eventId, schema.meetingAvailability.eventId),
+            eq(schema.eventGuests.guestId, schema.meetingAvailability.guestId)
+          )
+        )
+        .where(
+          and(
+            eq(schema.meetingAvailability.guestId, schema.guests.id),
+            eq(schema.events.meetingsEnabled, true),
+            gt(schema.meetingAvailability.slotStart, now.toISOString())
+          )
+        )
     );
 
     return (
@@ -205,6 +233,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
           // SQLite has no boolean type; this yields 0/1 at runtime despite the
           // sql<boolean> annotation, so coerce explicitly below.
           isHost: isHostExpr,
+          openToMeetings: openToMeetingsExpr,
         })
         .from(schema.guests)
         // id as tiebreaker so equal names keep a deterministic order.
@@ -215,6 +244,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
             ({
               ...row,
               isHost: Boolean(row.isHost),
+              openToMeetings: Boolean(row.openToMeetings),
               profileUpdatedAt: row.profileUpdatedAt
                 ? new Date(row.profileUpdatedAt)
                 : null,

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -258,6 +258,9 @@ opening anything.
 
 ![Searchable attendee directory with avatars, bios, and Session host badges](../screenshots/attendees.webp)
 
+- **Filters** narrow the list to session hosts, to people who have filled in a
+  profile, or to anyone **open to 1-on-1s** — anyone with slots still to come,
+  at any event on the site rather than only this one.
 - **Search covers everything on a profile**: names, pronouns, bios, languages,
   where someone is based, prompts and answers, and any contact details they
   published. A remembered handle, a service name like "Signal", or a shared

--- a/tests/integration/guest-search-attendees.test.ts
+++ b/tests/integration/guest-search-attendees.test.ts
@@ -4,6 +4,11 @@ import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const now = new Date("2026-06-15T12:00:00.000Z");
+const lastWeek = new Date(now.getTime() - 7 * DAY_MS);
+const nextWeek = new Date(now.getTime() + 7 * DAY_MS);
+
 describe("guests.listAttendees", () => {
   beforeAll(() => setupTestDb());
   beforeEach(() => resetTestDb());
@@ -15,11 +20,80 @@ describe("guests.listAttendees", () => {
     await createSession(event.id, { hostIds: [host.id] });
     const repos = getRepositories();
 
-    const rows = await repos.guests.listAttendees();
+    const rows = await repos.guests.listAttendees(now);
 
     const byName = Object.fromEntries(rows.map((r) => [r.name, r.isHost]));
     expect(byName["Host Person"]).toBe(true);
     expect(byName["Regular Person"]).toBe(false);
+  });
+
+  it("flags anyone bookable at any event where 1-on-1s are on", async () => {
+    const repos = getRepositories();
+    const on = await createEvent();
+    const off = await createEvent({ name: "Meetings Off" });
+    await repos.events.update(on.id, { meetingsEnabled: true });
+    const open = await createGuest({ name: "Open Person", eventId: on.id });
+    const stale = await createGuest({ name: "Stale Person", eventId: off.id });
+    await createGuest({ name: "Regular Person", eventId: on.id });
+    const slot = [nextWeek];
+    await repos.meetingAvailability.replaceForGuest(open.id, on.id, slot);
+    // Declared while it was on, and the organizer has since switched it off.
+    await repos.meetingAvailability.replaceForGuest(stale.id, off.id, slot);
+
+    const rows = await repos.guests.listAttendees(now);
+
+    const byName = Object.fromEntries(
+      rows.map((r) => [r.name, r.openToMeetings])
+    );
+    expect(byName["Open Person"]).toBe(true);
+    expect(byName["Stale Person"]).toBe(false);
+    expect(byName["Regular Person"]).toBe(false);
+  });
+
+  it("stops flagging someone whose declared slots have all passed", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    await repos.events.update(event.id, { meetingsEnabled: true });
+    const over = await createGuest({ name: "Over Person", eventId: event.id });
+    const ahead = await createGuest({
+      name: "Ahead Person",
+      eventId: event.id,
+    });
+    await repos.meetingAvailability.replaceForGuest(over.id, event.id, [
+      lastWeek,
+    ]);
+    await repos.meetingAvailability.replaceForGuest(ahead.id, event.id, [
+      lastWeek,
+      nextWeek,
+    ]);
+
+    const rows = await repos.guests.listAttendees(now);
+
+    const byName = Object.fromEntries(
+      rows.map((r) => [r.name, r.openToMeetings])
+    );
+    expect(byName["Over Person"]).toBe(false);
+    expect(byName["Ahead Person"]).toBe(true);
+  });
+
+  it("stops flagging someone taken off the event they declared for", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    await repos.events.update(event.id, { meetingsEnabled: true });
+    const dropped = await createGuest({
+      name: "Dropped Person",
+      eventId: event.id,
+    });
+    await repos.meetingAvailability.replaceForGuest(dropped.id, event.id, [
+      nextWeek,
+    ]);
+    await repos.guests.removeFromEvent(event.id, [dropped.id]);
+
+    const rows = await repos.guests.listAttendees(now);
+
+    expect(rows.find((r) => r.name === "Dropped Person")?.openToMeetings).toBe(
+      false
+    );
   });
 
   it("orders by name and never exposes the private email", async () => {
@@ -28,7 +102,7 @@ describe("guests.listAttendees", () => {
     }
     const repos = getRepositories();
 
-    const rows = await repos.guests.listAttendees();
+    const rows = await repos.guests.listAttendees(now);
 
     expect(rows.map((r) => r.name)).toEqual(["A", "B", "C", "D", "E"]);
     for (const row of rows) {
@@ -55,7 +129,7 @@ describe("guests.listAttendees", () => {
       new Date()
     );
 
-    const rows = await repos.guests.listAttendees();
+    const rows = await repos.guests.listAttendees(now);
 
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
@@ -86,7 +160,7 @@ describe("guests.listAttendees", () => {
       updatedAt
     );
 
-    const rows = await repos.guests.listAttendees();
+    const rows = await repos.guests.listAttendees(now);
 
     const byName = Object.fromEntries(
       rows.map((r) => [r.name, r.profileUpdatedAt])

--- a/tests/integration/release-upgrade.test.ts
+++ b/tests/integration/release-upgrade.test.ts
@@ -90,7 +90,7 @@ describe.each(dumps)("upgrading from $version", (dump) => {
 
     const allEvents = await events.list();
     expect(allEvents).not.toHaveLength(0);
-    expect(await guests.listAttendees()).not.toHaveLength(0);
+    expect(await guests.listAttendees(new Date())).not.toHaveLength(0);
 
     const proposals = (
       await Promise.all(

--- a/tests/unit/attendee-filters.test.ts
+++ b/tests/unit/attendee-filters.test.ts
@@ -21,6 +21,9 @@ describe("attendee filters", () => {
   });
 
   it("serializes in a fixed order, so the same view is always the same URL", () => {
+    expect(
+      serializeAttendeeFilters(["openToMeetings", "hasProfile", "isHost"])
+    ).toBe("isHost,hasProfile,openToMeetings");
     expect(serializeAttendeeFilters(["hasProfile", "isHost"])).toBe(
       "isHost,hasProfile"
     );

--- a/tests/unit/attendee-profile.test.ts
+++ b/tests/unit/attendee-profile.test.ts
@@ -9,6 +9,7 @@ function attendee(overrides: Partial<Attendee> & { name: string }): Attendee {
   return {
     id: `id-${++counter}`,
     isHost: false,
+    openToMeetings: false,
     info: undefined,
     ...overrides,
   };

--- a/tests/unit/attendee-search.test.ts
+++ b/tests/unit/attendee-search.test.ts
@@ -9,6 +9,7 @@ function attendee(overrides: Partial<Attendee> & { name: string }): Attendee {
   return {
     id: `id-${++counter}`,
     isHost: false,
+    openToMeetings: false,
     info: undefined,
     ...overrides,
   };

--- a/utils/attendee-filters.ts
+++ b/utils/attendee-filters.ts
@@ -5,6 +5,7 @@
 export const ATTENDEE_FILTERS = [
   { value: "isHost", label: "Session host" },
   { value: "hasProfile", label: "Has profile" },
+  { value: "openToMeetings", label: "Open to 1-on-1s" },
 ] as const;
 
 export type AttendeeFilter = (typeof ATTENDEE_FILTERS)[number]["value"];


### PR DESCRIPTION
Part of schellingboard/schellingboard#945 — note 9 of @omarkohl's UX notes on schellingboard/schellingboard-legacy#943. **Stacked on schellingboard/schellingboard-legacy#980** to keep the
chain linear; independent of it.

A third filter chip in the attendee directory, **Open to 1-on-1s**, beside Session host and Has
profile. Global rather than scoped to one event, which is why the flag rides on the attendee
row: the directory is the whole site's, and "who is up for 1-on-1s at all" is how someone
browses it looking for people to meet.

**Bookable means declared availability at an event that still offers meetings** — rows outlive
the organizer's switch, and someone nobody can book is not open to anything, whatever they once
declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
