### PR TITLE
fix: treat a name that no longer exists as no name selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   set up, "Enable protection" looked like it did nothing at all
 - **A comment opened from an email no longer strands the page it lands on** (#930): a link
   to a comment on a long profile could leave the profile scrolled under its own header
+- **A deleted name no longer leaves you half logged in** (#931): the header asked you to
+  pick a name again while the comment box still let you post, and posting then failed
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/comment-actions.ts
+++ b/app/(site)/[eventSlug]/comment-actions.ts
@@ -21,7 +21,7 @@ import {
 } from "@/utils/notifications";
 import { serverNow } from "@/utils/dev-clock-server";
 import {
-  NAME_PROTECTED_ERROR,
+  unverifiedUserMessage,
   verifiedCurrentUser,
 } from "@/utils/acting-guest";
 import { requireSiteAuth } from "@/utils/action-auth";
@@ -31,8 +31,6 @@ export type CommentActionResult =
 
 export type CommentLikeResult =
   { error: string | z.core.$ZodIssue[] } | { success: true; liked: boolean };
-
-const NO_NAME_ERROR = `Select your name before commenting — ${NAME_PROTECTED_ERROR.toLowerCase()}`;
 
 class Refusal extends Error {
   constructor(readonly payload: string | z.core.$ZodIssue[]) {
@@ -60,10 +58,11 @@ function revalidateEvent(eventSlug: string | undefined): void {
   }
 }
 
-async function requireGuest(): Promise<string> {
-  const guest = await verifiedCurrentUser(await cookies());
+async function requireGuest(task: string): Promise<string> {
+  const cookieStore = await cookies();
+  const guest = await verifiedCurrentUser(cookieStore);
   if (!guest) {
-    throw new Refusal(NO_NAME_ERROR);
+    throw new Refusal(await unverifiedUserMessage(cookieStore, task));
   }
   return guest;
 }
@@ -99,7 +98,7 @@ export async function createProposalComment(
 ): Promise<CommentActionResult> {
   await requireSiteAuth();
   try {
-    const guest = await requireGuest();
+    const guest = await requireGuest("commenting");
     const { proposalId, parentId, body, eventSlug } = await requireParsed(
       proposalCommentSchema,
       input
@@ -141,7 +140,7 @@ export async function createSessionComment(
 ): Promise<CommentActionResult> {
   await requireSiteAuth();
   try {
-    const guest = await requireGuest();
+    const guest = await requireGuest("commenting");
     const { sessionId, parentId, body } = await requireParsed(
       sessionCommentSchema,
       input
@@ -182,7 +181,7 @@ export async function createProfileComment(
 ): Promise<CommentActionResult> {
   await requireSiteAuth();
   try {
-    const guest = await requireGuest();
+    const guest = await requireGuest("commenting");
     const { profileId, parentId, body } = await requireParsed(
       profileCommentSchema,
       input
@@ -223,7 +222,7 @@ export async function updateComment(
 ): Promise<CommentActionResult> {
   await requireSiteAuth();
   try {
-    const guest = await requireGuest();
+    const guest = await requireGuest("editing your comment");
     const { commentId, body, eventSlug } = await requireParsed(
       commentUpdateSchema,
       input
@@ -250,7 +249,7 @@ export async function toggleCommentLike(
 ): Promise<CommentLikeResult> {
   await requireSiteAuth();
   try {
-    const guest = await requireGuest();
+    const guest = await requireGuest("liking a comment");
     const { commentId, eventSlug } = await requireParsed(
       commentLikeSchema,
       input
@@ -282,7 +281,7 @@ export async function deleteComment(
 ): Promise<CommentActionResult> {
   await requireSiteAuth();
   try {
-    const guest = await requireGuest();
+    const guest = await requireGuest("deleting your comment");
     const { commentId, eventSlug } = await requireParsed(
       commentDeleteSchema,
       input

--- a/tests/integration/acting-guest.test.ts
+++ b/tests/integration/acting-guest.test.ts
@@ -1,0 +1,109 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import {
+  GUEST_COOKIE_NAME,
+  openGuestValue,
+  verifiedGuestValue,
+} from "../helpers/guest-cookie";
+import {
+  unverifiedUserMessage,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+function jar(value?: string) {
+  return {
+    get: (name: string) =>
+      name === GUEST_COOKIE_NAME && value !== undefined ? { value } : undefined,
+  };
+}
+
+describe("the acting guest", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("is the selected guest", async () => {
+    const guest = await createGuest();
+
+    expect(await verifiedCurrentUser(jar(openGuestValue(guest.id)))).toBe(
+      guest.id
+    );
+  });
+
+  it("is nobody when a protected name is selected without a verified session", async () => {
+    const guest = await createGuest();
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+
+    expect(await verifiedCurrentUser(jar(openGuestValue(guest.id)))).toBeNull();
+  });
+
+  it("is the protected guest a verified session names", async () => {
+    const guest = await createGuest();
+    const cookie = await verifiedGuestValue(guest.id);
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+
+    expect(await verifiedCurrentUser(jar(cookie))).toBe(guest.id);
+  });
+
+  it("is nobody once the selected guest has been deleted", async () => {
+    const guest = await createGuest();
+    const cookie = openGuestValue(guest.id);
+    await getRepositories().guests.delete(guest.id);
+
+    expect(await verifiedCurrentUser(jar(cookie))).toBeNull();
+  });
+
+  it("is nobody when a verified session names a deleted guest", async () => {
+    const guest = await createGuest();
+    const cookie = await verifiedGuestValue(guest.id);
+    await getRepositories().guests.delete(guest.id);
+
+    expect(await verifiedCurrentUser(jar(cookie))).toBeNull();
+  });
+
+  it("tells a visitor whose guest was deleted to pick a name", async () => {
+    const guest = await createGuest();
+    const cookie = openGuestValue(guest.id);
+    await getRepositories().guests.delete(guest.id);
+
+    expect(await unverifiedUserMessage(jar(cookie), "commenting")).toMatch(
+      /select who you are/i
+    );
+  });
+
+  it("tells a visitor with an unverified protected name to switch to it", async () => {
+    const guest = await createGuest();
+    await getRepositories().guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: null,
+    });
+
+    expect(
+      await unverifiedUserMessage(jar(openGuestValue(guest.id)), "commenting")
+    ).toMatch(/protected/i);
+  });
+});

--- a/tests/integration/proposal-comments.test.ts
+++ b/tests/integration/proposal-comments.test.ts
@@ -189,6 +189,23 @@ describe("proposal comments", () => {
     ).toHaveLength(0);
   });
 
+  it("tells a commenter whose guest was deleted what to do about it", async () => {
+    const { event, guest, proposal } = await setup();
+    act(guest.id);
+    await getRepositories().guests.delete(guest.id);
+
+    const result = await createComment({
+      proposalId: proposal.id,
+      eventSlug: event.slug,
+      body: "ghost",
+    });
+
+    expect("error" in result && result.error).toMatch(/select who you are/i);
+    expect(
+      await getRepositories().proposalComments.list(proposal.id)
+    ).toHaveLength(0);
+  });
+
   it("refuses to comment as a protected guest without a verified session", async () => {
     const { event, guest, proposal } = await setup();
     await getRepositories().guests.setAuthProtection(guest.id, {

--- a/utils/acting-guest.ts
+++ b/utils/acting-guest.ts
@@ -64,6 +64,12 @@ type ReadonlyCookies = {
   get(name: string): { value: string } | undefined;
 };
 
+async function guestExists(id: string): Promise<boolean> {
+  // The cheapest existence probe the repository offers: two columns, where
+  // findById assembles the whole profile.
+  return (await getRepositories().guests.getAuthCredentials(id)) !== null;
+}
+
 /**
  * The current user id from the guest cookie, for server components and
  * actions — but null when that guest is protected and the cookie isn't a
@@ -74,11 +80,9 @@ export async function verifiedCurrentUser(
   cookieStore: ReadonlyCookies
 ): Promise<string | null> {
   const value = cookieStore.get(GUEST_COOKIE_NAME)?.value;
-  const parsed = await readGuestCookie(value);
-  if (!parsed) return null;
-  return (await isVerifiedAsGuest(parsed.guestId, value))
-    ? parsed.guestId
-    : null;
+  const guestId = await currentGuestSelection(cookieStore);
+  if (!guestId) return null;
+  return (await isVerifiedAsGuest(guestId, value)) ? guestId : null;
 }
 
 /**
@@ -86,6 +90,12 @@ export async function verifiedCurrentUser(
  * selected. Use only to tell "no name selected" apart from "a protected name
  * selected but not yet verified" — never to authorize acting as the guest
  * (use verifiedCurrentUser for that).
+ *
+ * A cookie naming a guest the database no longer has counts as no selection:
+ * it outlives the guest when an organizer deletes one, or when a development
+ * database is reseeded under the browser. The header chip already reads that
+ * state as "Select your name" — everything else has to agree, or the page
+ * keeps offering actions that die on a foreign key (#931).
  */
 export async function currentGuestSelection(
   cookieStore: ReadonlyCookies
@@ -93,7 +103,8 @@ export async function currentGuestSelection(
   const parsed = await readGuestCookie(
     cookieStore.get(GUEST_COOKIE_NAME)?.value
   );
-  return parsed?.guestId ?? null;
+  if (!parsed) return null;
+  return (await guestExists(parsed.guestId)) ? parsed.guestId : null;
 }
 
 /**


### PR DESCRIPTION
Deleting a guest left every browser holding that selection half logged
in: the header chip fell back to "Select your name" (it looks the name
up in the guest list) while the comment box, which trusts the cookie,
stayed open — and posting died on the author foreign key as "Failed to
post comment". Resolving the acting guest now checks the guest is still
there, so the whole UI agrees nobody is selected, and the comment
actions explain which step is missing instead of concatenating the
pick-a-name and protected-name messages into one contradictory line.

fixes schellingboard/schellingboard#931

<!-- jip:pushed-commit=b8995fec4a4cc1b9dcd88499979c90b345df9e0c -->