### PR TITLE
feat: hovering a 1-on-1 block tells the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   on the new 1-on-1s page, ask someone from their profile, and accept or decline what they
   are asked. Both sides are told the outcome; an unanswered request lapses at its slot
 - **Your 1-on-1s on the schedule** (#392): the grid's first column is yours alone — agreed
-  1-on-1s and open requests, beside whatever they clash with. Tap one to open or cancel it
+  1-on-1s and open requests. Hover for what it clashes with, tap to open or cancel it
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
   beside Session host and Has profile. It covers every event on the site, not only this one
 

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -14,34 +14,10 @@ import {
   SECONDARY_BUTTON,
 } from "@/app/components/buttons";
 import { EventContext } from "@/app/(site)/context";
-import { clashLine } from "@/utils/meeting-clash-text";
-import { canCancel } from "@/utils/meeting-rules";
-import type { MeetingView } from "@/utils/meeting-views";
+import { clashLines } from "@/utils/meeting-clash-text";
+import { canCancel, statusLine } from "@/utils/meeting-rules";
 import { dismissViewMeeting } from "./modal-nav";
 import { useMyMeetings } from "./use-meetings";
-
-/** What has become of the request, in the words of whoever is reading. */
-function statusLine(meeting: MeetingView): string {
-  const them = meeting.otherName;
-  switch (meeting.status) {
-    case "pending":
-      return meeting.role === "recipient"
-        ? `${them} is waiting for your answer.`
-        : `Waiting for ${them} to answer.`;
-    case "accepted":
-      return "Confirmed — see you there.";
-    case "declined":
-      return meeting.role === "recipient"
-        ? "You declined this."
-        : `${them} declined this.`;
-    case "canceled":
-      return "This 1-on-1 was canceled.";
-    case "expired":
-      // Nobody is at fault for an unanswered request, so it is not phrased as
-      // one: the slot simply came and went (issue #392, section 1.4).
-      return "Nobody answered before the slot began.";
-  }
-}
 
 /**
  * The meeting modal wherever `?viewMeeting=` can be opened — the meetings page
@@ -175,8 +151,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
                 request (issue #392, section 1.4). */}
             {meeting.clashes.length > 0 && (
               <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
-                {[...new Set(meeting.clashes.map(clashLine))].join("; ")} during
-                this slot.
+                {clashLines(meeting.clashes)} during this slot.
               </p>
             )}
 

--- a/app/(site)/[eventSlug]/meetings-col.tsx
+++ b/app/(site)/[eventSlug]/meetings-col.tsx
@@ -9,8 +9,47 @@ import type { MeetingView } from "@/utils/meeting-views";
 import { meetingColumnRows } from "@/utils/meeting-column";
 import type { DayWithSessions } from "@/app/(site)/context";
 import { EventContext, useSlotIncrement } from "@/app/(site)/context";
+import { clashLines } from "@/utils/meeting-clash-text";
+import { statusLine } from "@/utils/meeting-rules";
 import { viewMeetingLinkFromOwner } from "./modal-nav";
 import { NowLine } from "./now-line";
+import { Tooltip } from "./tooltip";
+
+/** The word of status a block has room for; the tooltip says the rest. */
+function blockStatus(meeting: MeetingView): string {
+  if (meeting.status === "accepted") return "confirmed";
+  return meeting.role === "recipient"
+    ? "needs your reply"
+    : "waiting for reply";
+}
+
+// What the block has no room for, on hover -- the pattern a session block
+// already follows. A tap still opens the modal, where all of it is anyway.
+function MeetingSummary({ meeting }: { meeting: MeetingView }) {
+  return (
+    <div className="p-2 space-y-1">
+      <p className="text-sm font-semibold text-fg">
+        1-on-1 with {meeting.otherName}
+      </p>
+      <p className="text-xs text-fg-muted">
+        {meeting.timeLabel} · {meeting.meetingPoint}
+      </p>
+      <p className="text-xs text-fg">{statusLine(meeting)}</p>
+      {meeting.message && (
+        // Up to 2000 characters, and the panel has no height to
+        // spare: unclamped it pushes the clash below the fold.
+        <p className="text-xs text-fg-muted line-clamp-3">
+          “{meeting.message}”
+        </p>
+      )}
+      {meeting.clashes.length > 0 && (
+        <p className="text-xs text-fg">
+          {clashLines(meeting.clashes)} during this slot.
+        </p>
+      )}
+    </div>
+  );
+}
 
 /**
  * The viewer's own 1-on-1s for one day, as the grid's first column, beside
@@ -73,35 +112,53 @@ export function MeetingsCol({
               className={`row-span-${span} flex gap-0.5 my-0.5`}
             >
               {atRow.map((meeting) => (
-                <Link
+                <Tooltip
                   key={meeting.id}
-                  {...viewMeetingLinkFromOwner(
-                    searchParams,
-                    eventSlug,
-                    meeting.id
-                  )}
-                  className={clsx(
-                    "flex-1 min-w-0 rounded px-1 py-0.5 overflow-hidden font-roboto",
-                    meeting.status === "accepted"
-                      ? "bg-brand-tint border-2 border-brand-accent"
-                      : // Pending reads as unfinished business, not a plan.
-                        "bg-surface-muted border-2 border-dashed border-line"
-                  )}
+                  content={<MeetingSummary meeting={meeting} />}
+                  className="flex flex-1 min-w-0"
+                  triggerClassName="flex flex-1 min-w-0"
+                  noTap
                 >
-                  <p className="font-medium text-xs leading-[1.15] line-clamp-1 text-fg">
-                    {meeting.otherName}
-                  </p>
-                  <p className="text-[10px] leading-[1.15] line-clamp-1 text-fg-muted">
-                    {meeting.meetingPoint}
-                  </p>
-                  <p className="text-[10px] leading-[1.15] text-fg-subtle">
-                    {meeting.status === "accepted"
-                      ? "confirmed"
-                      : meeting.role === "recipient"
-                        ? "needs your reply"
-                        : "waiting for reply"}
-                  </p>
-                </Link>
+                  <Link
+                    {...viewMeetingLinkFromOwner(
+                      searchParams,
+                      eventSlug,
+                      meeting.id
+                    )}
+                    className={clsx(
+                      "flex-1 min-w-0 rounded px-1 py-0.5 overflow-hidden font-roboto",
+                      meeting.status === "accepted"
+                        ? "bg-brand-tint border-2 border-brand-accent"
+                        : // Pending reads as unfinished business, not a plan.
+                          "bg-surface-muted border-2 border-dashed border-line"
+                    )}
+                  >
+                    <p className="font-medium text-xs leading-[1.15] line-clamp-1 text-fg">
+                      {meeting.otherName}
+                    </p>
+                    {span > 1 ? (
+                      <>
+                        <p className="text-[10px] leading-[1.15] line-clamp-1 text-fg-muted">
+                          {meeting.meetingPoint}
+                        </p>
+                        <p className="text-[10px] leading-[1.15] text-fg-subtle">
+                          {blockStatus(meeting)}
+                        </p>
+                      </>
+                    ) : (
+                      // One slot fits a name and one more line; the place gives
+                      // way first, since the state is what may want answering.
+                      <p className="flex gap-1 text-[10px] leading-[1.15] text-fg-subtle">
+                        <span className="truncate text-fg-muted">
+                          {meeting.meetingPoint}
+                        </span>
+                        <span className="shrink-0">
+                          · {blockStatus(meeting)}
+                        </span>
+                      </p>
+                    )}
+                  </Link>
+                </Tooltip>
               ))}
             </div>
           )

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -5,7 +5,7 @@ import { Modal } from "@/app/components/modal";
 import { Input } from "@/app/input";
 import { requestMeetingAction } from "@/app/actions/meetings";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
-import { clashLine } from "@/utils/meeting-clash-text";
+import { clashLines } from "@/utils/meeting-clash-text";
 import type { MeetingDayOption, MeetingOption } from "@/utils/meeting-options";
 
 function SlotList({
@@ -147,8 +147,7 @@ function RequestForm({
       {/* A clash is raised, never enforced: the pair decide for themselves. */}
       {slot?.state === "busy" && (
         <p className="text-sm rounded-md bg-warning-tint p-3 text-fg">
-          {[...new Set(slot.clashes.map(clashLine))].join("; ")} during this
-          slot — book it anyway?
+          {clashLines(slot.clashes)} during this slot — book it anyway?
         </p>
       )}
 

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -263,9 +263,10 @@ once you take part at all — open to 1-on-1s, or with one arranged — so the
 rooms line up from day to day, and it isn't there at all otherwise. It also
 shows the slots you are not offering. Declined and lapsed requests drop off it.
 
-Tap one to open it. That is also where either of you can **cancel** a 1-on-1
-you had agreed, or take back a request nobody has answered yet, up until the
-slot begins; the other person is told.
+Hovering one shows what the block has no room for — the time, their line of
+context, and anything it clashes with. Tap one to open it. That is also where
+either of you can **cancel** a 1-on-1 you had agreed, or take back a request
+nobody has answered yet, up until the slot begins; the other person is told.
 
 ## Attendee directory & profiles
 

--- a/tests/unit/meeting-clash-text.test.ts
+++ b/tests/unit/meeting-clash-text.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { clashLine, toMeetingClashes } from "@/utils/meeting-clash-text";
+import {
+  clashLine,
+  clashLines,
+  toMeetingClashes,
+  type MeetingClash,
+} from "@/utils/meeting-clash-text";
 
 describe("toMeetingClashes", () => {
   const hosting = {
@@ -98,5 +103,23 @@ describe("clashLine", () => {
         isViewer: true,
       })
     ).toBe("You are busy");
+  });
+});
+
+describe("clashLines", () => {
+  it("says each distinct line once, in order", () => {
+    const theirs: MeetingClash = {
+      isViewer: false,
+      guestName: "Yuki",
+      kind: "busy",
+      title: null,
+    };
+    expect(
+      clashLines([
+        { isViewer: true, guestName: "Me", kind: "hosting", title: "Talk" },
+        theirs,
+        theirs,
+      ])
+    ).toBe("You are hosting Talk; Yuki is already booked");
   });
 });

--- a/tests/unit/meeting-rules.test.ts
+++ b/tests/unit/meeting-rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { canCancel } from "@/utils/meeting-rules";
+import { canCancel, statusLine } from "@/utils/meeting-rules";
 
 const NOW = new Date("2026-10-01T09:00:00.000Z");
 const LATER = "2026-10-01T10:00:00.000Z";
@@ -49,6 +49,46 @@ describe("canCancel", () => {
       expect(
         canCancel({ status, role: "requester", slotStart: LATER }, NOW)
       ).toBe(false);
+    }
+  });
+});
+
+describe("statusLine", () => {
+  const them = { otherName: "Yuki" };
+
+  it("tells each side whose turn it is", () => {
+    expect(statusLine({ ...them, status: "pending", role: "recipient" })).toBe(
+      "Yuki is waiting for your answer."
+    );
+    expect(statusLine({ ...them, status: "pending", role: "requester" })).toBe(
+      "Waiting for Yuki to answer."
+    );
+  });
+
+  it("names who declined", () => {
+    expect(statusLine({ ...them, status: "declined", role: "recipient" })).toBe(
+      "You declined this."
+    );
+    expect(statusLine({ ...them, status: "declined", role: "requester" })).toBe(
+      "Yuki declined this."
+    );
+  });
+
+  // Nobody is at fault for an unanswered request (issue #392, section 1.4).
+  it("blames nobody for a lapsed request", () => {
+    expect(statusLine({ ...them, status: "expired", role: "recipient" })).toBe(
+      "Nobody answered before the slot began."
+    );
+  });
+
+  it("says the same to both sides once it is settled", () => {
+    for (const role of ["requester", "recipient"] as const) {
+      expect(statusLine({ ...them, status: "accepted", role })).toBe(
+        "Confirmed — see you there."
+      );
+      expect(statusLine({ ...them, status: "canceled", role })).toBe(
+        "This 1-on-1 was canceled."
+      );
     }
   });
 });

--- a/utils/meeting-clash-text.ts
+++ b/utils/meeting-clash-text.ts
@@ -58,3 +58,8 @@ export function clashLine(clash: MeetingClash): string {
     ? `You are hosting ${clash.title}`
     : `You are attending ${clash.title}`;
 }
+
+/** Every clash in one breath, each distinct line said once. */
+export function clashLines(clashes: MeetingClash[]): string {
+  return [...new Set(clashes.map(clashLine))].join("; ");
+}

--- a/utils/meeting-rules.ts
+++ b/utils/meeting-rules.ts
@@ -17,3 +17,28 @@ export function canCancel(
     (meeting.status === "pending" && meeting.role === "requester")
   );
 }
+
+/** What has become of the request, in the words of whoever is reading. */
+export function statusLine(
+  meeting: Pick<MeetingView, "status" | "role" | "otherName">
+): string {
+  const them = meeting.otherName;
+  switch (meeting.status) {
+    case "pending":
+      return meeting.role === "recipient"
+        ? `${them} is waiting for your answer.`
+        : `Waiting for ${them} to answer.`;
+    case "accepted":
+      return "Confirmed — see you there.";
+    case "declined":
+      return meeting.role === "recipient"
+        ? "You declined this."
+        : `${them} declined this.`;
+    case "canceled":
+      return "This 1-on-1 was canceled.";
+    case "expired":
+      // Nobody is at fault for an unanswered request, so it is not phrased as
+      // one: the slot simply came and went (issue #392, section 1.4).
+      return "Nobody answered before the slot began.";
+  }
+}


### PR DESCRIPTION
Part of schellingboard/schellingboard#392 — note 6 of @omarkohl's UX notes on schellingboard/schellingboard-legacy#943. **Stacked on schellingboard/schellingboard-legacy#982**.

The block fits a name, a place and a word of status. The line of context, the time, the full
status and any clash go in a tooltip on hover, the way a session block already does it; a tap
still opens the modal. The status line moves to `utils/meeting-rules.ts` so the column and the
modal say the same thing, and the three copies of the clash summary become one.

Same commit, same question of what the block has room for: three lines of text in a 40px block
left the third — "confirmed", "needs your reply" — clipped at the border. A one-slot block now
says the place and the state on one line under the name, the way a session block gives up its
host line at that height; taller blocks keep all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
