### PR TITLE
fix: close a modal dismissed while it is still fading in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   pick a name again while the comment box still let you post, and posting then failed
 - **Kiosk displays move to the current time as soon as the day starts**: a display left on
   overnight sat at the top of the schedule for up to three minutes after the first slot began
+- **A modal closed while still opening no longer gets stuck**: pressing Escape or Close before a
+  modal had finished fading in could leave it open with no way out but a reload
 
 ### Internal
 

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { Dialog, Transition } from "@headlessui/react";
-import { Fragment, useRef } from "react";
+import { Fragment, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useSafeLayoutEffect } from "@/utils/hooks";
 
 export function Modal(props: {
   open: boolean;
@@ -26,9 +27,36 @@ export function Modal(props: {
   } = props;
   const fakeRef = useRef(null);
 
+  // Headless UI reverses an in-flight transition, then one frame later reads
+  // which animations to wait for — a frame React can miss on a busy page, after
+  // which the leave never completes and the dialog is stuck open. So remount the
+  // transition on a flip that interrupts one, snapping instead of reversing.
+  const [generation, setGeneration] = useState(0);
+  const transitioning = useRef(false);
+  const settled = () => {
+    transitioning.current = false;
+  };
+  const previousOpen = useRef(open);
+  useSafeLayoutEffect(() => {
+    if (open === previousOpen.current) return;
+    previousOpen.current = open;
+    if (transitioning.current) {
+      transitioning.current = false;
+      setGeneration((g) => g + 1);
+    } else {
+      transitioning.current = true;
+    }
+  }, [open]);
+
   const modalContent = (
     <div>
-      <Transition.Root show={open} as={Fragment}>
+      <Transition.Root
+        key={generation}
+        show={open}
+        as={Fragment}
+        afterEnter={settled}
+        afterLeave={settled}
+      >
         <Dialog
           as="div"
           initialFocus={fakeRef}


### PR DESCRIPTION
Headless UI reverses an in-flight enter transition on close and, one frame
later, reads which animations to wait for. On a busy page (still hydrating)
React applies the reversal after that frame, so the hook waits on animations
the reversal then cancels, bails out, and never unmounts: the dialog stays
open with no way out but a reload. Behind the release-notes and
schedule-layout E2E flakes.

Modal now remounts its Transition when open flips mid-animation, so an early
close snaps shut instead of reversing. Reproduced by delaying React's
scheduler; stuck ~1 in 6 attempts before, 0 of 72 after.

<!-- jip:pushed-commit=82b4dfb24a0776e994c7a2521878f1b51d31dcf4 -->