### PR TITLE
refactor: a 1-on-1 is called that wherever an attendee reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   on the new 1-on-1s page, ask someone from their profile, and accept or decline what they
   are asked. Both sides are told the outcome; an unanswered request lapses at its slot
 - **Your 1-on-1s on the schedule** (#392): the grid's first column is yours alone — agreed
-  meetings and open requests, beside whatever they clash with. Tap one to open or cancel it
+  1-on-1s and open requests, beside whatever they clash with. Tap one to open or cancel it
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
   beside Session host and Has profile. It covers every event on the site, not only this one
 

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -35,7 +35,7 @@ function statusLine(meeting: MeetingView): string {
         ? "You declined this."
         : `${them} declined this.`;
     case "canceled":
-      return "This meeting was canceled.";
+      return "This 1-on-1 was canceled.";
     case "expired":
       // Nobody is at fault for an unanswered request, so it is not phrased as
       // one: the slot simply came and went (issue #392, section 1.4).
@@ -114,7 +114,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
       className="fixed inset-0 z-50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"
-      aria-label="Meeting details"
+      aria-label="1-on-1 details"
     >
       <div className="fixed inset-0 bg-overlay" onClick={dismissViewMeeting} />
       <div className="relative bg-surface-raised rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto p-6">
@@ -142,7 +142,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
         {meetings === null ? (
           <p className="text-fg-muted">Loading…</p>
         ) : !meeting ? (
-          <p className="text-fg-muted">Meeting not found.</p>
+          <p className="text-fg-muted">1-on-1 not found.</p>
         ) : (
           <div className="flex flex-col gap-4">
             <h2 className="text-xl font-bold text-fg pr-8">
@@ -247,7 +247,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                   onClick={() => setConfirmingCancel(true)}
                   className={`${SECONDARY_BUTTON} self-start`}
                 >
-                  Cancel meeting
+                  Cancel 1-on-1
                 </button>
               ))}
 

--- a/app/(site)/[eventSlug]/meetings/availability-form.tsx
+++ b/app/(site)/[eventSlug]/meetings/availability-form.tsx
@@ -94,12 +94,12 @@ export function AvailabilityForm({
   return (
     <form
       onSubmit={handleSave}
-      aria-label="1-on-1 meetings"
+      aria-label="1-on-1s"
       className="max-w-2xl mx-auto w-full px-4 sm:px-0 flex flex-col gap-6 py-8"
     >
       <BackLink href={`/${eventSlug}`}>Schedule</BackLink>
       <div>
-        <h1 className="text-3xl font-bold text-fg">1-on-1 meetings</h1>
+        <h1 className="text-3xl font-bold text-fg">1-on-1s</h1>
         <p className="text-fg-muted mt-2">{eventName}</p>
       </div>
 
@@ -116,7 +116,7 @@ export function AvailabilityForm({
           />
           <div>
             <label htmlFor="meetings-open" className="font-medium text-fg">
-              I&apos;m open to 1-on-1 meetings at this event
+              I&apos;m open to 1-on-1s at this event
             </label>
             <p className="text-sm text-fg-subtle">
               While this is off, nobody can book you and you won&apos;t appear
@@ -137,7 +137,7 @@ export function AvailabilityForm({
 
           {days.length === 0 && (
             <p className="text-fg-muted">
-              The organizer hasn&apos;t set up any days with meeting slots yet.
+              The organizer hasn&apos;t set up any days with 1-on-1 slots yet.
             </p>
           )}
 

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -55,7 +55,7 @@ export default async function MeetingsPage({
       <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
         {await unverifiedUserMessage(
           cookieStore,
-          "setting your meeting availability"
+          "setting your 1-on-1 availability"
         )}
       </PageNotice>
     );
@@ -68,7 +68,7 @@ export default async function MeetingsPage({
     return (
       <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
         You&apos;re not on the guest list for {event.name}, so you can&apos;t
-        set meeting availability here. Ask the organizer to add you.
+        set 1-on-1 availability here. Ask the organizer to add you.
       </PageNotice>
     );
   }

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -128,7 +128,7 @@ function RequestForm({
   return (
     <form onSubmit={handleSend} className="flex flex-col gap-4">
       <h2 className="text-xl font-bold text-fg">
-        Meet {recipientName}
+        1-on-1 with {recipientName}
         <span className="block text-sm font-normal text-fg-muted">
           {option.eventName}
         </span>
@@ -227,7 +227,7 @@ function RequestForm({
 }
 
 /**
- * "Schedule a meeting" on an attendee's profile — one button per event the
+ * "Schedule a 1-on-1" on an attendee's profile — one button per event the
  * pair share where meetings are on and they are bookable, so nothing shows at
  * all when there is nothing to book.
  */
@@ -256,8 +256,8 @@ export function MeetingPicker({
           className={SECONDARY_BUTTON}
         >
           {options.length === 1
-            ? "Schedule a meeting"
-            : `Schedule a meeting at ${option.eventName}`}
+            ? "Schedule a 1-on-1"
+            : `Schedule a 1-on-1 at ${option.eventName}`}
         </button>
       ))}
       {/* Opened from inside the profile modal, which is z-50: without the

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -61,8 +61,8 @@ export function SettingsForm({
       {/* Availability is per-event, so it cannot live here -- but this is
           where people look for it first. */}
       <p className="text-sm text-fg-subtle">
-        Setting when you&apos;re free for 1-on-1 meetings is per event: open the
-        event and use its <strong>1-on-1s</strong> link.
+        Setting when you&apos;re free for 1-on-1s is per event: open the event
+        and use its <strong>1-on-1s</strong> link.
       </p>
 
       <form
@@ -108,11 +108,11 @@ export function SettingsForm({
           </label>
           <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("meetingRequest")} />
-            someone asks me for a 1-on-1 meeting
+            someone asks me for a 1-on-1
           </label>
           <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("meetingResponse")} />a
-            1-on-1 meeting of mine is accepted, declined or canceled
+            1-on-1 of mine is accepted, declined or canceled
           </label>
         </fieldset>
 

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -72,10 +72,10 @@ export async function requestMeetingAction(
 
   const requesterId = await verifiedCurrentUser(await cookies());
   if (!requesterId) {
-    return { ok: false, error: "Sign in to request a meeting" };
+    return { ok: false, error: "Sign in to request a 1-on-1" };
   }
   if (requesterId === input.recipientId) {
-    return { ok: false, error: "You can't book a meeting with yourself" };
+    return { ok: false, error: "You can't book a 1-on-1 with yourself" };
   }
 
   // Presets are a convenience, not a constraint -- but "we'll figure it out"
@@ -89,7 +89,7 @@ export async function requestMeetingAction(
   const event = await repos.events.findById(input.eventId);
   if (!event) return { ok: false, error: "Event not found" };
   if (!event.meetingsEnabled) {
-    return { ok: false, error: "Meetings are not enabled for this event" };
+    return { ok: false, error: "1-on-1s are not enabled for this event" };
   }
 
   const attending = await repos.guests.listEventsByGuests([
@@ -179,12 +179,12 @@ export async function respondToMeetingAction(
 
   const guestId = await verifiedCurrentUser(await cookies());
   if (!guestId) {
-    return { ok: false, error: "Sign in to answer a meeting request" };
+    return { ok: false, error: "Sign in to answer a 1-on-1 request" };
   }
 
   const repos = getRepositories();
   const meeting = await repos.meetings.findById(input.meetingId);
-  if (!meeting) return { ok: false, error: "Meeting not found" };
+  if (!meeting) return { ok: false, error: "1-on-1 not found" };
   // Only the person asked can answer; the requester's own control is cancelling.
   if (meeting.recipientId !== guestId) {
     return { ok: false, error: "Only the person asked can answer this" };
@@ -237,15 +237,15 @@ export async function cancelMeetingAction(
 
   const guestId = await verifiedCurrentUser(await cookies());
   if (!guestId) {
-    return { ok: false, error: "Sign in to cancel a meeting" };
+    return { ok: false, error: "Sign in to cancel a 1-on-1" };
   }
 
   const repos = getRepositories();
   const meeting = await repos.meetings.findById(input.meetingId);
-  if (!meeting) return { ok: false, error: "Meeting not found" };
+  if (!meeting) return { ok: false, error: "1-on-1 not found" };
   const isRequester = meeting.requesterId === guestId;
   if (!isRequester && meeting.recipientId !== guestId) {
-    return { ok: false, error: "This isn't your meeting" };
+    return { ok: false, error: "This isn't your 1-on-1" };
   }
 
   const now = await serverNow();
@@ -307,7 +307,7 @@ export async function saveMeetingAvailabilityAction(
       ok: false,
       error: await unverifiedUserMessage(
         cookieStore,
-        "setting your meeting availability"
+        "setting your 1-on-1 availability"
       ),
     };
   }
@@ -316,7 +316,7 @@ export async function saveMeetingAvailabilityAction(
   const event = await repos.events.findById(input.eventId);
   if (!event) return { ok: false, error: "Event not found" };
   if (!event.meetingsEnabled) {
-    return { ok: false, error: "Meetings are not enabled for this event" };
+    return { ok: false, error: "1-on-1s are not enabled for this event" };
   }
 
   const attending = await repos.guests.listEventsByGuests([guestId]);

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -48,7 +48,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Install it on your phone**: add the site to your home screen and it opens like an app, in its own window with no address bar.",
       "**Notifications on your phone**: Settings can send the notifications you already get to your phone or laptop, so they arrive while the site is closed. iPhones need it on the home screen first.",
       "**Notifications in the app**: a bell counts what is waiting, and clicking one takes you to it. Tick the ones you are done with to mark them read or delete them. No email set-up needed.",
-      "**1-on-1 meetings**: organizers switch them on and suggest where to meet; attendees mark when they are free, ask someone from their profile, accept or decline, and see them on the schedule.",
+      "**1-on-1s**: organizers switch them on and suggest where to meet; attendees mark when they are free, ask someone from their profile, accept or decline, and see them on the schedule.",
       '**The schedule shows where you are in the day**: a red line marks the current time while the event is running, and a "Now" button jumps to it.',
     ],
   },

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -186,15 +186,15 @@ Open a session to find the same comment section proposals have — useful for
 "which room did this move to?" and other last-minute coordination. Everything works as described under
 [Discuss a proposal](#discuss-a-proposal): threaded replies, likes, editing and deleting your own comments.
 
-## 1-on-1 meetings
+## 1-on-1s
 
-When the organizer has switched meetings on for the event, the schedule toolbar
+When the organizer has switched 1-on-1s on for the event, the schedule toolbar
 gains a **1-on-1s** link. That page is where you say when you are free to meet
 people one to one.
 
 One switch controls the whole thing:
 
-> **I'm open to 1-on-1 meetings at this event**
+> **I'm open to 1-on-1s at this event**
 
 While it is off, nobody can book you and you don't appear as bookable — it is
 the opt-out, so turning it back off and saving clears what you declared.
@@ -212,9 +212,9 @@ Slots are as long as the event's schedule increment and cover the whole of each
 day. If the organizer later changes that increment, everyone's availability is
 cleared and you are asked to choose again — the slots themselves have moved.
 
-### Ask someone for a meeting
+### Ask someone for a 1-on-1
 
-Anyone who is open to meetings has a **Schedule a meeting** button on their
+Anyone who is open to 1-on-1s has a **Schedule a 1-on-1** button on their
 profile. It shows their slots day by day:
 
 - **Available** — tap to pick it.
@@ -249,7 +249,7 @@ You can't change the time or the place — accept it or decline it, and let them
 ask again if it doesn't suit. Either way they are told. A request nobody answers
 before its slot begins simply lapses; nothing is held against you.
 
-### Your meetings on the schedule
+### Your 1-on-1s on the schedule
 
 Once the event reaches its scheduling phase, your 1-on-1s get the **first
 column of the schedule grid**, before the rooms: the other person's name, where
@@ -263,7 +263,7 @@ once you take part at all — open to 1-on-1s, or with one arranged — so the
 rooms line up from day to day, and it isn't there at all otherwise. It also
 shows the slots you are not offering. Declined and lapsed requests drop off it.
 
-Tap one to open it. That is also where either of you can **cancel** a meeting
+Tap one to open it. That is also where either of you can **cancel** a 1-on-1
 you had agreed, or take back a request nobody has answered yet, up until the
 slot begins; the other person is told.
 

--- a/emails/meeting.tsx
+++ b/emails/meeting.tsx
@@ -74,7 +74,7 @@ export function meetingOutcomeEmail(props: {
           </p>
         )}
         <p>
-          <a href={props.url}>View the meeting</a>
+          <a href={props.url}>View the 1-on-1</a>
         </p>
       </>
     ),

--- a/tests/e2e/meetings-availability.spec.ts
+++ b/tests/e2e/meetings-availability.spec.ts
@@ -105,12 +105,12 @@ test.describe("attendee meeting availability", () => {
     await expect(page).toHaveURL(/\/meetings$/);
     const eventSlug = new URL(page.url()).pathname.split("/")[1];
 
-    const form = page.getByRole("form", { name: "1-on-1 meetings" });
-    await expect(form.getByLabel(/open to 1-on-1 meetings/)).not.toBeChecked();
+    const form = page.getByRole("form", { name: "1-on-1s" });
+    await expect(form.getByLabel(/open to 1-on-1s/)).not.toBeChecked();
 
     // Switching it on marks every slot available; you clear what you want kept
     // free rather than building the set up from nothing.
-    await form.getByLabel(/open to 1-on-1 meetings/).check();
+    await form.getByLabel(/open to 1-on-1s/).check();
     await expect(form.getByText("09:00 – 09:30")).toBeVisible();
     const firstSlot = form.getByRole("listitem").first().getByRole("checkbox");
     await expect(firstSlot).toBeChecked();
@@ -120,7 +120,7 @@ test.describe("attendee meeting availability", () => {
     await expect(form.getByText("Saved!")).toBeVisible();
 
     await page.reload();
-    await expect(form.getByLabel(/open to 1-on-1 meetings/)).toBeChecked();
+    await expect(form.getByLabel(/open to 1-on-1s/)).toBeChecked();
     await expect(
       form.getByRole("listitem").first().getByRole("checkbox")
     ).not.toBeChecked();
@@ -152,11 +152,11 @@ test.describe("attendee meeting availability", () => {
     await expect(form.getByText("Saved!")).toBeVisible();
 
     // Opting back out clears the declaration entirely.
-    await form.getByLabel(/open to 1-on-1 meetings/).uncheck();
+    await form.getByLabel(/open to 1-on-1s/).uncheck();
     await form.getByRole("button", { name: "Save availability" }).click();
     await expect(form.getByText("Saved!")).toBeVisible();
     await page.reload();
-    await expect(form.getByLabel(/open to 1-on-1 meetings/)).not.toBeChecked();
+    await expect(form.getByLabel(/open to 1-on-1s/)).not.toBeChecked();
   });
 
   // The save action refuses a non-attendee, but the page used to render the
@@ -180,9 +180,7 @@ test.describe("attendee meeting availability", () => {
     await page.goto(`/${slug}/meetings`);
 
     await expect(page.getByText(/not on the guest list/i)).toBeVisible();
-    await expect(
-      page.getByRole("form", { name: "1-on-1 meetings" })
-    ).toBeHidden();
+    await expect(page.getByRole("form", { name: "1-on-1s" })).toBeHidden();
   });
 
   test("is not offered while the organizer keeps meetings off", async ({

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -230,15 +230,15 @@ test.describe("1-on-1 meetings", () => {
     await actAs(page, new RegExp(asker));
     await openProfile(page, askee);
     await expect(
-      page.getByRole("button", { name: /schedule a meeting/i })
+      page.getByRole("button", { name: /schedule a 1-on-1/i })
     ).toBeHidden();
 
     // The askee declares they are open to meetings.
     await page.goto(`/${slug}/meetings`);
     await actAs(page, new RegExp(askee));
     await page.goto(`/${slug}/meetings`);
-    const availability = page.getByRole("form", { name: "1-on-1 meetings" });
-    await availability.getByLabel(/open to 1-on-1 meetings/).check();
+    const availability = page.getByRole("form", { name: "1-on-1s" });
+    await availability.getByLabel(/open to 1-on-1s/).check();
     await availability
       .getByRole("button", { name: "Save availability" })
       .click();
@@ -248,7 +248,7 @@ test.describe("1-on-1 meetings", () => {
     await actAs(page, new RegExp(asker));
     await openProfile(page, askee);
 
-    const schedule = page.getByRole("button", { name: /schedule a meeting/i });
+    const schedule = page.getByRole("button", { name: /schedule a 1-on-1/i });
     await expect(schedule).toBeVisible();
     await schedule.click();
 
@@ -277,7 +277,7 @@ test.describe("1-on-1 meetings", () => {
       })
       .click();
 
-    const meeting = page.getByRole("dialog", { name: "Meeting details" });
+    const meeting = page.getByRole("dialog", { name: "1-on-1 details" });
     await expect(meeting).toBeVisible();
     await expect(meeting.getByText("Coffee bar")).toBeVisible();
     await meeting.getByRole("button", { name: "Accept" }).click();
@@ -308,7 +308,7 @@ test.describe("1-on-1 meetings", () => {
     ).toBeVisible();
 
     await openProfile(page, askee);
-    await page.getByRole("button", { name: /schedule a meeting/i }).click();
+    await page.getByRole("button", { name: /schedule a 1-on-1/i }).click();
     const sendAgain = page.getByRole("button", { name: "Send request" });
     await expect(sendAgain).toBeVisible();
     await page.getByRole("button", { name: "Coffee bar" }).click();
@@ -351,7 +351,7 @@ test.describe("1-on-1 meetings", () => {
     await page.goto(`/${slug}`);
     await page.getByRole("link", { name: new RegExp(askee) }).click();
     await expect(
-      page.getByRole("dialog", { name: "Meeting details" })
+      page.getByRole("dialog", { name: "1-on-1 details" })
     ).toBeVisible();
     await page.keyboard.press("Escape");
 
@@ -362,7 +362,7 @@ test.describe("1-on-1 meetings", () => {
       })
       .click();
     const fromNotification = page.getByRole("dialog", {
-      name: "Meeting details",
+      name: "1-on-1 details",
     });
     await expect(fromNotification).toBeVisible();
     await page.keyboard.press("Escape");
@@ -373,8 +373,8 @@ test.describe("1-on-1 meetings", () => {
     // Either of them can call it off from the block on the schedule.
     await page.goto(`/${slug}`);
     await page.getByRole("link", { name: new RegExp(askee) }).click();
-    const confirmed = page.getByRole("dialog", { name: "Meeting details" });
-    await confirmed.getByRole("button", { name: "Cancel meeting" }).click();
+    const confirmed = page.getByRole("dialog", { name: "1-on-1 details" });
+    await confirmed.getByRole("button", { name: "Cancel 1-on-1" }).click();
     await confirmed.getByRole("button", { name: "Yes, cancel it" }).click();
     await expect(confirmed.getByText(/was canceled/)).toBeVisible();
     await page.keyboard.press("Escape");


### PR DESCRIPTION
Part of schellingboard/schellingboard#392 — note 4 of @omarkohl's UX notes on schellingboard/schellingboard-legacy#943. **Stacked on schellingboard/schellingboard-legacy#943**.

The profile's button, the request form's title, the modal's name and its buttons, the action
errors and the email settings all said "meeting"; the notifications, the column and the guide
already said 1-on-1. One word now. The organizer's Config section keeps its "Meetings" heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
