### PR TITLE
test: wait for the reload instead of polling through it in the pull-to-refresh spec

### DIFF
--- a/tests/e2e/schedule-layout.spec.ts
+++ b/tests/e2e/schedule-layout.spec.ts
@@ -276,8 +276,10 @@ test.describe("pull to refresh", () => {
     page,
   }) => {
     expect(await navigationType(page)).toBe("navigate");
+    const reloaded = page.waitForEvent("load");
     await swipe(page.getByTestId("schedule-scroll"), { by: 0, down: 220 });
-    await expect.poll(() => navigationType(page)).toBe("reload");
+    await reloaded;
+    expect(await navigationType(page)).toBe("reload");
   });
 
   test("panning the schedule never reloads it by accident", async ({


### PR DESCRIPTION
The pull-to-refresh E2E test in `tests/e2e/schedule-layout.spec.ts` (added in 07e19f5) was flaky on Firefox: `expect.poll(() => navigationType(page))` called `page.evaluate` while the reload it was waiting for tore the execution context down, failing with "Execution context was destroyed, most likely because of a navigation" (3 of 6 runs on 2026-09-06).

The test now registers a wait for the page `load` event before the swipe, awaits it afterwards, and then asserts once that the navigation type is `reload`. The reload fires synchronously in the `touchend` handler, so nothing evaluates through the navigation any more.

Verified with `--repeat-each 3` and `--repeat-each 5` on Firefox: 16 of 16 passed. Test-only change, no changelog entry.

Written by Claude Code, which also made the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)