### PR TITLE
feat: 1-on-1 availability moves under Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Meetings section — switch 1-on-1s on, list the places you suggest people meet, and cap
   how many unanswered requests one attendee may have out at a time
 - **Asking an attendee for a 1-on-1** (#392): attendees mark the slots they are free for
-  on the new 1-on-1s page, ask someone from their profile, and accept or decline what they
-  are asked. Both sides are told the outcome; an unanswered request lapses at its slot
+  under Settings, ask someone from their profile, and accept or decline what they are
+  asked. Both sides are told the outcome; an unanswered request lapses at its slot
 - **Your 1-on-1s on the schedule** (#392): the grid's first column is yours alone — agreed
   1-on-1s and open requests. Hover for what it clashes with, tap to open or cancel it
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,

--- a/app/(site)/[eventSlug]/meetings/page.tsx
+++ b/app/(site)/[eventSlug]/meetings/page.tsx
@@ -1,19 +1,26 @@
 import { cookies } from "next/headers";
-import { notFound } from "next/navigation";
-import { DateTime } from "luxon";
+import { notFound, redirect } from "next/navigation";
 import { PageNotice } from "@/app/components/page-notice";
+import { EventPhase, getCurrentPhase } from "@/app/(site)/utils/events";
 import { getRepositories } from "@/db/container";
 import {
   unverifiedUserMessage,
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
-import { meetingSlotsForDay } from "@/utils/meeting-slots";
+import { serverNow } from "@/utils/dev-clock-server";
 import { MeetingModalFromUrl } from "../meeting-modal";
 import { MeetingsProvider } from "../use-meetings";
-import { AvailabilityForm, type SlotDay } from "./availability-form";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Where a meeting notification lands. Availability is set under Settings, so
+ * all that is left here is opening the one meeting -- and even that is handed
+ * to the schedule once there is one, where the meeting sits in its slot next
+ * to whatever it clashes with. Before the scheduling phase the schedule
+ * redirects to the proposals and would lose the meeting on the way, so until
+ * then it opens here (#952 is to settle that).
+ */
 export default async function MeetingsPage({
   params,
   searchParams,
@@ -22,114 +29,35 @@ export default async function MeetingsPage({
   searchParams: Promise<{ viewMeeting?: string | string[] }>;
 }) {
   const { eventSlug } = await params;
-  const repos = getRepositories();
-  const event = await repos.events.findBySlug(eventSlug);
-
+  const event = await getRepositories().events.findBySlug(eventSlug);
   if (!event) notFound();
 
-  // Turning meetings off neither cancels nor deletes the requests already
-  // made, and every notification about one points here for good -- so a
-  // meeting still opens, even where there is no longer any availability to
-  // set. The toolbar link is hidden either way.
   const { viewMeeting } = await searchParams;
-  if (!event.meetingsEnabled) {
-    if (!viewMeeting) notFound();
-    return (
-      <>
-        <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
-          {event.name} is no longer offering 1-on-1s, so there is no
-          availability to set — but the ones already arranged are still yours to
-          settle.
-        </PageNotice>
-        <MeetingsProvider evenIfMeetingsAreOff>
-          <MeetingModalFromUrl />
-        </MeetingsProvider>
-      </>
-    );
-  }
+  const meetingId = Array.isArray(viewMeeting) ? viewMeeting[0] : viewMeeting;
+  if (!meetingId) redirect(`/${eventSlug}`);
 
+  // Before the redirect below: the schedule has no notice for a visitor who
+  // hasn't said who they are, so its modal could only call the meeting "not
+  // found".
   const cookieStore = await cookies();
-  const currentUser = await verifiedCurrentUser(cookieStore);
-  if (!currentUser) {
+  if (!(await verifiedCurrentUser(cookieStore))) {
     return (
-      <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
-        {await unverifiedUserMessage(
-          cookieStore,
-          "setting your 1-on-1 availability"
-        )}
+      <PageNotice backHref={`/${eventSlug}`} backLabel={event.name}>
+        {await unverifiedUserMessage(cookieStore, "opening your 1-on-1s")}
       </PageNotice>
     );
   }
 
-  // The save action refuses a non-attendee anyway; checking here too means
-  // they are told before filling the form in rather than after.
-  const attending = await repos.guests.listEventsByGuests([currentUser]);
-  if (!attending.get(currentUser)?.some((e) => e.id === event.id)) {
-    return (
-      <PageNotice backHref={`/${eventSlug}`} backLabel="Schedule">
-        You&apos;re not on the guest list for {event.name}, so you can&apos;t
-        set 1-on-1 availability here. Ask the organizer to add you.
-      </PageNotice>
-    );
+  if (getCurrentPhase(event, await serverNow()) === EventPhase.SCHEDULING) {
+    redirect(`/${eventSlug}?viewMeeting=${encodeURIComponent(meetingId)}`);
   }
-
-  const [days, declared] = await Promise.all([
-    repos.days.listByEvent(event.id),
-    repos.meetingAvailability.listByGuestAndEvent(currentUser, event.id),
-  ]);
-
-  const zoned = (date: Date) =>
-    DateTime.fromJSDate(date).setZone(event.timezone);
-
-  // Days only have to not overlap, so an event may legitimately run 09:00-12:00
-  // and 14:00-18:00 on one date: the date alone is not a unique heading, and
-  // the window disambiguates the ones that repeat.
-  const dateCounts = new Map<string, number>();
-  for (const day of days) {
-    const date = zoned(day.start).toFormat("EEE d LLL");
-    dateCounts.set(date, (dateCounts.get(date) ?? 0) + 1);
-  }
-
-  const slotDays: SlotDay[] = days
-    .map((day) => ({
-      id: day.id,
-      label:
-        (dateCounts.get(zoned(day.start).toFormat("EEE d LLL")) ?? 0) > 1
-          ? `${zoned(day.start).toFormat("EEE d LLL")}, ${zoned(
-              day.start
-            ).toFormat("HH:mm")}–${zoned(day.end).toFormat("HH:mm")}`
-          : zoned(day.start).toFormat("EEE d LLL"),
-      slots: meetingSlotsForDay(day, event.slotIncrementMinutes).map(
-        (slot) => ({
-          start: slot.start.toISOString(),
-          label: `${zoned(slot.start).toFormat("HH:mm")} – ${zoned(
-            slot.end
-          ).toFormat("HH:mm")}`,
-        })
-      ),
-    }))
-    .filter((day) => day.slots.length > 0);
-
-  // Only what the event still offers. A day shortened or deleted after someone
-  // declared leaves rows for slots the form no longer renders, and the save
-  // action refuses any it isn't offering -- so passing them through would leave
-  // the guest with a form that cannot be saved and nothing to untick.
-  const offered = new Set(slotDays.flatMap((d) => d.slots.map((s) => s.start)));
 
   return (
     <>
-      <AvailabilityForm
-        eventId={event.id}
-        eventSlug={eventSlug}
-        eventName={event.name}
-        timezone={event.timezone}
-        days={slotDays}
-        declared={declared
-          .map((d) => d.toISOString())
-          .filter((start) => offered.has(start))}
-      />
-      {/* Where a meeting notification lands: this page is here in every phase,
-          while the schedule only exists once scheduling starts. */}
+      <PageNotice backHref={`/${eventSlug}`} backLabel={event.name}>
+        Your 1-on-1s at {event.name} will sit on its schedule once scheduling
+        starts; until then, this is where one opens.
+      </PageNotice>
       <MeetingsProvider>
         <MeetingModalFromUrl />
       </MeetingsProvider>

--- a/app/(site)/[eventSlug]/schedule-toolbar.tsx
+++ b/app/(site)/[eventSlug]/schedule-toolbar.tsx
@@ -11,7 +11,6 @@ import {
   InformationCircleIcon,
   LinkIcon,
   TableCellsIcon,
-  UserGroupIcon,
 } from "@heroicons/react/24/outline";
 import { DateTime } from "luxon";
 import Link from "next/link";
@@ -65,12 +64,6 @@ export function ScheduleToolbar(props: {
             <Link href={`/${event.slug}/proposals`} className={ITEM_CLASS}>
               <ClipboardDocumentListIcon className="h-4 w-4 stroke-2" />
               Proposals
-            </Link>
-          )}
-          {event.meetingsEnabled && (
-            <Link href={`/${event.slug}/meetings`} className={ITEM_CLASS}>
-              <UserGroupIcon className="h-4 w-4 stroke-2" />
-              1-on-1s
             </Link>
           )}
         </div>

--- a/app/(site)/[eventSlug]/use-meetings.tsx
+++ b/app/(site)/[eventSlug]/use-meetings.tsx
@@ -39,18 +39,7 @@ const MeetingsContext = createContext<MyMeetings>({
  * shared by everyone looking at it, and these are private to one guest
  * (issue #392, section 2.6).
  */
-export function MeetingsProvider({
-  children,
-  evenIfMeetingsAreOff = false,
-}: {
-  children: ReactNode;
-  /**
-   * A meeting outlives the organizer switching the feature off, and the
-   * notification about it still opens one — so the page that opens it asks
-   * for the viewer's meetings anyway, where the schedule's column does not.
-   */
-  evenIfMeetingsAreOff?: boolean;
-}) {
+export function MeetingsProvider({ children }: { children: ReactNode }) {
   const { event } = useContext(EventContext);
   const { user } = useContext(UserContext);
   const [loaded, setLoaded] = useState<
@@ -60,10 +49,10 @@ export function MeetingsProvider({
   const [reloads, setReloads] = useState(0);
 
   const eventId = event?.id;
-  // A kiosk with nobody picked, or an event that never offered meetings:
-  // there is nothing this guest could have.
-  const offered = event?.meetingsEnabled || evenIfMeetingsAreOff;
-  const key = eventId && offered && user ? `${eventId}:${user}` : null;
+  // A kiosk with nobody picked has nothing to fetch. An event with meetings
+  // switched off still might: a request outlives the switch, and the one its
+  // notification opens has to load.
+  const key = eventId && user ? `${eventId}:${user}` : null;
 
   useEffect(() => {
     if (!key) return;

--- a/app/(site)/settings/availability-form.tsx
+++ b/app/(site)/settings/availability-form.tsx
@@ -1,35 +1,26 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { BackLink } from "@/app/components/back-link";
+import { useId, useState, useTransition } from "react";
 import { saveMeetingAvailabilityAction } from "@/app/actions/meetings";
 import { PRIMARY_BUTTON } from "@/app/components/buttons";
-
-export type SlotDay = {
-  /** Two days may share a date, so the id is what keys them apart. */
-  id: string;
-  label: string;
-  slots: { start: string; label: string }[];
-};
+import type {
+  AvailabilityFormData,
+  SlotDay,
+} from "@/utils/meeting-availability-form";
 
 const QUIET_BUTTON =
   "px-2 py-1 text-sm rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors";
 
+/** One event's availability, inside its panel on the Settings page. */
 export function AvailabilityForm({
   eventId,
-  eventSlug,
   eventName,
   timezone,
   days,
   declared,
-}: {
-  eventId: string;
-  eventSlug: string;
-  eventName: string;
-  timezone: string;
-  days: SlotDay[];
-  declared: string[];
-}) {
+}: AvailabilityFormData) {
+  // Settings holds one of these per event, so the checkbox id cannot be fixed.
+  const switchId = useId();
   // No rows means not bookable, which is also the state of someone who never
   // turned the switch on -- so the switch is simply "did you declare anything".
   const [open, setOpen] = useState(declared.length > 0);
@@ -94,28 +85,22 @@ export function AvailabilityForm({
   return (
     <form
       onSubmit={handleSave}
-      aria-label="1-on-1s"
-      className="max-w-2xl mx-auto w-full px-4 sm:px-0 flex flex-col gap-6 py-8"
+      aria-label={`1-on-1s at ${eventName}`}
+      className="flex flex-col gap-4"
     >
-      <BackLink href={`/${eventSlug}`}>Schedule</BackLink>
-      <div>
-        <h1 className="text-3xl font-bold text-fg">1-on-1s</h1>
-        <p className="text-fg-muted mt-2">{eventName}</p>
-      </div>
-
       {error && <p className="text-sm text-danger-fg">{error}</p>}
 
       <div className="rounded-md border border-line-subtle p-4">
         <div className="flex items-start gap-2">
           <input
-            id="meetings-open"
+            id={switchId}
             type="checkbox"
             checked={open}
             onChange={(e) => toggleOpen(e.target.checked)}
             className="mt-0.5 h-4 w-4 rounded border-line text-brand-fg focus:ring-brand-accent"
           />
           <div>
-            <label htmlFor="meetings-open" className="font-medium text-fg">
+            <label htmlFor={switchId} className="font-medium text-fg">
               I&apos;m open to 1-on-1s at this event
             </label>
             <p className="text-sm text-fg-subtle">
@@ -144,7 +129,7 @@ export function AvailabilityForm({
           {days.map((day) => (
             <section key={day.id} aria-label={day.label}>
               <div className="flex items-center justify-between gap-3 mb-1">
-                <h2 className="text-lg font-semibold text-fg">{day.label}</h2>
+                <h3 className="text-base font-semibold text-fg">{day.label}</h3>
                 <div className="flex gap-2">
                   <button
                     type="button"

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -7,10 +7,15 @@ import {
 } from "@/utils/acting-guest";
 import { serverNow } from "@/utils/dev-clock-server";
 import { vapidPublicKey } from "@/utils/push";
+import {
+  availabilityFormsFor,
+  type AvailabilityFormData,
+} from "@/utils/meeting-availability-form";
 import { SettingsForm } from "./settings-form";
 import { AccountSecurity } from "./account-security";
 import { PushNotifications } from "./push-notifications";
 import { AppearanceSettings } from "./appearance";
+import { AvailabilityForm } from "./availability-form";
 
 export default async function SettingsPage() {
   const cookieStore = await cookies();
@@ -42,7 +47,9 @@ export default async function SettingsPage() {
     );
   }
 
-  const publicKey = await vapidPublicKey(await serverNow());
+  const now = await serverNow();
+  const publicKey = await vapidPublicKey(now);
+  const availability = await availabilityFormsFor(guest.id, now);
 
   // Never render the stored email address here: switching the current user
   // is unauthenticated, so anyone could impersonate a guest and read it.
@@ -50,6 +57,7 @@ export default async function SettingsPage() {
     <div className="flex flex-col gap-8">
       <SettingsForm emailSettings={guest.info.emailSettings} />
       <PushNotifications publicKey={publicKey} />
+      <OneOnOneSettings forms={availability} />
       <div className="max-w-2xl mx-auto w-full px-4 sm:px-0">
         <AccountSecurity
           guestId={guest.id}
@@ -59,5 +67,44 @@ export default async function SettingsPage() {
       </div>
       <AppearanceSettings />
     </div>
+  );
+}
+
+// Availability is per event, so it is one panel per event rather than one
+// form -- collapsed, except that a lone one starts open.
+function OneOnOneSettings({ forms }: { forms: AvailabilityFormData[] }) {
+  return (
+    <section
+      aria-labelledby="one-on-ones"
+      className="max-w-2xl mx-auto w-full px-4 sm:px-0 flex flex-col gap-3"
+    >
+      <h2 id="one-on-ones" className="text-lg font-semibold">
+        1-on-1s
+      </h2>
+      <p className="text-sm text-fg-subtle">
+        When you&apos;re free to meet other attendees, event by event. Only the
+        events you&apos;re attending that offer 1-on-1s are listed.
+      </p>
+      {forms.length === 0 ? (
+        <p className="text-sm text-fg-muted">
+          None of your events offers 1-on-1s at the moment.
+        </p>
+      ) : (
+        forms.map((form) => (
+          <details
+            key={form.eventId}
+            open={forms.length === 1}
+            className="rounded-md border border-line-subtle"
+          >
+            <summary className="cursor-pointer px-4 py-3 font-medium text-fg">
+              {form.eventName}
+            </summary>
+            <div className="px-4 pb-4">
+              <AvailabilityForm {...form} />
+            </div>
+          </details>
+        ))
+      )}
+    </section>
   );
 }

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -58,12 +58,6 @@ export function SettingsForm({
         </Link>{" "}
         is edited separately.
       </p>
-      {/* Availability is per-event, so it cannot live here -- but this is
-          where people look for it first. */}
-      <p className="text-sm text-fg-subtle">
-        Setting when you&apos;re free for 1-on-1s is per event: open the event
-        and use its <strong>1-on-1s</strong> link.
-      </p>
 
       <form
         onSubmit={(e) => form.handleSubmit(handleSubmit)(e) as never}

--- a/app/actions/meetings.ts
+++ b/app/actions/meetings.ts
@@ -339,6 +339,6 @@ export async function saveMeetingAvailabilityAction(
     declared.map((slot) => new Date(slot))
   );
 
-  revalidatePath(`/${event.slug}/meetings`);
+  revalidatePath("/settings");
   return { ok: true };
 }

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -188,9 +188,9 @@ Open a session to find the same comment section proposals have — useful for
 
 ## 1-on-1s
 
-When the organizer has switched 1-on-1s on for the event, the schedule toolbar
-gains a **1-on-1s** link. That page is where you say when you are free to meet
-people one to one.
+Under **Settings**, every event you're attending where the organizer offers
+1-on-1s gets a panel of its own. That is where you say when you are free to
+meet people one to one.
 
 One switch controls the whole thing:
 
@@ -237,7 +237,8 @@ Once you are at that number, wait for a reply or cancel one first.
 ### Answering a request
 
 You'll get a notification (and an email, unless you've turned that off) with
-who, when, where and their line of context, and **Accept** or **Decline**.
+who, when, where and their line of context, and **Accept** or **Decline**. It
+opens on the schedule, in its slot, once the event has one.
 Declining takes no explanation — nobody should feel obliged.
 
 If the slot clashes with something of yours, the request says so before you
@@ -410,6 +411,8 @@ same notifications reach your phone or laptop when the site isn't open.
   email only — you still see it in the app. Every email says what happened and
   links to it — session descriptions and comment text stay on the site rather
   than going out to your email provider.
+- **1-on-1s** — one panel per event you're attending that offers them, with the
+  switch and the slots you're keeping free. See [1-on-1s](#1-on-1s).
 - **Appearance** — System, Light or Dark, also available at the very bottom of
   every page. **System** follows your phone or laptop, so the site turns dark
   in the evening if your device does. The choice is remembered per device, not

--- a/tests/e2e/helpers/meetings.ts
+++ b/tests/e2e/helpers/meetings.ts
@@ -1,0 +1,17 @@
+import { Locator, Page, expect } from "@playwright/test";
+
+// Settings holds one collapsed panel per event that offers 1-on-1s, except
+// that a lone one starts open -- so look before clicking its summary.
+export async function openAvailability(
+  page: Page,
+  eventName: string
+): Promise<Locator> {
+  const form = page.getByRole("form", { name: `1-on-1s at ${eventName}` });
+  const panels = page.getByRole("region", { name: "1-on-1s" });
+  await expect(panels).toBeVisible();
+  if (!(await form.isVisible())) {
+    await panels.getByText(eventName, { exact: true }).click();
+  }
+  await expect(form).toBeVisible();
+  return form;
+}

--- a/tests/e2e/meetings-availability.spec.ts
+++ b/tests/e2e/meetings-availability.spec.ts
@@ -1,8 +1,9 @@
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
 import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
+import { openAvailability } from "./helpers/meetings";
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
 
@@ -50,12 +51,10 @@ test.describe("attendee meeting availability", () => {
   const leftBehind: string[] = [];
 
   test.afterEach(async ({ page }) => {
-    if (leftBehind.length === 0) return;
-    // A test may end on an event page with its votes and RSVPs still in
-    // flight; a hard goto aborts those, and the console guard fails on it.
-    await page.waitForLoadState("networkidle");
-
     for (const eventName of leftBehind.splice(0)) {
+      // A test may end on an event page with its votes and RSVPs still loading;
+      // a hard goto aborts those, and the console guard fails on the abort.
+      await page.waitForLoadState("networkidle");
       await page.goto("/admin/events");
       await manage(page, eventName);
       await page.getByRole("button", { name: "Delete event" }).click();
@@ -70,6 +69,9 @@ test.describe("attendee meeting availability", () => {
   }) => {
     const eventName = `E2E Availability ${uniqueSuffix()}`;
     leftBehind.push(eventName);
+
+    // A throwaway event of its own, so switching meetings on here can't change
+    // what the other specs see on the seeded ones.
     await createEvent(page, eventName);
 
     const meetings = page.getByRole("form", { name: "Meetings" });
@@ -96,16 +98,15 @@ test.describe("attendee meeting availability", () => {
     await alice.click();
     await expect(alice).toBeChecked();
 
-    // Now as that attendee, reaching the page the way one would: the event in
-    // the header, then the toolbar's 1-on-1s link.
+    // Now as that attendee, reaching the form the way one would: Settings,
+    // from the name menu.
     await loginAndGoto(page, "/guests");
     await selectUser(page, /Alice Test/i);
-    await page.getByRole("link", { name: eventName }).click();
-    await page.getByRole("link", { name: "1-on-1s" }).click();
-    await expect(page).toHaveURL(/\/meetings$/);
-    const eventSlug = new URL(page.url()).pathname.split("/")[1];
+    await page.getByRole("button", { name: /your name/i }).click();
+    await page.getByRole("menuitem", { name: /settings/i }).click();
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 
-    const form = page.getByRole("form", { name: "1-on-1s" });
+    let form = await openAvailability(page, eventName);
     await expect(form.getByLabel(/open to 1-on-1s/)).not.toBeChecked();
 
     // Switching it on marks every slot available; you clear what you want kept
@@ -120,6 +121,7 @@ test.describe("attendee meeting availability", () => {
     await expect(form.getByText("Saved!")).toBeVisible();
 
     await page.reload();
+    form = await openAvailability(page, eventName);
     await expect(form.getByLabel(/open to 1-on-1s/)).toBeChecked();
     await expect(
       form.getByRole("listitem").first().getByRole("checkbox")
@@ -146,7 +148,8 @@ test.describe("attendee meeting availability", () => {
       page.getByText(/2026-10-01T09:00 – 2026-10-01T10:00/)
     ).toBeVisible();
 
-    await page.goto(`/${eventSlug}/meetings`);
+    await page.goto("/settings");
+    form = await openAvailability(page, eventName);
     await expect(form.getByRole("listitem")).toHaveCount(2);
     await form.getByRole("button", { name: "Save availability" }).click();
     await expect(form.getByText("Saved!")).toBeVisible();
@@ -156,16 +159,18 @@ test.describe("attendee meeting availability", () => {
     await form.getByRole("button", { name: "Save availability" }).click();
     await expect(form.getByText("Saved!")).toBeVisible();
     await page.reload();
+    form = await openAvailability(page, eventName);
     await expect(form.getByLabel(/open to 1-on-1s/)).not.toBeChecked();
   });
 
-  // The save action refuses a non-attendee, but the page used to render the
-  // whole form first -- so the refusal only arrived after ticking boxes.
-  test("says so up front when you are not on the event's guest list", async ({
+  // Only events the attendee can actually be booked at get a panel; the rest
+  // of Settings is for everyone, so the section is never missing, only empty.
+  test("lists only the events you attend that offer 1-on-1s", async ({
     page,
   }) => {
-    const eventName = `E2E Not Attending ${uniqueSuffix()}`;
+    const eventName = `E2E Listed ${uniqueSuffix()}`;
     leftBehind.push(eventName);
+
     await createEvent(page, eventName);
 
     const meetings = page.getByRole("form", { name: "Meetings" });
@@ -173,30 +178,36 @@ test.describe("attendee meeting availability", () => {
     await meetings.getByRole("button", { name: "Save meetings" }).click();
     await expect(meetings.getByText("Saved!")).toBeVisible();
 
-    // Nobody is assigned to this event, so Alice is not attending it.
-    const slug = eventName.replace(/ /g, "-");
-    await loginAndGoto(page, `/${slug}/meetings`);
+    // Nobody is assigned yet, so Alice is not attending it.
+    await loginAndGoto(page, "/guests");
     await selectUser(page, /Alice Test/i);
-    await page.goto(`/${slug}/meetings`);
+    await page.goto("/settings");
+    const panels = page.getByRole("region", { name: "1-on-1s" });
+    await expect(panels).toBeVisible();
+    await expect(panels.getByText(eventName, { exact: true })).toBeHidden();
 
-    await expect(page.getByText(/not on the guest list/i)).toBeVisible();
-    await expect(page.getByRole("form", { name: "1-on-1s" })).toBeHidden();
-  });
+    await page.goto("/admin/events");
+    await manage(page, eventName);
+    await page.getByRole("link", { name: "Guests" }).click();
+    const alice = page
+      .getByRole("region", { name: "Guests" })
+      .getByRole("row")
+      .filter({ hasText: "Alice Test" })
+      .getByRole("checkbox", { name: /^Assign / });
+    await alice.click();
+    await expect(alice).toBeChecked();
 
-  test("is not offered while the organizer keeps meetings off", async ({
-    page,
-  }) => {
-    const eventName = `E2E No Meetings ${uniqueSuffix()}`;
-    leftBehind.push(eventName);
-    await createEvent(page, eventName);
+    await page.goto("/settings");
+    await expect(panels.getByText(eventName, { exact: true })).toBeVisible();
 
-    await loginAndGoto(page, `/${eventName.replace(/ /g, "-")}`);
+    // Switching 1-on-1s off takes the panel away again.
+    await page.goto("/admin/events");
+    await manage(page, eventName);
+    await meetings.getByLabel("Enable meetings").uncheck();
+    await meetings.getByRole("button", { name: "Save meetings" }).click();
+    await expect(meetings.getByText("Saved!")).toBeVisible();
 
-    // Event details is the control: the toolbar rendered, and the 1-on-1s link
-    // is what is missing from it.
-    await expect(
-      page.getByRole("button", { name: "Event details" })
-    ).toBeVisible();
-    await expect(page.getByRole("link", { name: "1-on-1s" })).toBeHidden();
+    await page.goto("/settings");
+    await expect(panels.getByText(eventName, { exact: true })).toBeHidden();
   });
 });

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from "./helpers/fixtures";
 import { uniqueSuffix } from "./helpers/unique";
 import { loginAndGoto } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
+import { openAvailability } from "./helpers/meetings";
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admintest";
 
@@ -233,11 +234,12 @@ test.describe("1-on-1 meetings", () => {
       page.getByRole("button", { name: /schedule a 1-on-1/i })
     ).toBeHidden();
 
-    // The askee declares they are open to meetings.
-    await page.goto(`/${slug}/meetings`);
+    // The askee declares they are open to 1-on-1s, under Settings. The goto
+    // first: the profile modal is still up, over the header actAs needs.
+    await page.goto("/settings");
     await actAs(page, new RegExp(askee));
-    await page.goto(`/${slug}/meetings`);
-    const availability = page.getByRole("form", { name: "1-on-1s" });
+    await page.goto("/settings");
+    const availability = await openAvailability(page, eventName);
     await availability.getByLabel(/open to 1-on-1s/).check();
     await availability
       .getByRole("button", { name: "Save availability" })

--- a/tests/integration/meeting-availability-action.test.ts
+++ b/tests/integration/meeting-availability-action.test.ts
@@ -89,6 +89,22 @@ describe("saveMeetingAvailabilityAction", () => {
     expect(saved.map((d) => d.toISOString())).toEqual([SLOT_1, SLOT_3]);
   });
 
+  // Settings is where the form is rendered; the event's own pages never show
+  // the declaration back.
+  it("refreshes the settings page it was saved from", async () => {
+    const { revalidatePath } = await import("next/cache");
+    const event = await meetingsEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await signIn(guest.id);
+
+    await saveMeetingAvailabilityAction({
+      eventId: event.id,
+      slotStarts: [SLOT_1],
+    });
+
+    expect(revalidatePath).toHaveBeenCalledWith("/settings");
+  });
+
   it("replaces the previous set rather than adding to it", async () => {
     const event = await meetingsEvent();
     const guest = await createGuest({ eventId: event.id });

--- a/tests/integration/meeting-availability-form.test.ts
+++ b/tests/integration/meeting-availability-form.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createDay } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { availabilityFormsFor } from "@/utils/meeting-availability-form";
+
+const NOW = new Date("2026-10-01T08:00:00.000Z");
+const DAY = {
+  start: new Date("2026-10-02T09:00:00.000Z"),
+  end: new Date("2026-10-02T11:00:00.000Z"),
+};
+
+async function offering(opts?: { name?: string; meetingsEnabled?: boolean }) {
+  const event = await createEvent({
+    name: opts?.name,
+    slotIncrementMinutes: 30,
+  });
+  await getRepositories().events.update(event.id, {
+    meetingsEnabled: opts?.meetingsEnabled ?? true,
+  });
+  return event;
+}
+
+describe("availabilityFormsFor", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("lists an event you attend that offers 1-on-1s, with its slots and what you declared", async () => {
+    const event = await offering({ name: "Autumn Camp" });
+    await createDay(event.id, DAY);
+    const guest = await createGuest({ eventId: event.id });
+    await getRepositories().meetingAvailability.replaceForGuest(
+      guest.id,
+      event.id,
+      [new Date("2026-10-02T09:30:00.000Z")]
+    );
+
+    const forms = await availabilityFormsFor(guest.id, NOW);
+
+    expect(forms).toHaveLength(1);
+    expect(forms[0]).toMatchObject({
+      eventId: event.id,
+      eventName: "Autumn Camp",
+      timezone: "UTC",
+      declared: ["2026-10-02T09:30:00.000Z"],
+    });
+    expect(forms[0].days).toHaveLength(1);
+    expect(forms[0].days[0].label).toBe("Fri 2 Oct");
+    expect(forms[0].days[0].slots.map((s) => s.label)).toEqual([
+      "09:00 – 09:30",
+      "09:30 – 10:00",
+      "10:00 – 10:30",
+      "10:30 – 11:00",
+    ]);
+  });
+
+  it("leaves out events you are not attending, and ones not offering 1-on-1s", async () => {
+    const notAttended = await offering();
+    await createDay(notAttended.id, DAY);
+    const notOffering = await offering({ meetingsEnabled: false });
+    await createDay(notOffering.id, DAY);
+    const guest = await createGuest({ eventId: notOffering.id });
+
+    expect(await availabilityFormsFor(guest.id, NOW)).toEqual([]);
+  });
+
+  // Nothing is left to be booked into once every day has passed. An event
+  // with no days yet is different: the organizer may still add some.
+  it("leaves out an event whose days are all over, but not one with no days yet", async () => {
+    const over = await offering({ name: "Last Year" });
+    await createDay(over.id, {
+      start: new Date("2026-09-01T09:00:00.000Z"),
+      end: new Date("2026-09-01T11:00:00.000Z"),
+    });
+    const notYet = await offering({ name: "Not Planned" });
+    const guest = await createGuest({ eventId: over.id });
+    await getRepositories().guests.assignToEvent(notYet.id, [guest.id]);
+
+    const forms = await availabilityFormsFor(guest.id, NOW);
+
+    expect(forms.map((f) => f.eventName)).toEqual(["Not Planned"]);
+    expect(forms[0].days).toEqual([]);
+  });
+
+  // A day shortened after someone declared leaves rows for slots the form no
+  // longer renders, and the save action refuses any it isn't offering -- so
+  // passing them through would leave a form that cannot be saved and nothing
+  // to untick.
+  it("keeps only the declared slots the event still offers", async () => {
+    const event = await offering();
+    await createDay(event.id, DAY);
+    const guest = await createGuest({ eventId: event.id });
+    await getRepositories().meetingAvailability.replaceForGuest(
+      guest.id,
+      event.id,
+      [
+        new Date("2026-10-02T09:30:00.000Z"),
+        new Date("2026-10-02T12:00:00.000Z"),
+      ]
+    );
+
+    const [form] = await availabilityFormsFor(guest.id, NOW);
+
+    expect(form.declared).toEqual(["2026-10-02T09:30:00.000Z"]);
+  });
+
+  // Days only have to not overlap, so one date may hold a morning and an
+  // afternoon: the date alone is not a heading that tells them apart.
+  it("labels two days on one date by their hours", async () => {
+    const event = await offering();
+    await createDay(event.id, DAY);
+    await createDay(event.id, {
+      start: new Date("2026-10-02T14:00:00.000Z"),
+      end: new Date("2026-10-02T16:00:00.000Z"),
+    });
+    const guest = await createGuest({ eventId: event.id });
+
+    const [form] = await availabilityFormsFor(guest.id, NOW);
+
+    expect(form.days.map((d) => d.label)).toEqual([
+      "Fri 2 Oct, 09:00–11:00",
+      "Fri 2 Oct, 14:00–16:00",
+    ]);
+  });
+});

--- a/tests/integration/meetings-page.test.tsx
+++ b/tests/integration/meetings-page.test.tsx
@@ -22,27 +22,27 @@ vi.mock("next/headers", () => ({
     }),
 }));
 
-// Both are client components — one reads router search params, the other a
-// form's own state. This test only cares which of them the page renders.
-vi.mock("@/app/(site)/[eventSlug]/meetings/availability-form", () => ({
-  AvailabilityForm: () => "AVAILABILITY_FORM_STUB",
+// Both throw for real, to abandon the render; the messages are what the
+// tests read.
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT;${url}`);
+  },
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
 }));
+
+// A client component that reads router search params; the page only decides
+// whether to render it.
 vi.mock("@/app/(site)/[eventSlug]/meeting-modal", () => ({
   MeetingModalFromUrl: () => "MEETING_MODAL_STUB",
 }));
-// The modal reads the viewer's meetings from this provider, so where the page
-// renders it says whether it can load one at all.
+// The modal reads the viewer's meetings from this provider, so the page has to
+// render it inside one for the meeting to load at all.
 vi.mock("@/app/(site)/[eventSlug]/use-meetings", () => ({
-  MeetingsProvider: ({
-    children,
-    evenIfMeetingsAreOff,
-  }: {
-    children: ReactNode;
-    evenIfMeetingsAreOff?: boolean;
-  }) => (
-    <div data-provider-off={String(Boolean(evenIfMeetingsAreOff))}>
-      {children}
-    </div>
+  MeetingsProvider: ({ children }: { children: ReactNode }) => (
+    <div data-provider>{children}</div>
   ),
 }));
 
@@ -78,40 +78,86 @@ describe("the meetings page", () => {
 
   afterEach(() => vi.unstubAllEnvs());
 
-  async function scenario(meetingsEnabled: boolean) {
-    const event = await createEvent({ phase: "scheduling" });
+  async function scenario(opts: {
+    phase: "proposal" | "scheduling";
+    meetingsEnabled: boolean;
+    identified?: boolean;
+  }) {
+    const event = await createEvent({ phase: opts.phase });
     await createDay(event.id);
     const guest = await createGuest({ name: "Ada", eventId: event.id });
-    await getRepositories().events.update(event.id, { meetingsEnabled });
-    cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guest.id));
+    await getRepositories().events.update(event.id, {
+      meetingsEnabled: opts.meetingsEnabled,
+    });
+    if (opts.identified ?? true) {
+      cookieJar.set(GUEST_COOKIE_NAME, await verifiedGuestValue(guest.id));
+    }
     return { event, guest };
   }
 
-  it("offers the availability form while the organizer offers meetings", async () => {
-    const { event } = await scenario(true);
+  // Availability is set under Settings now; nothing else lived here.
+  it("sends you to the schedule when there is no meeting to open", async () => {
+    const { event } = await scenario({
+      phase: "scheduling",
+      meetingsEnabled: true,
+    });
 
-    expect(await renderPage(event.slug)).toMatch(/AVAILABILITY_FORM_STUB/);
+    await expect(renderPage(event.slug)).rejects.toThrow(
+      new RegExp(`NEXT_REDIRECT;/${event.slug}$`)
+    );
+  });
+
+  // Where a meeting notification lands: on the schedule, where the meeting
+  // sits in its slot next to whatever it clashes with.
+  it("opens a meeting on top of the schedule once scheduling has begun", async () => {
+    const { event } = await scenario({
+      phase: "scheduling",
+      meetingsEnabled: true,
+    });
+
+    await expect(
+      renderPage(event.slug, { viewMeeting: "any-id" })
+    ).rejects.toThrow(`NEXT_REDIRECT;/${event.slug}?viewMeeting=any-id`);
+  });
+
+  // Before then the schedule redirects to the proposals, and the meeting
+  // would be lost on the way.
+  it("opens a meeting here before scheduling starts", async () => {
+    const { event } = await scenario({
+      phase: "proposal",
+      meetingsEnabled: true,
+    });
+
+    expect(await renderPage(event.slug, { viewMeeting: "any-id" })).toMatch(
+      /MEETING_MODAL_STUB/
+    );
+  });
+
+  // The schedule has no notice to show a visitor who hasn't said who they
+  // are, so its modal could only call the meeting "not found" -- ask here,
+  // before handing the meeting over.
+  it("asks who you are rather than sending you on unidentified", async () => {
+    const { event } = await scenario({
+      phase: "scheduling",
+      meetingsEnabled: true,
+      identified: false,
+    });
+
+    expect(await renderPage(event.slug, { viewMeeting: "any-id" })).toMatch(
+      /select who you are/i
+    );
   });
 
   // A request outlives the switch: it is neither canceled nor deleted when the
   // organizer turns meetings off, and its notification points here forever.
   it("still opens a meeting once the organizer has switched meetings off", async () => {
-    const { event } = await scenario(false);
+    const { event } = await scenario({
+      phase: "proposal",
+      meetingsEnabled: false,
+    });
 
-    const html = await renderPage(event.slug, { viewMeeting: "any-id" });
-
-    // Inside the provider, and told to fetch even though the event no longer
-    // offers meetings: outside one, or gated on the switch, the modal has
-    // nothing to show but "Loading...".
-    expect(html).toMatch(
-      /<div data-provider-off="true">MEETING_MODAL_STUB<\/div>/
+    expect(await renderPage(event.slug, { viewMeeting: "any-id" })).toMatch(
+      /MEETING_MODAL_STUB/
     );
-    expect(html).not.toMatch(/AVAILABILITY_FORM_STUB/);
-  });
-
-  it("is gone with the feature when there is no meeting to open", async () => {
-    const { event } = await scenario(false);
-
-    await expect(renderPage(event.slug)).rejects.toThrow();
   });
 });

--- a/utils/meeting-availability-form.ts
+++ b/utils/meeting-availability-form.ts
@@ -1,0 +1,111 @@
+import { DateTime } from "luxon";
+import { getRepositories } from "@/db/container";
+import type { Day, Event } from "@/db/repositories/interfaces";
+import { meetingSlotsForDay } from "@/utils/meeting-slots";
+
+export type SlotDay = {
+  /** Two days may share a date, so the id is what keys them apart. */
+  id: string;
+  label: string;
+  slots: { start: string; label: string }[];
+};
+
+/** Everything one event's availability form needs, ready to render. */
+export type AvailabilityFormData = {
+  eventId: string;
+  eventName: string;
+  timezone: string;
+  days: SlotDay[];
+  /** ISO slot starts, already narrowed to what the event still offers. */
+  declared: string[];
+};
+
+/**
+ * One form per event the guest can still be booked at: attended, offering
+ * 1-on-1s, and with a day still to come -- or none yet, since the organizer
+ * may add some. Ordered by when the event starts.
+ */
+export async function availabilityFormsFor(
+  guestId: string,
+  now: Date
+): Promise<AvailabilityFormData[]> {
+  const repos = getRepositories();
+  // The assignment lookup carries ids and names only.
+  const attending = await Promise.all(
+    ((await repos.guests.listEventsByGuests([guestId])).get(guestId) ?? []).map(
+      ({ id }) => repos.events.findById(id)
+    )
+  );
+  const offering = attending
+    .filter(
+      (event): event is Event => event !== undefined && event.meetingsEnabled
+    )
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  const forms = await Promise.all(
+    offering.map(async (event) => {
+      const [days, declared] = await Promise.all([
+        repos.days.listByEvent(event.id),
+        repos.meetingAvailability.listByGuestAndEvent(guestId, event.id),
+      ]);
+      if (
+        days.length > 0 &&
+        days.every((d) => d.end.getTime() <= now.getTime())
+      ) {
+        return null;
+      }
+      const slotDays = slotDaysFor(event, days);
+      // Only what the event still offers. A day shortened or deleted after
+      // someone declared leaves rows for slots the form no longer renders, and
+      // the save action refuses any it isn't offering -- so passing them
+      // through would leave a form that cannot be saved and nothing to untick.
+      const offered = new Set(
+        slotDays.flatMap((d) => d.slots.map((s) => s.start))
+      );
+      return {
+        eventId: event.id,
+        eventName: event.name,
+        timezone: event.timezone,
+        days: slotDays,
+        declared: declared
+          .map((d) => d.toISOString())
+          .filter((start) => offered.has(start)),
+      };
+    })
+  );
+  return forms.filter((form) => form !== null);
+}
+
+function slotDaysFor(event: Event, days: Day[]): SlotDay[] {
+  const zoned = (date: Date) =>
+    DateTime.fromJSDate(date).setZone(event.timezone);
+  const dateOf = (day: Day) => zoned(day.start).toFormat("EEE d LLL");
+
+  // Days only have to not overlap, so an event may legitimately run 09:00-12:00
+  // and 14:00-18:00 on one date: the date alone is not a unique heading, and
+  // the window disambiguates the ones that repeat.
+  const dateCounts = new Map<string, number>();
+  for (const day of days) {
+    dateCounts.set(dateOf(day), (dateCounts.get(dateOf(day)) ?? 0) + 1);
+  }
+
+  return days
+    .map((day) => ({
+      id: day.id,
+      label:
+        (dateCounts.get(dateOf(day)) ?? 0) > 1
+          ? `${dateOf(day)}, ${zoned(day.start).toFormat("HH:mm")}–${zoned(
+              day.end
+            ).toFormat("HH:mm")}`
+          : dateOf(day),
+      slots: meetingSlotsForDay(day, event.slotIncrementMinutes).map(
+        (slot) => ({
+          start: slot.start.toISOString(),
+          label: `${zoned(slot.start).toFormat("HH:mm")} – ${zoned(
+            slot.end
+          ).toFormat("HH:mm")}`,
+        })
+      ),
+    }))
+    .filter((day) => day.slots.length > 0);
+}


### PR DESCRIPTION
Part of schellingboard/schellingboard#392 — notes 1 and 8 of @omarkohl's UX notes on schellingboard/schellingboard-legacy#943. **Stacked on schellingboard/schellingboard-legacy#984**.

Availability moves to where people look for it first: one panel per event you attend that
offers 1-on-1s under **Settings**, collapsed unless it is the only one, in place of the schedule
toolbar's link and its own page. Events whose days have all passed are not listed; an event
with no days yet is, since the organizer may still add some. The data behind the panels is
`utils/meeting-availability-form.ts`.

**What is left of `/[event]/meetings` is where a notification lands**, and in the scheduling
phase it now redirects to the schedule with the meeting open, so it shows in its slot next to
whatever it clashes with. Before then the schedule bounces to the proposals and would lose the
meeting on the way, so the modal still opens on that page until schellingboard/schellingboard#952.

The provider had grown a gate on `meetingsEnabled` that `main` never had; it would have left a
meeting unloadable once the organizer switched the feature off, though a request outlives the
switch. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
