### PR TITLE
fix: bring pull-to-refresh back to the schedule on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   overnight sat at the top of the schedule for up to three minutes after the first slot began
 - **A modal closed while still opening no longer gets stuck**: pressing Escape or Close before a
   modal had finished fading in could leave it open with no way out but a reload
+- **Pull to refresh works on the schedule again** (#858): on a phone, pulling down from
+  the top reloads it — a deliberate pull, so panning the grid never reloads by accident
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -15,6 +15,7 @@ import { SessionModal } from "./session-modal";
 import { MeetingModalFromUrl } from "./meeting-modal";
 import type { DayWithSessions } from "../context";
 import { useDragToPan } from "./use-drag-to-pan";
+import { PullToRefresh } from "./pull-to-refresh";
 import Footer from "@/app/footer";
 
 export function EventDisplay() {
@@ -167,6 +168,9 @@ export function EventDisplay() {
         className="fixed inset-x-0 top-16 bottom-0 flex flex-col bg-surface"
       >
         {scheduleBody}
+        {/* Keyed on the view: each renders its own scroll surface, so the
+            gesture's listeners have to move with it. */}
+        <PullToRefresh key={view} scrollerRef={scrollerRef} />
       </div>
       {viewSession && (
         <SessionModal sessionId={viewSession} eventSlug={event.slug} />

--- a/app/(site)/[eventSlug]/pull-to-refresh.tsx
+++ b/app/(site)/[eventSlug]/pull-to-refresh.tsx
@@ -1,0 +1,114 @@
+"use client";
+import { useEffect, useRef, type RefObject } from "react";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+
+const AXIS_PX = 8;
+// Far enough that only a pull meant as one reaches it: panning the grid around
+// starts the same way, and must never end in a reload.
+const TRIGGER_PX = 90;
+// The badge follows at half speed and stops here, short of the finger, so a
+// pull that has arrived still looks like it has more to give.
+const MAX_TRAVEL_PX = 64;
+
+/**
+ * The schedule's own pull-to-refresh. Its frame locks window scrolling (see
+ * EventDisplay), and the browser's native gesture goes with it — there is no
+ * scrollable body left for it to attach to — so the inner scroller grows one.
+ */
+export function PullToRefresh({
+  scrollerRef,
+}: {
+  scrollerRef: RefObject<HTMLElement | null>;
+}) {
+  const badgeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    const badge = badgeRef.current;
+    if (!scroller || !badge) return;
+
+    let start: { x: number; y: number } | null = null;
+    let pulling = false;
+    let pulled = 0;
+
+    const onTouchStart = (e: TouchEvent) => {
+      start =
+        e.touches.length === 1 && scroller.scrollTop <= 0
+          ? { x: e.touches[0].clientX, y: e.touches[0].clientY }
+          : null;
+      pulling = false;
+      pulled = 0;
+      badge.style.transition = "none";
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (!start) return;
+      if (e.touches.length !== 1) {
+        start = null;
+        return;
+      }
+      const dx = e.touches[0].clientX - start.x;
+      const dy = e.touches[0].clientY - start.y;
+      if (!pulling) {
+        if (Math.hypot(dx, dy) < AXIS_PX) return;
+        if (dy <= Math.abs(dx) || scroller.scrollTop > 0) {
+          start = null;
+          return;
+        }
+        pulling = true;
+      }
+      pulled = dy;
+      // Clamped: the finger can come back up past where it started, and a
+      // badge driven straight off a negative dy flies off the top instead.
+      const shown = Math.max(dy, 0);
+      badge.style.transform = `translate(-50%, ${Math.min(shown / 2, MAX_TRAVEL_PX)}px)`;
+      badge.style.opacity = String(Math.min(shown / TRIGGER_PX, 1));
+      badge.toggleAttribute("data-armed", shown >= TRIGGER_PX);
+      // Or the scroller rubber-bands away under the badge.
+      if (e.cancelable) e.preventDefault();
+    };
+
+    const onTouchEnd = () => {
+      const reload = pulling && pulled >= TRIGGER_PX;
+      start = null;
+      pulling = false;
+      badge.style.transition = "transform 200ms ease-out, opacity 200ms";
+      if (!reload) {
+        badge.style.transform = "translate(-50%, 0)";
+        badge.style.opacity = "0";
+        badge.removeAttribute("data-armed");
+        return;
+      }
+      badge.toggleAttribute("data-refreshing", true);
+      badge.style.transform = `translate(-50%, ${MAX_TRAVEL_PX}px)`;
+      location.reload();
+    };
+
+    const onTouchCancel = () => {
+      pulled = 0;
+      onTouchEnd();
+    };
+
+    scroller.addEventListener("touchstart", onTouchStart, { passive: true });
+    scroller.addEventListener("touchmove", onTouchMove, { passive: false });
+    scroller.addEventListener("touchend", onTouchEnd);
+    scroller.addEventListener("touchcancel", onTouchCancel);
+    return () => {
+      scroller.removeEventListener("touchstart", onTouchStart);
+      scroller.removeEventListener("touchmove", onTouchMove);
+      scroller.removeEventListener("touchend", onTouchEnd);
+      scroller.removeEventListener("touchcancel", onTouchCancel);
+    };
+  }, [scrollerRef]);
+
+  return (
+    <div
+      ref={badgeRef}
+      aria-hidden
+      style={{ opacity: 0, transform: "translate(-50%, 0)" }}
+      className="group pointer-events-none absolute left-1/2 top-1 z-30 rounded-full border border-line bg-surface-raised p-2 text-fg-subtle shadow-sm data-[armed]:text-brand-fg data-[refreshing]:text-brand-fg"
+    >
+      <ArrowPathIcon className="h-5 w-5 group-data-[refreshing]:animate-spin" />
+    </div>
+  );
+}

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -115,6 +115,9 @@ to read what the room offers: projector, whiteboard, the kind of seating.
 While the event is running, a red line across the grid marks the current time,
 and **"Now"** at the top of the schedule jumps straight to it.
 
+On a phone, pull down from the top of the schedule and let go to load the
+latest sessions.
+
 ### Put a proposal on the schedule
 
 Two ways, whichever you find first:

--- a/tests/e2e/attendee-profiles.spec.ts
+++ b/tests/e2e/attendee-profiles.spec.ts
@@ -1,7 +1,8 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
+import { swipe } from "./helpers/touch";
 
 /**
  * Narrows the directory to the three seeded "… Test" guests, in that order: a
@@ -239,51 +240,6 @@ test("escape closes the profile, and back retraces the ones read", async ({
 
 test.describe("on a touchscreen", () => {
   test.use({ hasTouch: true, viewport: { width: 390, height: 844 } });
-
-  /**
-   * A finger, in the only terms Playwright leaves for one: touch events on the
-   * element under it. Dispatched one round trip at a time so the browser lays
-   * out and paints between them, the way it would under a real thumb.
-   */
-  async function swipe(
-    target: Locator,
-    { by, down = 0, startX }: { by: number; down?: number; startX?: number }
-  ) {
-    const box = (await target.boundingBox())!;
-    const x0 = startX ?? box.x + box.width / 2;
-    const y0 = box.y + box.height / 2;
-    const steps = 6;
-    for (let i = 0; i <= steps; i++) {
-      const type =
-        i === 0 ? "touchstart" : i === steps ? "touchend" : "touchmove";
-      await target.page().evaluate(
-        ({ type, x, y, x0, y0 }) => {
-          // Whatever is under the finger, as a real touchscreen would have it:
-          // the gesture is handled somewhere up the tree from there, and the
-          // whole sequence goes to the element the finger landed on.
-          const node = document.elementFromPoint(x0, y0);
-          if (!node) throw new Error("nothing under the finger");
-          const point = new Touch({
-            identifier: 1,
-            target: node,
-            clientX: x,
-            clientY: y,
-          });
-          const held = type === "touchend" ? [] : [point];
-          node.dispatchEvent(
-            new TouchEvent(type, {
-              bubbles: true,
-              cancelable: true,
-              touches: held,
-              targetTouches: held,
-              changedTouches: [point],
-            })
-          );
-        },
-        { type, x: x0 + (by * i) / steps, y: y0 + (down * i) / steps, x0, y0 }
-      );
-    }
-  }
 
   test("reads on with a swipe, and stops at the end of the collection", async ({
     page,

--- a/tests/e2e/helpers/touch.ts
+++ b/tests/e2e/helpers/touch.ts
@@ -1,0 +1,46 @@
+import type { Locator } from "@playwright/test";
+
+/**
+ * A finger, in the only terms Playwright leaves for one: touch events on the
+ * element under it. Dispatched one round trip at a time so the browser lays
+ * out and paints between them, the way it would under a real thumb.
+ */
+export async function swipe(
+  target: Locator,
+  { by, down = 0, startX }: { by: number; down?: number; startX?: number }
+) {
+  const box = (await target.boundingBox())!;
+  const x0 = startX ?? box.x + box.width / 2;
+  const y0 = box.y + box.height / 2;
+  const steps = 6;
+  for (let i = 0; i <= steps; i++) {
+    const type =
+      i === 0 ? "touchstart" : i === steps ? "touchend" : "touchmove";
+    await target.page().evaluate(
+      ({ type, x, y, x0, y0 }) => {
+        // Whatever is under the finger, as a real touchscreen would have it:
+        // the gesture is handled somewhere up the tree from there, and the
+        // whole sequence goes to the element the finger landed on.
+        const node = document.elementFromPoint(x0, y0);
+        if (!node) throw new Error("nothing under the finger");
+        const point = new Touch({
+          identifier: 1,
+          target: node,
+          clientX: x,
+          clientY: y,
+        });
+        const held = type === "touchend" ? [] : [point];
+        node.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: held,
+            targetTouches: held,
+            changedTouches: [point],
+          })
+        );
+      },
+      { type, x: x0 + (by * i) / steps, y: y0 + (down * i) / steps, x0, y0 }
+    );
+  }
+}

--- a/tests/e2e/schedule-layout.spec.ts
+++ b/tests/e2e/schedule-layout.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
+import { swipe } from "./helpers/touch";
 
 // The grid view is an "app frame": below the nav bar a single scroll
 // container owns the viewport, with a slim toolbar as its first row. The
@@ -252,4 +253,58 @@ test("dragging the schedule pans it sideways", async ({ page }) => {
   // The toolbar's controls stick to the visible area (like the fold bars and
   // the footer) instead of scrolling out with the wide grid.
   await expect(page.getByRole("button", { name: "Grid" })).toBeInViewport();
+});
+
+// The frame locks window scrolling, which takes the browser's own
+// pull-to-refresh with it (there is no scrollable body left for the gesture to
+// attach to), so the schedule brings its own — guarded so that panning the
+// grid around never reloads by accident.
+test.describe("pull to refresh", () => {
+  test.use({ hasTouch: true });
+
+  const navigationType = (page: import("@playwright/test").Page) =>
+    page.evaluate(
+      () =>
+        (
+          performance.getEntriesByType(
+            "navigation"
+          )[0] as PerformanceNavigationTiming
+        ).type
+    );
+
+  test("a long pull down at the top of the schedule reloads it", async ({
+    page,
+  }) => {
+    expect(await navigationType(page)).toBe("navigate");
+    await swipe(page.getByTestId("schedule-scroll"), { by: 0, down: 220 });
+    await expect.poll(() => navigationType(page)).toBe("reload");
+  });
+
+  test("panning the schedule never reloads it by accident", async ({
+    page,
+  }) => {
+    const scroller = page.getByTestId("schedule-scroll");
+    const stillThere = async () => {
+      await page.waitForTimeout(200);
+      expect(await navigationType(page)).toBe("navigate");
+    };
+
+    // A nudge downwards — the start of any drag — is short of the threshold.
+    await swipe(scroller, { by: 0, down: 40 });
+    await stillThere();
+
+    // Panning sideways to see the later rooms.
+    await swipe(scroller, { by: -220 });
+    await stillThere();
+
+    // And a long pull down once the schedule is scrolled: there the gesture
+    // belongs to the schedule's own scrolling, not to a refresh.
+    await page.mouse.move(250, 400);
+    await page.mouse.wheel(0, 300);
+    await expect
+      .poll(() => scroller.evaluate((el) => el.scrollTop))
+      .toBeGreaterThan(100);
+    await swipe(scroller, { by: 0, down: 220 });
+    await stillThere();
+  });
 });


### PR DESCRIPTION
Fixes schellingboard/schellingboard#858.

The schedule's frame locks window scrolling so the inner grid can own the
viewport, and the browser's native pull-to-refresh goes with it: the gesture
attaches to a scrollable body, and there isn't one. So the schedule grows its
own on the inner scroller — option 1 from the issue, rather than re-enabling
native body scroll conditionally.

## The guard

Panning the grid starts as the same downward drag, so a gesture only counts when
it starts with the scroller **at its own top**, uses **one finger**, and settles
into a **downward-dominant** drag within its first 8px. 90px of travel then arms
it, and letting go there reloads.

A badge follows at half speed up to 64px — short of the finger, so a pull that
has arrived still looks like it has more to give — fades in as the threshold
nears, and turns brand-coloured once armed. The pull is visible well before it
commits, and springs back if you let go early.

Nothing changes on pages that scroll normally: their native gesture was never
broken, and this only listens on the schedule's scroller.

## Tests

Red-first. E2E covers the reload and the three gestures that must **not** cause
one: a short nudge, a sideways pan, and a long pull from an already-scrolled
schedule. The touch-swipe helper moves out of `attendee-profiles.spec.ts` into
`tests/e2e/helpers/touch.ts`, since both specs need a finger now.

`make precommit` is green.

## Tried on a phone

Confirmed on a physical iPhone in **Chrome on iOS**, against the dev server
through a tunnel: the pull reads as deliberate, the badge tracks the finger,
letting go reloads, and panning the grid around doesn't. The thresholds felt
right as they are, so nothing was adjusted after the fact.

Chrome on iOS is WebKit, so that covers the engine — but not Safari's own
overscroll handling in a tab, and not Android. Neither has been tried.

Written by Claude Code, which also made the changes described here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


