### PR TITLE
fix: scroll kiosk displays to the now line as soon as it appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to a comment on a long profile could leave the profile scrolled under its own header
 - **A deleted name no longer leaves you half logged in** (#931): the header asked you to
   pick a name again while the comment box still let you post, and posting then failed
+- **Kiosk displays move to the current time as soon as the day starts**: a display left on
+  overnight sat at the top of the schedule for up to three minutes after the first slot began
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -172,7 +172,7 @@ export function EventDisplay() {
         <SessionModal sessionId={viewSession} eventSlug={event.slug} />
       )}
       <MeetingModalFromUrl />
-      {kiosk && <KioskController />}
+      {kiosk && <KioskController nowIsOnSchedule={nowIsOnSchedule} />}
     </>
   );
 }

--- a/app/(site)/[eventSlug]/kiosk.tsx
+++ b/app/(site)/[eventSlug]/kiosk.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { scrollNowLineIntoView } from "./now-line";
 
@@ -69,7 +69,11 @@ export function useKioskMode(): boolean {
  * whole: periodic data refresh, keeping the screen awake, and scrolling the
  * schedule back to the now line.
  */
-export function KioskController() {
+export function KioskController(props: {
+  /** Whether a now line is drawn at all — false outside the event's days. */
+  nowIsOnSchedule: boolean;
+}) {
+  const { nowIsOnSchedule } = props;
   const router = useRouter();
 
   // Kiosk screens stay open for days while organizers move sessions around;
@@ -106,13 +110,13 @@ export function KioskController() {
     };
   }, []);
 
-  // Periodically bring the now line back into view, the same jump the
-  // toolbar's "Now" button makes. Paused while someone is interacting with
+  // Outside the effect below, which restarts when the now line appears: a day
+  // starting under someone's fingers must not clear how recently they touched
   // the display.
+  const lastInteraction = useRef(-Infinity);
   useEffect(() => {
-    let lastInteraction = -Infinity;
     const markInteraction = () => {
-      lastInteraction = performance.now();
+      lastInteraction.current = performance.now();
     };
     const interactionEvents = [
       "pointerdown",
@@ -123,9 +127,23 @@ export function KioskController() {
     for (const name of interactionEvents) {
       document.addEventListener(name, markInteraction, { passive: true });
     }
+    return () => {
+      for (const name of interactionEvents) {
+        document.removeEventListener(name, markInteraction);
+      }
+    };
+  }, []);
 
+  // Periodically bring the now line back into view, the same jump the
+  // toolbar's "Now" button makes. Paused while someone is interacting with
+  // the display. The cycle restarts when the line appears — the event day
+  // starting, or the dev fake clock jumping into one — so the display moves
+  // to it right away instead of at the next interval.
+  useEffect(() => {
+    if (!nowIsOnSchedule) return;
     const scrollToNow = () => {
-      if (performance.now() - lastInteraction < INTERACTION_IDLE_MS) return;
+      if (performance.now() - lastInteraction.current < INTERACTION_IDLE_MS)
+        return;
       scrollNowLineIntoView();
     };
 
@@ -134,11 +152,8 @@ export function KioskController() {
     return () => {
       clearTimeout(initial);
       clearInterval(interval);
-      for (const name of interactionEvents) {
-        document.removeEventListener(name, markInteraction);
-      }
     };
-  }, []);
+  }, [nowIsOnSchedule]);
 
   return null;
 }

--- a/tests/e2e/kiosk.spec.ts
+++ b/tests/e2e/kiosk.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "./helpers/fixtures";
-import { openGammaScheduleDuringEvent } from "./helpers/dev-clock";
+import { login } from "./helpers/auth";
+import {
+  duringGammaDayOne,
+  openGammaScheduleDuringEvent,
+  setDevClock,
+} from "./helpers/dev-clock";
 
 // Kiosk mode (?kiosk=1) is meant for large screens at the venue. The now line
 // itself is drawn on every schedule (see now-line.spec.ts); what kiosk mode
@@ -59,4 +64,21 @@ test("?kiosk=0 clears the cookie and leaves kiosk mode", async ({ page }) => {
   await page.goto("/Conference-Gamma");
   await page.waitForTimeout(2000);
   await expect(page.getByTestId("now-line")).not.toBeInViewport();
+});
+
+// A display that was already on before the day started has no line to scroll to
+// at load; the fake clock stands in for the day beginning under it.
+test("kiosk mode scrolls to the now line once it appears", async ({ page }) => {
+  await login(page);
+  await page.goto("/Conference-Gamma?kiosk=1&dev=1");
+
+  // The real clock is not inside any event day, so nothing is drawn yet.
+  await expect(page.getByTestId("now-line")).toHaveCount(0);
+
+  // Wait out the initial auto-scroll so it can't be what brings the line into
+  // view: the next scheduled scroll is three minutes off, well past the
+  // assertion below, so only reacting to the line appearing can satisfy it.
+  await page.waitForTimeout(2000);
+  await setDevClock(page, duringGammaDayOne);
+  await expect(page.getByTestId("now-line")).toBeInViewport();
 });


### PR DESCRIPTION
The kiosk controller scrolled once a second after mount and then only
every three minutes, so a display whose page loaded before the line
existed — a day starting under it, or the dev fake clock jumping into
one — sat at the top of the schedule until the next interval. The scroll
cycle now restarts when the line appears.

How recently someone touched the display is kept outside that cycle, so
a day starting under their fingers doesn't reset the idle guard and yank
the schedule away from them.

<!-- jip:pushed-commit=6899bc34e1bbd010aa9b01cbeadfad2cf8c00859 -->