### PR TITLE
feat: let hosts record how many people attended their session

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -26,6 +26,10 @@ SMTP_FROM=
 # emails can link back to the site. Required when email is configured.
 SITE_URL=
 
+# How often to send due attendee-count reminders, in milliseconds
+# (default: 60000). Set to 0 to switch those two emails off entirely.
+REMINDER_DISPATCH_INTERVAL_MS=
+
 # Option A: a single connection URL, e.g. smtp://user:pass@localhost:1025
 SMTP_URL=
 

--- a/.env.test
+++ b/.env.test
@@ -11,6 +11,12 @@ SB_UPLOADS_DIR=./uploads-test/
 # test can time-travel. Inert for other tests, which never opt in.
 SB_ENABLE_DEV_TOOLS=1
 
+# No unattended reminder dispatch during E2E. The seed dates every fixture
+# relative to now, so a live tick would drop unrelated mail into the mailbox
+# the delivery assertions search, flaky by time of day. Tests that need a
+# dispatch trigger one from the dev toolbar.
+REMINDER_DISPATCH_INTERVAL_MS=0
+
 # Email tests are opt-in: they need Mailpit running (make mailpit) and these
 # variables set in .env.test.local, otherwise they are skipped. See
 # docs/dev/testing.md § Running tests. Typical values:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,3 +227,13 @@ const renderedSize = { lg: 112, md: 64, sm: 48 }[size];
 ## Misc
 
 When adding a link to session/proposal modal, see `modal-nav.ts`, there are gotchas (anchor: MnpjIo7Y).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,11 +244,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   fixed amount and waiting 300–500ms for it. The room-details hover retries too: under load the
   mouse could arrive before the grid had hydrated, and that first hover was simply lost
 - E2E tests settle the page before reloading it rather than after. The kiosk tests wait for the
-  dev clock's refresh to finish streaming — a wait that now lives in
-  `tests/e2e/helpers/dev-clock.ts`, shared by every spec that time-travels — and the view-session
-  test for the fetches the session modal starts; a reload aborts whatever is still in flight, which
-  logs the RSC-payload and `NetworkError` failures the console guard fails on. Waiting only
-  afterwards was too late
+  dev clock's refresh to finish streaming, and the view-session test for the fetches the session
+  modal starts; a reload aborts whatever is still in flight, which logs the RSC-payload and
+  `NetworkError` failures the console guard fails on. Waiting only afterwards was too late
 - Mail E2E tests wait for the mail they triggered by its identity instead of counting how many
   match its subject. Mailpit answers a search with the newest 50 matches and keeps only the newest
   500 messages, so once a few suite runs had filled those the count of "Set your password" mails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   other person reads on the meeting itself
 - **Find the attendees who are open to 1-on-1s** (#945): a new filter in the attendee directory,
   beside Session host and Has profile. It covers every event on the site, not only this one
+- **Hosts can record how many people came** (#852): a finished session offers its hosts a
+  field for the real attendance figure. Only its hosts see it, and 0 means "held, nobody came"
+- **Two reminders nudge hosts to count the room** (#852): an hour before a session starts
+  and a quarter of an hour after it ends, in the app and — where email is set up — by email
 
 ### Changed
 
@@ -240,9 +244,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   fixed amount and waiting 300–500ms for it. The room-details hover retries too: under load the
   mouse could arrive before the grid had hydrated, and that first hover was simply lost
 - E2E tests settle the page before reloading it rather than after. The kiosk tests wait for the
-  dev clock's refresh to finish streaming, and the view-session test for the fetches the session
-  modal starts; a reload aborts whatever is still in flight, which logs the RSC-payload and
-  `NetworkError` failures the console guard fails on. Waiting only afterwards was too late
+  dev clock's refresh to finish streaming — a wait that now lives in
+  `tests/e2e/helpers/dev-clock.ts`, shared by every spec that time-travels — and the view-session
+  test for the fetches the session modal starts; a reload aborts whatever is still in flight, which
+  logs the RSC-payload and `NetworkError` failures the console guard fails on. Waiting only
+  afterwards was too late
 - Mail E2E tests wait for the mail they triggered by its identity instead of counting how many
   match its subject. Mailpit answers a search with the newest 50 matches and keeps only the newest
   500 messages, so once a few suite runs had filled those the count of "Set your password" mails

--- a/app/(site)/[eventSlug]/modal-nav.ts
+++ b/app/(site)/[eventSlug]/modal-nav.ts
@@ -165,6 +165,11 @@ export function dismissViewSession() {
   }
   const params = new URLSearchParams(window.location.search);
   params.delete("viewSession");
+  // The attendee-count follow-up's auto-focus flag belongs to the session it
+  // arrived for. viewSessionLinkFromOwner copies the current query into every
+  // session link on the schedule, so leaving it behind auto-focuses the field
+  // on every finished session opened afterwards.
+  params.delete("record");
   const query = params.toString();
   const url = query
     ? `${window.location.pathname}?${query}`

--- a/app/(site)/[eventSlug]/view-session/attendee-count-field.tsx
+++ b/app/(site)/[eventSlug]/view-session/attendee-count-field.tsx
@@ -21,7 +21,7 @@ import { setActionErrors } from "@/utils/forms";
  *
  * The stored count is fetched here rather than read off the session: it is
  * absent from the `Session` type on purpose, because that type reaches every
- * visitor's browser (docs/dev/adr/0006).
+ * visitor's browser (docs/dev/adr/0007).
  */
 export function AttendeeCountField({
   sessionId,

--- a/app/(site)/[eventSlug]/view-session/attendee-count-field.tsx
+++ b/app/(site)/[eventSlug]/view-session/attendee-count-field.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import {
+  getAttendeeCountAction,
+  setAttendeeCountAction,
+} from "@/app/actions/attendee-count";
+import {
+  attendeeCountFormSchema,
+  MAX_ATTENDEE_COUNT,
+  MIN_ATTENDEE_COUNT,
+} from "@/model/attendee-count";
+import { setActionErrors } from "@/utils/forms";
+
+/**
+ * Records how many people came to a finished session. Rendered only for a
+ * host, but the server action is the enforcement — hiding it is a courtesy.
+ *
+ * The stored count is fetched here rather than read off the session: it is
+ * absent from the `Session` type on purpose, because that type reaches every
+ * visitor's browser (docs/dev/adr/0006).
+ */
+export function AttendeeCountField({
+  sessionId,
+  autoFocus = false,
+}: {
+  sessionId: string;
+  /**
+   * Set only when the URL carries the follow-up email's `record=count`.
+   * Focusing every finished session a host opens would steal their scroll
+   * position and pop the keyboard on mobile.
+   */
+  autoFocus?: boolean;
+}) {
+  const fieldId = useId();
+  const messageId = `${fieldId}-message`;
+  const [loaded, setLoaded] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const form = useForm({
+    defaultValues: { count: "" },
+    resolver: zodResolver(attendeeCountFormSchema),
+  });
+  const { reset, setError } = form;
+
+  useEffect(() => {
+    let cancelled = false;
+    void getAttendeeCountAction(sessionId).then((result) => {
+      if (cancelled) return;
+      if (result.ok) {
+        reset({ count: result.count === null ? "" : String(result.count) });
+      } else if (typeof result.error === "string") {
+        setError("root", { message: result.error });
+      }
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, reset, setError]);
+
+  const handleSubmit = async ({ count }: { count: number | null }) => {
+    setSaved(false);
+    try {
+      const result = await setAttendeeCountAction(sessionId, count);
+      if (!result.ok) {
+        setActionErrors(form, result.error);
+        return;
+      }
+      // Rebaseline from what was stored, so a second save racing this one
+      // leaves the field showing the value that actually won.
+      reset({ count: result.count === null ? "" : String(result.count) });
+      setSaved(true);
+    } catch (err) {
+      form.setError("root", { message: "Could not save — try again" });
+      console.error(err);
+    }
+  };
+
+  const { errors, isSubmitting } = form.formState;
+  const message = errors.count?.message ?? errors.root?.message;
+
+  if (!loaded) return null;
+
+  return (
+    <section className="mb-6 rounded-md border border-line-subtle bg-surface-muted p-3">
+      <form
+        onSubmit={(e) => form.handleSubmit(handleSubmit)(e) as never}
+        // The browser's own number validation would block the submit and show
+        // a tooltip, so the shared Zod rule would never get to put its message
+        // on the field where ADR 0003 wants it.
+        noValidate
+        className="flex flex-col gap-2"
+      >
+        <label htmlFor={fieldId} className="text-sm font-medium text-fg">
+          How many people attended?
+        </label>
+        <p className="text-xs text-fg-subtle">
+          Optional. Only you and your co-hosts will see this, not the attendees.
+          Enter <strong>0</strong> if the session was held but nobody came. If
+          it never happened at all, delete the session instead. Leave the field
+          empty to go back to no count at all.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            {...form.register("count")}
+            id={fieldId}
+            autoFocus={autoFocus}
+            type="number"
+            inputMode="numeric"
+            min={MIN_ATTENDEE_COUNT}
+            max={MAX_ATTENDEE_COUNT}
+            step={1}
+            aria-invalid={message ? true : undefined}
+            aria-describedby={message ? messageId : undefined}
+            className="w-24 rounded-md border border-line bg-surface-raised px-2 py-1 text-sm text-fg focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-accent"
+          />
+          <button
+            type="submit"
+            aria-label="Save attendee count"
+            disabled={isSubmitting}
+            className="rounded-md bg-brand px-3 py-1 text-sm font-medium text-on-brand shadow hover:bg-brand-hover disabled:bg-surface-hover disabled:text-fg-subtle disabled:shadow-none"
+          >
+            Save
+          </button>
+          {/* Announced rather than only coloured: the save has no other
+              outward sign once the value is already in the input. */}
+          <span role="status" aria-live="polite" className="text-xs">
+            {isSubmitting ? (
+              <span className="text-fg-muted">Saving&hellip;</span>
+            ) : saved && !form.formState.isDirty ? (
+              <span className="text-success-fg">Saved</span>
+            ) : null}
+          </span>
+        </div>
+        {message && (
+          <p id={messageId} className="text-xs text-danger-fg">
+            {message}
+          </p>
+        )}
+      </form>
+    </section>
+  );
+}

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useContext, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { PencilIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon, AcademicCapIcon } from "@heroicons/react/24/solid";
 
@@ -20,6 +20,7 @@ import { LocationTag } from "../session-text";
 import { viewProposalLinkFromElsewhere } from "../modal-nav";
 import { SessionComments } from "../session-comments";
 import { Markdown } from "@/app/(site)/markdown";
+import { AttendeeCountField } from "./attendee-count-field";
 
 export function ViewSession(props: {
   session: Session;
@@ -47,6 +48,7 @@ export function ViewSession(props: {
     userBusySessions,
     rsvps: userRsvps,
     locations,
+    now,
   } = useContext(EventContext);
 
   // Reconcile session RSVPs with the current user's RSVP from context, so
@@ -66,6 +68,8 @@ export function ViewSession(props: {
   }, [rsvps, currentUser, userRsvps, session.id]);
 
   const router = useRouter();
+  // Only the follow-up email adds `record=count`; see research.md §8.
+  const searchParams = useSearchParams();
   const [isRsvping, setIsRsvping] = useState(false);
   const [userModalOpen, setUserModalOpen] = useState(false);
   const [clashingSession, setClashingSession] = useState<Session | null>(null);
@@ -75,6 +79,10 @@ export function ViewSession(props: {
   const rsvpd = currentUser ? rsvpdForSession(session.id) : false;
   const isHost = currentUser && session.hosts.some((h) => h.id === currentUser);
   const isEditable = !!isHost && !session.adminManaged;
+  // Admin-managed sessions are included on purpose: a host records the count
+  // for a session they cannot otherwise edit (FR-007).
+  const canRecordAttendance =
+    !!isHost && !!session.endTime && session.endTime <= now;
 
   // session.numRsvps comes from localSessions, so it tracks optimistic RSVP
   // toggles; the fetched attendee list can be stale after a user switch.
@@ -328,6 +336,12 @@ export function ViewSession(props: {
           </span>
         </div>
       </div>
+      {canRecordAttendance && (
+        <AttendeeCountField
+          sessionId={session.id}
+          autoFocus={searchParams.get("record") === "count"}
+        />
+      )}
       <div className="mb-6">
         <h3 className="font-semibold mb-2">Description</h3>
         <Markdown>{session.description}</Markdown>

--- a/app/(site)/dev-toolbar.tsx
+++ b/app/(site)/dev-toolbar.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { TIME_OFFSET_COOKIE } from "@/utils/dev-clock";
+import { dispatchRemindersAction } from "@/app/actions/dev-reminders";
 
 // Hydration gate: false on the server and during the first hydration pass, true
 // once mounted on the client. Mirrors the useSyncExternalStore idiom used for
@@ -57,6 +58,7 @@ export function DevToolbar() {
   );
   const [dismissed, setDismissed] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [dispatched, setDispatched] = useState<string | null>(null);
   // Real wall-clock, ticked once a second so the displayed simulated time stays
   // live. Kept in state (not a render-time Date.now()) to satisfy purity rules.
   const [nowMs, setNowMs] = useState(0);
@@ -137,6 +139,32 @@ export function DevToolbar() {
           }}
         />
       </label>
+      {/* The reminder tick is off in E2E and once a minute in development, so
+          this triggers one against the simulated clock above. */}
+      <button
+        className="px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
+        onClick={() => {
+          setDispatched(null);
+          void dispatchRemindersAction()
+            .then((result) =>
+              setDispatched(
+                result.ok
+                  ? `sent ${result.summary.sent} reminders`
+                  : result.error
+              )
+            )
+            // Navigating away mid-flight aborts the request; that is not a
+            // failure worth surfacing from a dev-only button.
+            .catch(() => setDispatched("dispatch interrupted"));
+        }}
+      >
+        Send due reminders
+      </button>
+      {dispatched && (
+        <span role="status" className="tabular-nums">
+          {dispatched}
+        </span>
+      )}
       <button
         className="ml-auto px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
         onClick={() => setDismissed(true)}

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -108,6 +108,18 @@ export function SettingsForm({
             <input type="checkbox" {...form.register("meetingResponse")} />a
             1-on-1 of mine is accepted, declined or canceled
           </label>
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
+            <input type="checkbox" {...form.register("sessionHeadsUp")} />a
+            session I&rsquo;m hosting starts in an hour
+          </label>
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
+            <input
+              type="checkbox"
+              {...form.register("attendeeCountReminder")}
+            />
+            a session I&rsquo;m hosting ended a quarter of an hour ago, so I can
+            record how many people attended
+          </label>
         </fieldset>
 
         {form.formState.errors.root && (

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -117,8 +117,8 @@ export function SettingsForm({
               type="checkbox"
               {...form.register("attendeeCountReminder")}
             />
-            a session I&rsquo;m hosting ended a quarter of an hour ago, so I can
-            record how many people attended
+            a session I&rsquo;m hosting has ended, so I can record how many
+            people attended
           </label>
         </fieldset>
 

--- a/app/actions/attendee-count.ts
+++ b/app/actions/attendee-count.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { z } from "zod";
+import { getRepositories } from "@/db/container";
+import { attendeeCountFormSchema } from "@/model/attendee-count";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
+import { requireSiteAuth } from "@/utils/action-auth";
+import { serverNow } from "@/utils/dev-clock-server";
+
+export type AttendeeCountResult =
+  | { ok: true; count: number | null }
+  | { ok: false; error: string | z.core.$ZodIssue[] };
+
+// Deliberately the same wording for "not your session" and "no such session":
+// a distinct message would let a prober map out sessions they don't host.
+const NOT_YOURS = "Only this session's hosts can see its attendee count";
+const NOT_FINISHED =
+  "The attendee count can be recorded once the session has finished";
+
+/**
+ * The acting guest, and the session they are asking about, once every rule
+ * that does not depend on the submitted value has been enforced. Shared by
+ * both actions so the read and the write can never drift apart — the read is
+ * what a prober would use to find a gap in the write.
+ */
+async function authorizedSession(
+  sessionId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  await requireSiteAuth();
+  const currentUser = await verifiedCurrentUser(await cookies());
+  if (!currentUser) return { ok: false, error: "No user is logged in" };
+
+  const session = await getRepositories().sessions.findById(sessionId);
+  if (!session) return { ok: false, error: NOT_YOURS };
+  if (!session.hosts.some((host) => host.id === currentUser)) {
+    return { ok: false, error: NOT_YOURS };
+  }
+  if (!session.endTime || session.endTime > (await serverNow())) {
+    return { ok: false, error: NOT_FINISHED };
+  }
+  return { ok: true };
+}
+
+export async function getAttendeeCountAction(
+  sessionId: string
+): Promise<AttendeeCountResult> {
+  const authorized = await authorizedSession(sessionId);
+  if (!authorized.ok) return authorized;
+
+  const count = await getRepositories().sessions.getAttendeeCount(sessionId);
+  return { ok: true, count };
+}
+
+export async function setAttendeeCountAction(
+  sessionId: string,
+  value: unknown
+): Promise<AttendeeCountResult> {
+  // Authorization before validation (Constitution IV): a stranger must not be
+  // able to probe the validation rules of a session that isn't theirs.
+  const authorized = await authorizedSession(sessionId);
+  if (!authorized.ok) return authorized;
+
+  const parsed = attendeeCountFormSchema.safeParse({ count: value });
+  if (!parsed.success) return { ok: false, error: parsed.error.issues };
+
+  const { sessions } = getRepositories();
+  await sessions.setAttendeeCount(sessionId, parsed.data.count);
+
+  // The stored value, not the submitted one, so two saves racing each other
+  // converge on what is actually in the database (SC-007).
+  return { ok: true, count: await sessions.getAttendeeCount(sessionId) };
+}

--- a/app/actions/dev-reminders.ts
+++ b/app/actions/dev-reminders.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { requireSiteAuth } from "@/utils/action-auth";
+import { isDevToolsEnabled } from "@/utils/dev-clock";
+import { serverNow } from "@/utils/dev-clock-server";
+import {
+  dispatchDueReminders,
+  type DispatchSummary,
+} from "@/utils/reminder-dispatch";
+
+/**
+ * Runs one dispatch tick on demand, from the dev toolbar. Only exists so the
+ * reminder emails can be exercised without waiting for the interval — E2E
+ * disables the scheduler outright (REMINDER_DISPATCH_INTERVAL_MS=0) to keep
+ * stray sends out of the Mailpit assertions, and a developer checking the
+ * emails by hand does not want to wait either.
+ *
+ * Refuses unless SB_ENABLE_DEV_TOOLS is set, which no real deployment sets.
+ * It reads the dev clock, so time-travelling the browser past a session's end
+ * is enough to make its follow-up due.
+ */
+export async function dispatchRemindersAction(): Promise<
+  { ok: true; summary: DispatchSummary } | { ok: false; error: string }
+> {
+  await requireSiteAuth();
+  if (!isDevToolsEnabled()) {
+    return { ok: false, error: "Dev tools are not enabled" };
+  }
+  return { ok: true, summary: await dispatchDueReminders(await serverNow()) };
+}

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -49,7 +49,7 @@ export const releaseNotes: ReleaseNote[] = [
       "**Notifications on your phone**: Settings can send the notifications you already get to your phone or laptop, so they arrive while the site is closed. iPhones need it on the home screen first.",
       "**Notifications in the app**: a bell counts what is waiting, and clicking one takes you to it. Tick the ones you are done with to mark them read or delete them. No email set-up needed.",
       "**1-on-1s**: organizers switch them on and suggest where to meet; attendees mark when they are free, ask from a profile or an empty slot on the schedule, and accept or decline.",
-      '**The schedule shows where you are in the day**: a red line marks the current time while the event is running, and a "Now" button jumps to it.',
+      '**Hosts can record how many people came** to a session once it has finished. Only that session\'s hosts ever see the number, and 0 is a real answer: "held, nobody came".',
     ],
   },
   {

--- a/db/container.ts
+++ b/db/container.ts
@@ -17,6 +17,7 @@ import { SqliteMeetingPointsRepository } from "./repositories/sqlite/meeting-poi
 import { SqliteMeetingsRepository } from "./repositories/sqlite/meetings";
 import { SqliteNotificationsRepository } from "./repositories/sqlite/notifications";
 import { SqlitePushRepository } from "./repositories/sqlite/push";
+import { SqliteRemindersRepository } from "./repositories/sqlite/reminders";
 import { SqliteRsvpsRepository } from "./repositories/sqlite/rsvps";
 import { SqliteSettingsRepository } from "./repositories/sqlite/settings";
 import { SqliteSessionProposalsRepository } from "./repositories/sqlite/session-proposals";
@@ -34,6 +35,7 @@ import type {
   MeetingsRepository,
   NotificationsRepository,
   PushRepository,
+  RemindersRepository,
   RsvpsRepository,
   SettingsRepository,
   SessionProposalsRepository,
@@ -59,6 +61,7 @@ export type Repositories = {
   notifications: NotificationsRepository;
   push: PushRepository;
   sessions: SessionsRepository;
+  reminders: RemindersRepository;
   rsvps: RsvpsRepository;
   settings: SettingsRepository;
   sessionProposals: SessionProposalsRepository;
@@ -86,6 +89,7 @@ function buildRepositories(sqlite: Database.Database): Repositories {
     notifications: new SqliteNotificationsRepository(db),
     push: new SqlitePushRepository(db),
     sessions: new SqliteSessionsRepository(db),
+    reminders: new SqliteRemindersRepository(db),
     rsvps: new SqliteRsvpsRepository(db),
     settings: new SqliteSettingsRepository(db),
     sessionProposals: new SqliteSessionProposalsRepository(db),

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -154,6 +154,14 @@ export type EmailSettings = {
   meetingRequest: boolean;
   /** A 1-on-1 the guest asked for was accepted, declined or canceled. */
   meetingResponse: boolean;
+  /** The heads-up an hour before a session the guest is hosting starts. */
+  sessionHeadsUp: boolean;
+  /**
+   * The follow-up after a session the guest is hosting ends, asking for the
+   * attendee count. Like every other key here, both of these gate the mail
+   * alone: the reminders still reach the guest in the app.
+   */
+  attendeeCountReminder: boolean;
 };
 
 export const DEFAULT_EMAIL_SETTINGS: EmailSettings = {
@@ -168,6 +176,8 @@ export const DEFAULT_EMAIL_SETTINGS: EmailSettings = {
   // personally to the guest and is waiting on their answer.
   meetingRequest: true,
   meetingResponse: true,
+  sessionHeadsUp: true,
+  attendeeCountReminder: true,
 };
 
 type GuestPrivateInfo = {
@@ -600,6 +610,17 @@ export interface SessionsRepository {
     opts: { query?: string; limit: number; offset: number }
   ): Promise<SessionPage>;
   findById(id: string): Promise<Session | undefined>;
+  /**
+   * How many people attended, or null when nobody has recorded it (0 is a
+   * recorded value meaning "held, nobody came"). Host-only data: the caller
+   * must have already established that the requester hosts this session.
+   *
+   * Deliberately not a field of `Session`, which is serialised to every
+   * visitor by the [eventSlug] layout — see docs/dev/adr/0006.
+   */
+  getAttendeeCount(sessionId: string): Promise<number | null>;
+  /** Records, changes (a number) or clears (null) the attendee count. */
+  setAttendeeCount(sessionId: string, count: number | null): Promise<void>;
   create(data: SessionCreateInput): Promise<Session>;
   /**
    * When `hostIds` is given, any RSVPs by the session's hosts are removed
@@ -619,6 +640,110 @@ export interface SessionsRepository {
     locationIds: string[],
     excludeId?: string
   ): Promise<{ id: string; title: string } | undefined>;
+}
+
+// ── Session reminders ─────────────────────────────────────────────────────────
+
+export type ReminderKind = "headsUp" | "followUp";
+
+export type ReminderKey = {
+  sessionId: string;
+  guestId: string;
+  kind: ReminderKind;
+};
+
+/** One (session, host, kind) the dispatcher may owe a reminder for. */
+export type DueReminderCandidate = ReminderKey & {
+  dueTime: Date;
+
+  sessionTitle: string;
+  sessionStartTime: Date;
+  sessionEndTime: Date;
+  sessionLocationNames: string[];
+  /**
+   * Whether a count is already recorded — a flag, not the number. Suppressing
+   * the follow-up (FR-011) is the dispatcher's decision; the value itself is
+   * host-only and stays inside db/.
+   */
+  hasRecordedCount: boolean;
+
+  eventSlug: string;
+  eventTimezone: string;
+  eventBreakMinutes: number;
+
+  /**
+   * Null when the host has no address on file. That skips the mail only — the
+   * in-app notification still goes out and a row is still written.
+   */
+  guestEmail: string | null;
+  /**
+   * The EmailSettings key for *this* kind — `sessionHeadsUp` or
+   * `attendeeCountReminder` — which gates the **email** alone (FR-017). It has
+   * no bearing on the notification.
+   */
+  reminderOptIn: boolean;
+
+  storedDueTime: Date | null;
+  storedClaimedAt: Date | null;
+  storedNotifiedAt: Date | null;
+};
+
+export interface RemindersRepository {
+  /**
+   * Every (scheduled session with hosts × host × kind) whose reminder could
+   * be due by `now`, joined to its event, its hosts' addresses and
+   * preferences, its recorded-count flag and its stored row. Everything the
+   * dispatcher and both email templates read is on the candidate, because
+   * dispatch never queries once it starts sending. Eligibility is decided by
+   * the pure predicates in utils/reminder-schedule.ts, not by SQL.
+   */
+  listCandidates(now: Date): Promise<DueReminderCandidate[]>;
+  /**
+   * Atomically claims the reminder for `dueTime`, in one write transaction.
+   *
+   * `claimed` is false when another tick already holds it — i.e. the stored
+   * row carries the same due time with `claimedAt` set. `claimedAt` is the
+   * guard, deliberately not `sentAt`: a reminder with nothing to mail must
+   * block a second claim without ever having sent anything.
+   *
+   * `notifyOwed` says whether the in-app notification for THIS due time still
+   * has to be created. The claim clears `notifiedAt` whenever it advances the
+   * row to a new due time, so a reschedule owes a fresh notification (FR-024)
+   * while a mail retry against an unchanged due time does not (FR-016).
+   * Meaningless when `claimed` is false.
+   */
+  claim(
+    key: ReminderKey,
+    dueTime: Date,
+    now: Date
+  ): Promise<{ claimed: boolean; notifyOwed: boolean }>;
+  /** Records that the notification for the current due time exists. */
+  markNotified(key: ReminderKey, now: Date): Promise<void>;
+  /**
+   * A real email was confirmed sent: sets `sentAt`, clears `firstFailedAt`.
+   * The only writer of `sentAt`, so that column always means exactly "an email
+   * went out for this due time".
+   */
+  markSent(key: ReminderKey, now: Date): Promise<void>;
+  /**
+   * Settles the claim when there is nothing to mail — an opted-out host, no
+   * address, or an instance with no mail configured. Clears `firstFailedAt`
+   * (there is nothing to retry) and leaves `sentAt` null. `claimedAt` from the
+   * winning claim is what stops the reminder being reprocessed.
+   */
+  markSkipped(key: ReminderKey): Promise<void>;
+  /**
+   * Failed send. Sets `firstFailedAt` when unset, then either clears
+   * `claimedAt` to re-arm for the next tick, or — once the first failure is
+   * older than `abandonAfterMs` — leaves it set so the reminder is never
+   * retried again. Never touches `sentAt`: a failed send is not a sent one.
+   * Reports which happened, so the caller can log the abandonment.
+   */
+  markFailed(
+    key: ReminderKey,
+    now: Date,
+    abandonAfterMs: number
+  ): Promise<{ abandoned: boolean }>;
 }
 
 // ── RSVPs ─────────────────────────────────────────────────────────────────────

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -616,7 +616,7 @@ export interface SessionsRepository {
    * must have already established that the requester hosts this session.
    *
    * Deliberately not a field of `Session`, which is serialised to every
-   * visitor by the [eventSlug] layout — see docs/dev/adr/0006.
+   * visitor by the [eventSlug] layout — see docs/dev/adr/0007.
    */
   getAttendeeCount(sessionId: string): Promise<number | null>;
   /** Records, changes (a number) or clears (null) the attendee count. */

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -96,6 +96,8 @@ function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
         commentThread: row.emailOnCommentThread,
         meetingRequest: row.emailOnMeetingRequest,
         meetingResponse: row.emailOnMeetingResponse,
+        sessionHeadsUp: row.emailOnSessionHeadsUp,
+        attendeeCountReminder: row.emailOnAttendeeCountReminder,
       },
     },
   };
@@ -554,6 +556,8 @@ export class SqliteGuestsRepository implements GuestsRepository {
         emailOnCommentThread: settings.commentThread,
         emailOnMeetingRequest: settings.meetingRequest,
         emailOnMeetingResponse: settings.meetingResponse,
+        emailOnSessionHeadsUp: settings.sessionHeadsUp,
+        emailOnAttendeeCountReminder: settings.attendeeCountReminder,
       })
       .where(eq(schema.guests.id, id))
       .run();

--- a/db/repositories/sqlite/reminders.ts
+++ b/db/repositories/sqlite/reminders.ts
@@ -1,0 +1,285 @@
+import { and, eq, inArray, isNotNull, lte } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import * as schema from "../../schema";
+import { followUpDueTime, headsUpDueTime } from "@/utils/reminder-schedule";
+import type {
+  DueReminderCandidate,
+  ReminderKey,
+  ReminderKind,
+  RemindersRepository,
+} from "../interfaces";
+
+type DB = BetterSQLite3Database<typeof schema>;
+
+const KINDS: ReminderKind[] = ["headsUp", "followUp"];
+
+const HOUR_MS = 60 * 60 * 1000;
+
+// A raw NUL byte here would make git and jj treat this file as binary, so the
+// same character is written as an escape. No id or kind can contain one.
+const KEY_SEPARATOR = "\u0000";
+
+function keyOf(key: ReminderKey): string {
+  return `${key.sessionId}${KEY_SEPARATOR}${key.guestId}${KEY_SEPARATOR}${key.kind}`;
+}
+
+function parse(value: string | null): Date | null {
+  return value === null ? null : new Date(value);
+}
+
+export class SqliteRemindersRepository implements RemindersRepository {
+  constructor(private readonly db: DB) {}
+
+  async listCandidates(now: Date): Promise<DueReminderCandidate[]> {
+    // A heads-up is due from `start + break - 60 min`, and break is never
+    // negative, so nothing due by `now` can start more than an hour from now.
+    // A follow-up is due later still. Narrowing on the start time keeps the
+    // scan off the whole schedule without the per-event break arithmetic
+    // having to happen in SQL — the pure predicates decide eligibility.
+    const horizon = new Date(now.getTime() + HOUR_MS).toISOString();
+
+    const sessionRows = this.db
+      .select({
+        id: schema.sessions.id,
+        title: schema.sessions.title,
+        startTime: schema.sessions.startTime,
+        endTime: schema.sessions.endTime,
+        attendeeCount: schema.sessions.attendeeCount,
+        eventSlug: schema.events.slug,
+        eventTimezone: schema.events.timezone,
+        eventBreakMinutes: schema.events.breakMinutes,
+      })
+      .from(schema.sessions)
+      .innerJoin(schema.events, eq(schema.sessions.eventId, schema.events.id))
+      .where(
+        and(
+          isNotNull(schema.sessions.startTime),
+          isNotNull(schema.sessions.endTime),
+          lte(schema.sessions.startTime, horizon)
+        )
+      )
+      .all();
+    if (sessionRows.length === 0) return [];
+
+    const sessionIds = sessionRows.map((row) => row.id);
+
+    const hostRows = this.db
+      .select({
+        sessionId: schema.sessionHosts.sessionId,
+        guestId: schema.guests.id,
+        email: schema.guests.email,
+        headsUpOptIn: schema.guests.emailOnSessionHeadsUp,
+        followUpOptIn: schema.guests.emailOnAttendeeCountReminder,
+      })
+      .from(schema.sessionHosts)
+      .innerJoin(
+        schema.guests,
+        eq(schema.sessionHosts.guestId, schema.guests.id)
+      )
+      .where(inArray(schema.sessionHosts.sessionId, sessionIds))
+      .all();
+    if (hostRows.length === 0) return [];
+
+    const locationRows = this.db
+      .select({
+        sessionId: schema.sessionLocations.sessionId,
+        name: schema.locations.name,
+      })
+      .from(schema.sessionLocations)
+      .innerJoin(
+        schema.locations,
+        eq(schema.sessionLocations.locationId, schema.locations.id)
+      )
+      .where(inArray(schema.sessionLocations.sessionId, sessionIds))
+      .all();
+
+    const storedRows = this.db
+      .select()
+      .from(schema.sessionReminders)
+      .where(inArray(schema.sessionReminders.sessionId, sessionIds))
+      .all();
+
+    const hostsBySession = new Map<string, typeof hostRows>();
+    for (const row of hostRows) {
+      const hosts = hostsBySession.get(row.sessionId);
+      if (hosts) hosts.push(row);
+      else hostsBySession.set(row.sessionId, [row]);
+    }
+
+    const locationsBySession = new Map<string, string[]>();
+    for (const row of locationRows) {
+      const names = locationsBySession.get(row.sessionId);
+      if (names) names.push(row.name);
+      else locationsBySession.set(row.sessionId, [row.name]);
+    }
+
+    const stored = new Map(
+      storedRows.map((row) => [
+        keyOf({
+          sessionId: row.sessionId,
+          guestId: row.guestId,
+          kind: row.kind as ReminderKind,
+        }),
+        row,
+      ])
+    );
+
+    const candidates: DueReminderCandidate[] = [];
+    for (const session of sessionRows) {
+      const hosts = hostsBySession.get(session.id);
+      if (!hosts || session.startTime === null || session.endTime === null) {
+        continue;
+      }
+      const startTime = new Date(session.startTime);
+      const endTime = new Date(session.endTime);
+
+      for (const host of hosts) {
+        for (const kind of KINDS) {
+          const row = stored.get(
+            keyOf({ sessionId: session.id, guestId: host.guestId, kind })
+          );
+          candidates.push({
+            sessionId: session.id,
+            guestId: host.guestId,
+            kind,
+            dueTime:
+              kind === "headsUp"
+                ? headsUpDueTime(startTime, session.eventBreakMinutes)
+                : followUpDueTime(endTime),
+            sessionTitle: session.title,
+            sessionStartTime: startTime,
+            sessionEndTime: endTime,
+            sessionLocationNames: locationsBySession.get(session.id) ?? [],
+            hasRecordedCount: session.attendeeCount !== null,
+            eventSlug: session.eventSlug,
+            eventTimezone: session.eventTimezone,
+            eventBreakMinutes: session.eventBreakMinutes,
+            guestEmail: host.email === "" ? null : host.email,
+            reminderOptIn:
+              kind === "headsUp" ? host.headsUpOptIn : host.followUpOptIn,
+            storedDueTime: parse(row?.dueTime ?? null),
+            storedClaimedAt: parse(row?.claimedAt ?? null),
+            storedNotifiedAt: parse(row?.notifiedAt ?? null),
+          });
+        }
+      }
+    }
+    return candidates;
+  }
+
+  // A synchronous better-sqlite3 transaction: nothing awaits between the read
+  // and the write, so no other tick in this process can interleave, and
+  // SQLite's write lock serialises the ones in other processes.
+  async claim(
+    key: ReminderKey,
+    dueTime: Date,
+    now: Date
+  ): Promise<{ claimed: boolean; notifyOwed: boolean }> {
+    return this.db.transaction((tx) => {
+      const existing = tx
+        .select()
+        .from(schema.sessionReminders)
+        .where(this.matches(key))
+        .get();
+      const sameDueTime =
+        existing !== undefined && existing.dueTime === dueTime.toISOString();
+      if (sameDueTime && existing.claimedAt !== null) {
+        return { claimed: false, notifyOwed: false };
+      }
+
+      const values = {
+        ...key,
+        dueTime: dueTime.toISOString(),
+        claimedAt: now.toISOString(),
+        // A different due time is a reschedule: the old delivery and failure
+        // history belong to the reminder that is being superseded, so the
+        // notification is owed again too (FR-024).
+        firstFailedAt: sameDueTime ? existing.firstFailedAt : null,
+        notifiedAt: sameDueTime ? existing.notifiedAt : null,
+        sentAt: sameDueTime ? existing.sentAt : null,
+      };
+      tx.insert(schema.sessionReminders)
+        .values(values)
+        .onConflictDoUpdate({
+          target: [
+            schema.sessionReminders.sessionId,
+            schema.sessionReminders.guestId,
+            schema.sessionReminders.kind,
+          ],
+          set: {
+            dueTime: values.dueTime,
+            claimedAt: values.claimedAt,
+            firstFailedAt: values.firstFailedAt,
+            notifiedAt: values.notifiedAt,
+            sentAt: values.sentAt,
+          },
+        })
+        .run();
+      return { claimed: true, notifyOwed: values.notifiedAt === null };
+    });
+  }
+
+  async markNotified(key: ReminderKey, now: Date): Promise<void> {
+    this.db
+      .update(schema.sessionReminders)
+      .set({ notifiedAt: now.toISOString() })
+      .where(this.matches(key))
+      .run();
+  }
+
+  async markSent(key: ReminderKey, now: Date): Promise<void> {
+    this.db
+      .update(schema.sessionReminders)
+      .set({ sentAt: now.toISOString(), firstFailedAt: null })
+      .where(this.matches(key))
+      .run();
+  }
+
+  async markSkipped(key: ReminderKey): Promise<void> {
+    // claimedAt from the winning claim already settles the row; all that is
+    // left is to drop a stale failure history, since there is nothing to
+    // retry.
+    this.db
+      .update(schema.sessionReminders)
+      .set({ firstFailedAt: null })
+      .where(this.matches(key))
+      .run();
+  }
+
+  async markFailed(
+    key: ReminderKey,
+    now: Date,
+    abandonAfterMs: number
+  ): Promise<{ abandoned: boolean }> {
+    return this.db.transaction((tx) => {
+      const existing = tx
+        .select()
+        .from(schema.sessionReminders)
+        .where(this.matches(key))
+        .get();
+      if (!existing) return { abandoned: false };
+
+      const firstFailedAt = existing.firstFailedAt ?? now.toISOString();
+      const abandoned =
+        now.getTime() - new Date(firstFailedAt).getTime() > abandonAfterMs;
+      tx.update(schema.sessionReminders)
+        // Keeping claimedAt set is what abandons it: the next tick then sees
+        // this exact due time as already spoken for and never retries.
+        .set({
+          firstFailedAt,
+          claimedAt: abandoned ? existing.claimedAt : null,
+        })
+        .where(this.matches(key))
+        .run();
+      return { abandoned };
+    });
+  }
+
+  private matches(key: ReminderKey) {
+    return and(
+      eq(schema.sessionReminders.sessionId, key.sessionId),
+      eq(schema.sessionReminders.guestId, key.guestId),
+      eq(schema.sessionReminders.kind, key.kind)
+    );
+  }
+}

--- a/db/repositories/sqlite/reminders.ts
+++ b/db/repositories/sqlite/reminders.ts
@@ -31,11 +31,11 @@ export class SqliteRemindersRepository implements RemindersRepository {
   constructor(private readonly db: DB) {}
 
   async listCandidates(now: Date): Promise<DueReminderCandidate[]> {
-    // A heads-up is due from `start + break - 60 min`, and break is never
-    // negative, so nothing due by `now` can start more than an hour from now.
-    // A follow-up is due later still. Narrowing on the start time keeps the
-    // scan off the whole schedule without the per-event break arithmetic
-    // having to happen in SQL — the pure predicates decide eligibility.
+    // A heads-up is due from `start + break - 60 min` and break is never
+    // negative, so nothing due by `now` starts more than an hour from now; a
+    // follow-up is due later still. Deliberately no lower bound: a follow-up
+    // is never dropped for being late (FR-011), so a session that ended
+    // during a long outage is still owed one on the next tick.
     const horizon = new Date(now.getTime() + HOUR_MS).toISOString();
 
     const sessionRows = this.db

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -255,6 +255,26 @@ export class SqliteSessionsRepository implements SessionsRepository {
     return this.enrichSessions([row])[0];
   }
 
+  async getAttendeeCount(sessionId: string): Promise<number | null> {
+    const row = this.db
+      .select({ attendeeCount: schema.sessions.attendeeCount })
+      .from(schema.sessions)
+      .where(eq(schema.sessions.id, sessionId))
+      .get();
+    return row?.attendeeCount ?? null;
+  }
+
+  async setAttendeeCount(
+    sessionId: string,
+    count: number | null
+  ): Promise<void> {
+    this.db
+      .update(schema.sessions)
+      .set({ attendeeCount: count })
+      .where(eq(schema.sessions.id, sessionId))
+      .run();
+  }
+
   async create(data: SessionCreateInput): Promise<Session> {
     const id = nanoid();
     this.db.transaction((tx) => {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -276,7 +276,7 @@ export const sessions = sqliteTable("sessions", {
   // How many people attended, recorded by a host after the session finished.
   // Nullable with no default on purpose: NULL means "not recorded", 0 means
   // "held, nobody came". Deliberately absent from the Session type, which is
-  // serialised to every visitor — see docs/dev/adr/0006.
+  // serialised to every visitor — see docs/dev/adr/0007.
   attendeeCount: integer("attendee_count"),
 });
 
@@ -311,7 +311,7 @@ export const sessionLocations = sqliteTable(
 // for: an equal one is the idempotency check, a different one is the re-arm
 // signal after a reschedule. A reminder is delivered on two channels, so each
 // gets its own timestamp — a mail retry must not re-notify, a reschedule must
-// do both. See docs/dev/adr/0006.
+// do both. See docs/dev/adr/0007.
 export const sessionReminders = sqliteTable(
   "session_reminders",
   {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -74,6 +74,16 @@ export const guests = sqliteTable(
     })
       .notNull()
       .default(true),
+    emailOnSessionHeadsUp: integer("email_on_session_heads_up", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(true),
+    emailOnAttendeeCountReminder: integer("email_on_attendee_count_reminder", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(true),
     avatarUrl: text("avatar_url"),
     // When the guest last changed a public profile field — their name counts,
     // email settings and credentials don't. NULL for profiles nobody ever
@@ -263,6 +273,11 @@ export const sessions = sqliteTable("sessions", {
   eventId: text("event_id")
     .notNull()
     .references(() => events.id, { onDelete: "cascade" }),
+  // How many people attended, recorded by a host after the session finished.
+  // Nullable with no default on purpose: NULL means "not recorded", 0 means
+  // "held, nobody came". Deliberately absent from the Session type, which is
+  // serialised to every visitor — see docs/dev/adr/0006.
+  attendeeCount: integer("attendee_count"),
 });
 
 export const sessionHosts = sqliteTable(
@@ -289,6 +304,44 @@ export const sessionLocations = sqliteTable(
       .references(() => locations.id, { onDelete: "cascade" }),
   },
   (t) => [primaryKey({ columns: [t.sessionId, t.locationId] })]
+);
+
+// Dispatch state for the two attendee-count reminders, one row per
+// (session, host, kind). The row carries the due time it was last claimed
+// for: an equal one is the idempotency check, a different one is the re-arm
+// signal after a reschedule. A reminder is delivered on two channels, so each
+// gets its own timestamp — a mail retry must not re-notify, a reschedule must
+// do both. See docs/dev/adr/0006.
+export const sessionReminders = sqliteTable(
+  "session_reminders",
+  {
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    guestId: text("guest_id")
+      .notNull()
+      .references(() => guests.id, { onDelete: "cascade" }),
+    // "headsUp" | "followUp"
+    kind: text("kind").notNull(),
+    dueTime: text("due_time").notNull(),
+    // The winning claim for this due time, and the only guard `claim` reads.
+    // NULL means "not spoken for": never attempted, or a failed send re-armed
+    // for retry. Stays set through every terminal state, mailed or not.
+    claimedAt: text("claimed_at"),
+    // A confirmed email. Written only by markSent, so it always means exactly
+    // "mail went out for this due time" — never the concurrency guard.
+    sentAt: text("sent_at"),
+    // Starts the 24-hour retry window; cleared on a successful send.
+    firstFailedAt: text("first_failed_at"),
+    // The in-app notification for this due time. Cleared only when a claim
+    // advances the row to a new due time, which is what re-notifies after a
+    // reschedule while leaving a mail retry alone.
+    notifiedAt: text("notified_at"),
+  },
+  (t) => [
+    primaryKey({ columns: [t.sessionId, t.guestId, t.kind] }),
+    index("session_reminders_session_idx").on(t.sessionId),
+  ]
 );
 
 export const rsvps = sqliteTable(
@@ -518,6 +571,8 @@ export const notifications = sqliteTable(
         "commentThread",
         "meetingRequest",
         "meetingResponse",
+        "sessionHeadsUp",
+        "attendeeCountReminder",
       ],
     }).notNull(),
     text: text("text").notNull(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD:-}
       SMTP_SECURE: ${SMTP_SECURE:-}
       SMTP_FROM: ${SMTP_FROM:-}
+      REMINDER_DISPATCH_INTERVAL_MS: ${REMINDER_DISPATCH_INTERVAL_MS:-}
     logging:
       driver: json-file
       options:

--- a/docs/dev/adr/0006-attendee-count-and-reminder-dispatch.md
+++ b/docs/dev/adr/0006-attendee-count-and-reminder-dispatch.md
@@ -1,0 +1,262 @@
+# ADR 0006: Attendee count storage and in-process reminder dispatch
+
+- **Status:** Accepted
+- **Date:** 2026-08-25, amended 2026-09-02 (see [Amendment](#amendment-2026-09-02--the-in-app-channel))
+
+## Context
+
+Hosts record how many people attended a session of theirs once it has finished,
+and are reminded to do so by two emails: a heads-up an hour before the session
+starts, and a follow-up fifteen minutes after it ends.
+
+Three parts of that constrain future work well beyond the feature itself, and
+none of them is covered by an existing ADR:
+
+1. The emails must go out unattended, which means this codebase acquires its
+   first background job.
+2. Sessions get rescheduled. A reminder that was already sent for one schedule
+   may be owed again for another, and must never be sent twice for the same
+   one — including when two dispatch runs overlap.
+3. The count is host-only data living on a record that is otherwise published
+   to every visitor's browser.
+
+## Decision
+
+### 1. Dispatch runs in-process, on an interval from `instrumentation.ts`
+
+`utils/reminder-scheduler.ts` starts a `setInterval` from `register()` in
+`instrumentation.ts`, guarded to `NEXT_RUNTIME === "nodejs"` and stored on
+`globalThis` — the pattern `utils/mailer.ts` already uses, for the reason in
+[vercel/next.js#68572](https://github.com/vercel/next.js/discussions/68572).
+The period comes from `REMINDER_DISPATCH_INTERVAL_MS` (default `60000`; `0`
+disables the scheduler entirely). The timer is `unref()`d, an in-process guard
+skips a tick while the previous run is still in flight, and a throw from a run
+is logged and swallowed.
+
+`instrumentation.ts` is the only hook that runs once per server process
+regardless of traffic, and the mailer is initialised there already: the two have
+identical lifecycles and the same "Node runtime only" constraint.
+
+Rejected:
+
+- **External cron or a systemd timer hitting an API route.** It puts setup work
+  on every self-hoster and needs an authenticated trigger endpoint — new attack
+  surface for no gain.
+- **Next.js `after()` on ordinary requests.** Request-driven: an event with no
+  overnight traffic would send nothing until someone visited, which is exactly
+  when hosts are asleep and reminders matter.
+- **A cron library (`node-cron`, `croner`).** A dependency to express "every 60
+  seconds".
+
+Consequence: behind a load balancer every instance ticks. That is safe because
+of decision 2, which concurrency-safety requires anyway.
+
+Because the interval is disabled outright in both E2E tiers — a live tick against
+the wall-clock-relative seed data drops stray mail into the mailbox the delivery
+assertions search — the dev toolbar carries a **Send due reminders** button, and
+`app/actions/dev-reminders.ts` refuses unless `SB_ENABLE_DEV_TOOLS` is set. It
+runs one tick against the dev clock, which is what lets the E2E suite reach a
+real follow-up email and follow the link out of it (SC-001) rather than
+hand-building a `?viewSession=` URL. Nothing about it exists on a real
+deployment.
+
+### 2. Reminder state is keyed by the reminder's due time, not a sent flag
+
+One row per `(session_id, guest_id, kind)` in `session_reminders`, carrying the
+due time it was last claimed for. That single column is simultaneously the
+idempotency key and the re-arm signal:
+
+- an unchanged schedule computes the same due time, so a repeated or concurrent
+  run finds it already sent and skips;
+- a moved start computes a different heads-up due time and re-arms only that
+  kind; a moved end re-arms only the follow-up; editing the title or the host
+  list moves neither.
+
+No boolean "sent" flag can express that without also storing the time it was
+sent for.
+
+Dispatch **claims before sending**: one write transaction sets the due time and
+`sent_at`, and reports whether this process won. Only one transaction can flip
+`sent_at` from NULL for a given due time, and `better-sqlite3` serialises
+writers through SQLite's own write lock, so overlapping ticks cannot both send.
+
+**The 90-minute reschedule guard** compares the new displayed start against the
+due time the host's existing heads-up was sent for: it is suppressed when that
+email went out 90 minutes or less before the new start, because it is still a
+useful warning for the new slot. `research.md` §5 sketched the guard as
+`now >= displayedStart − 90 min`, which does not work — a heads-up is only ever
+due from `displayedStart − 60 min` onwards, so that condition holds every time
+it is evaluated and would suppress every re-send, including the
+three-hours-later move the spec requires to re-arm.
+
+**Accepted limitation:** a process that crashes between the claim and the send
+drops that reminder for that due time. The window is milliseconds and the
+failure mode is one missing email rather than a duplicate — the opposite
+trade-off, send-then-mark, produces duplicates on the same crash, which is the
+one outcome the spec forbids. A lease column with an expiry that a later tick
+reclaims would close the window, and is more machinery than a single-process
+self-hosted app warrants. Recorded here rather than left to be rediscovered.
+
+### 3. The attendee count is deliberately absent from the `Session` type
+
+`sessions.attendee_count` is a nullable column with **no default**, so `NULL`
+("not recorded") stays distinguishable from `0` ("held, nobody came"). It is
+read and written through host-scoped methods on `SessionsRepository`, and it
+**must not** be added to `Session`, `SessionCreateInput`, or
+`SessionUpdateInput`.
+
+`Session` is loaded by the `[eventSlug]` layout and serialised into the client
+bundle for every visitor — that is how `view-session.tsx` receives its data. A
+field there publishes the count to every attendee's browser no matter what the
+JSX renders, which is the one way of leaking it that cannot be spotted by
+reading the component. Keeping it off the type makes the leak impossible to
+write by accident rather than something a reviewer has to remember; an
+integration test asserts that a non-host's event payload and the admin session
+read surface carry no count anywhere.
+
+The dispatch candidate projection in `db/repositories/sqlite/reminders.ts` does
+read `sessions.attendee_count` directly, and exposes it as a
+`hasRecordedCount` boolean rather than the number. That is compatible with this
+posture precisely because the projection is server-only and never serialised —
+the dispatcher decides suppression and has no business holding the value.
+
+Rejected: adding `attendeeCount` to `Session` and stripping it during
+serialisation. A strip step is a rule enforced by memory, and every new read
+path has to remember it.
+
+**Scope of the protection:** this is host-scoping, not secrecy. Guest switching
+on `(site)` pages is unauthenticated, so a determined visitor can select a
+host's name and see the count — as they can with every other host-only control.
+The requirement is that the number stays out of ordinary attendees' way and out
+of exports and listings.
+
+## Consequences
+
+### Positive
+
+- Reminders work out of the box for a self-hoster with SMTP configured; no
+  external scheduler to set up.
+- Rescheduling, repetition, and concurrency are all answered by one column.
+- FR-005 (the count never reaches a non-host) is a type-level property, not a
+  convention.
+
+### Negative
+
+- A background timer inside the web process is a new kind of moving part. It is
+  confined to one module, ~~inert without SMTP~~ (**superseded by the 2026-09-02
+  amendment**: it delivers in-app notifications whether or not mail is
+  configured), and disabled in both E2E tiers.
+- The count cannot be read alongside a session in one call; host-scoped reads
+  are separate round trips. At conference scale that is one extra query on a
+  modal open.
+- A crash in the claim-then-send window loses one email (above).
+
+### Neutral
+
+- `REMINDER_DISPATCH_INTERVAL_MS` is a real configuration variable, not a
+  test-only back door, so it must reach the configuration reference,
+  `docker-compose.yml`, and `.env.docker.example` — `tests/unit/docker-compose-env.test.ts`
+  enforces that.
+
+## Amendment, 2026-09-02 — the in-app channel
+
+The spec's second clarification session (FR-021 – FR-025) makes the reminder a
+two-channel delivery. Nothing above is withdrawn except where marked; three
+further decisions constrain future work.
+
+### 4. A reminder is delivered on two channels, not sent as an email
+
+"Sending a reminder" is no longer synonymous with "sending mail". Every due
+reminder creates an in-app notification for its host unconditionally; the email
+is a second, conditional half that goes out only when the host is opted in and
+reachable and the instance has mail configured. Dispatch therefore no longer
+bails out when SMTP is missing — an instance with no mail still reminds its
+hosts, which is the whole of FR-021.
+
+A future third channel, or a second reminder feature, inherits that shape:
+claim the reminder once, then deliver on each channel independently, and let
+the per-channel state decide what is still owed.
+
+Rejected: routing dispatch through `notifyGuest` in `utils/notifications.ts`,
+which already pairs "write the notification, then mail if opted in". It sends
+the mail inside the same call, so dispatch could not tell a failed send from a
+written notification — and the retry lifecycle is the one thing dispatch owns.
+What is shared instead is the smaller piece: `sessionPath` is exported and used
+for all three deep links rather than copied a third time.
+
+### 5. The email settings govern the emails, never the notifications
+
+`EmailSettings.sessionHeadsUp` and `EmailSettings.attendeeCountReminder` gate
+the two reminder **emails** and nothing else. A host who turns both off still
+finds both reminders in their notification list.
+
+One key per kind, not one for the pair: the two mails answer different
+questions. "Your session starts in an hour" is worth having on its own even to a
+host who never counts the room, and a host who finds the pre-session mail
+redundant should not have to give up the link that records the count. Dispatch
+therefore reads the key for the candidate's kind, `reminderOptIn` on
+`DueReminderCandidate` being whichever one applies.
+
+This is the house rule already stated at `notifyGuest` — "opting out of the mail
+is a request not to be interrupted outside the app, not a request to be
+uninformed inside it" — now binding on reminders too, which had been the one
+notification type that read the setting before deciding whether to act at all.
+The settings checkboxes are worded as email switches to match, and every other
+key in `EmailSettings` already works this way.
+
+### 6. Each channel gets its own column on `session_reminders`
+
+`notified_at` records the in-app notification for the current due time;
+`sent_at` records a confirmed email; `claimed_at` is the concurrency and
+settlement guard. Three columns because the two channels have different failure
+modes: a mail retry must resend without re-notifying (FR-016), while a
+reschedule must do both (FR-024), and a reminder settled with nothing to mail
+must still block reprocessing without ever claiming to have sent mail.
+
+The last of those is why `claimed_at` exists at all. Decision 2 above used
+`sent_at` as both "this due time is spoken for" and "an email went out", which
+cannot both be true once a reminder can settle with no mail to send. `claim`
+now guards on `claimed_at`, `markSent` is the only writer of `sent_at`, and
+`markFailed` clears `claimed_at` to re-arm the retry. `claim` clears
+`notified_at` whenever it advances the row to a new due time, which is what
+makes a reschedule re-notify while a retry does not.
+
+Rejected:
+
+- **Deriving "already notified" from the `notifications` table.** It stores
+  type, text, url and timestamps only; answering "was this host notified for
+  _this_ due time" would mean matching on a URL string or a time window, and
+  neither survives a reschedule that lands on the same session.
+- **A second row per channel.** Doubles the table and makes a reschedule re-arm
+  two rows atomically, for state that belongs to one reminder.
+- **Overloading `sent_at` to mean "delivered on whatever channels applied".**
+  It makes the field lie for every row it is true of, and breaks the guarantee
+  that a host who opts back in before the next tick still gets their mail.
+
+### 7. The migration settles the follow-up for sessions that had already finished
+
+A follow-up is deliberately never dropped for being late (FR-011), so on an
+existing installation the first tick after the upgrade would find every
+uncounted session in the event history owed one — a notification and an email
+per host per session, about sessions that finished months ago.
+
+`drizzle/0034_session_attendee_count.sql` therefore ends with a hand-written
+backfill: one settled `followUp` row (`claimed_at` and `notified_at` set,
+`sent_at` left NULL — nothing was mailed) for every host of every session whose
+follow-up was already due when the migration ran. The due time is computed in
+SQL to match `followUpDueTime` to the millisecond; anything else would read as
+a reschedule and re-arm the very reminder it suppresses.
+
+The line is "already due", not "already finished": a session that ended two
+minutes before the upgrade still gets its follow-up on the next tick, which is
+what a host would expect.
+
+Rejected: a staleness cutoff in `followUpEligible`. It would also drop the
+reminders an instance owes after a few hours of downtime, which is exactly the
+case FR-011 is written for.
+
+### The banner is withdrawn
+
+`listUncountedFinishedByHost` and the schedule prompt it fed are deleted
+(FR-025): the notification list says the same thing in the place hosts already
+look. The host-only control and the `?record=count` deep link stay.

--- a/docs/dev/adr/0007-attendee-count-and-reminder-dispatch.md
+++ b/docs/dev/adr/0007-attendee-count-and-reminder-dispatch.md
@@ -1,4 +1,4 @@
-# ADR 0006: Attendee count storage and in-process reminder dispatch
+# ADR 0007: Attendee count storage and in-process reminder dispatch
 
 - **Status:** Accepted
 - **Date:** 2026-08-25, amended 2026-09-02 (see [Amendment](#amendment-2026-09-02--the-in-app-channel))

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -348,6 +348,16 @@ is stable — the aim there is to measure flakiness, not to start failing on it.
   handler — so both come up green while hydration is still pending. Where the behavior under test
   lives in an effect, wait for that effect's own result before acting on it: `kiosk.spec.ts` polls
   until the `kiosk` cookie is gone before it navigates on, `helpers/user.ts` taps the chip again
+- The unattended reminder tick is off (`REMINDER_DISPATCH_INTERVAL_MS=0` in
+  `.env.test`, and in the allowlist `scripts/e2e-docker.sh` forwards to the
+  container). The seed dates every fixture relative to `new Date()`, so a live
+  tick would drop unrelated mail into the mailbox the delivery assertions
+  search, and unrelated notifications into the lists the notification tests
+  read — flaky by time of day, and worst in the Docker tier. That variable is
+  the only thing that turns the tick off: unsetting SMTP does not, since a
+  reminder is delivered in the app whether or not it can also be mailed. A
+  test that needs reminders delivered clicks **Send due reminders** on the
+  `?dev=1` toolbar, which runs one dispatch against the dev clock
 
 ## Test data
 

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -186,6 +186,42 @@ Open a session to find the same comment section proposals have — useful for
 "which room did this move to?" and other last-minute coordination. Everything works as described under
 [Discuss a proposal](#discuss-a-proposal): threaded replies, likes, editing and deleting your own comments.
 
+### Record how many people came
+
+Once a session you host has finished, open it and you'll find a field asking
+**how many people attended**. Fill it in if you can — RSVPs are a promise, and
+the real number is the only record of what actually happened.
+
+- **Only you and your co-hosts will see this, not the attendees.** Any
+  co-host can enter or change it.
+- **0 is a real answer**: the session was held and nobody came. If it never
+  happened at all, delete the session instead.
+- Leave the field empty to go back to no count at all. Nothing is lost by
+  skipping it — the field is entirely optional.
+
+The field appears only after the session's end time has passed, so there is
+nothing to fill in while you are still running it.
+
+#### Two reminders will nudge you
+
+You get two per session you host, each as a notification and — if the event has
+email — as a message to your inbox as well:
+
+- **An hour before it starts**, a heads-up naming the session, when it starts
+  and where — and asking you to count the people who turn up. Counting in the
+  room is the only way the number ends up being one.
+- **Fifteen minutes after it ends**, a follow-up with a link straight to the
+  field. If you've already recorded a count, you don't get this one at all.
+
+Move a session and the reminder that depends on the time you changed is sent
+again for the new slot: a new start time re-sends the heads-up, a new end time
+the follow-up. A small nudge of the start time doesn't, though — a heads-up you
+got in the last hour and a half already covers the new one.
+
+Each has its own switch under [Settings](#settings), so you can keep one and
+drop the other. Like every other email setting they silence the **email** only:
+both reminders still appear in your [notifications](#notifications).
+
 ## 1-on-1s
 
 Under **Settings**, every event you're attending where the organizer offers
@@ -390,6 +426,8 @@ page lists everything newest first. You'll be told when:
 - someone comments on a proposal or session you host, or on your profile
 - someone else comments on something you commented on
 - someone asks you for a 1-on-1, or answers a request of yours
+- it's time to [count how many people came](#record-how-many-people-came) to a
+  session you host
 
 **Clicking a notification marks it read and takes you straight to what
 happened.** If you'd rather clear one without opening it, use the tick beside

--- a/docs/public/self-hosting/configuration.md
+++ b/docs/public/self-hosting/configuration.md
@@ -12,24 +12,25 @@ a feature off when unset.
 
 ## Environment variables
 
-| Variable                 | Required | Description                                                                                                              |
-| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `SITE_PASSWORD`          | No       | Password gate for the whole site (leave unset to disable)                                                                |
-| `ADMIN_PASSWORD`         | No       | Password for the `/admin` UI (leave unset to disable)                                                                    |
-| `AUTH_SECRET`            | Yes      | Signs all login cookies — site, admin, and attendee name protection. Random, min 32 chars. Changing it logs everyone out |
-| `DATABASE_URL`           | No       | SQLite path (default: `file:/data/data.db`)                                                                              |
-| `SB_UPLOADS_DIR`         | No       | Dir for admin-uploaded files (default: `./uploads`, `/data/uploads` in Docker)                                           |
-| `HOST_PORT`              | No       | Host port to bind (default: `3000`, compose only)                                                                        |
-| `SCHELLINGBOARD_VERSION` | No       | Image tag to run, e.g. a release tag (default: `latest`, compose only)                                                   |
-| `SMTP_FROM`              | No       | Sender address for outgoing email                                                                                        |
-| `SMTP_URL`               | No       | SMTP connection URL (see below)                                                                                          |
-| `SMTP_HOST`              | No       | SMTP server hostname (see below)                                                                                         |
-| `SMTP_PORT`              | No       | SMTP server port                                                                                                         |
-| `SMTP_USER`              | No       | SMTP username                                                                                                            |
-| `SMTP_PASSWORD`          | No       | SMTP password                                                                                                            |
-| `SMTP_SECURE`            | No       | `true`, `false`, or `requireTLS` (default)                                                                               |
-| `SITE_URL`               | No\*     | Public base URL of the site, e.g. `https://sessions.example.org`                                                         |
-| `SB_ENABLE_DEV_TOOLS`    | No       | Set to `1` to enable the dev fake clock on a staging/demo instance. Leave unset in production                            |
+| Variable                        | Required | Description                                                                                                                                               |
+| ------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SITE_PASSWORD`                 | No       | Password gate for the whole site (leave unset to disable)                                                                                                 |
+| `ADMIN_PASSWORD`                | No       | Password for the `/admin` UI (leave unset to disable)                                                                                                     |
+| `AUTH_SECRET`                   | Yes      | Signs all login cookies — site, admin, and attendee name protection. Random, min 32 chars. Changing it logs everyone out                                  |
+| `DATABASE_URL`                  | No       | SQLite path (default: `file:/data/data.db`)                                                                                                               |
+| `SB_UPLOADS_DIR`                | No       | Dir for admin-uploaded files (default: `./uploads`, `/data/uploads` in Docker)                                                                            |
+| `HOST_PORT`                     | No       | Host port to bind (default: `3000`, compose only)                                                                                                         |
+| `SCHELLINGBOARD_VERSION`        | No       | Image tag to run, e.g. a release tag (default: `latest`, compose only)                                                                                    |
+| `SMTP_FROM`                     | No       | Sender address for outgoing email                                                                                                                         |
+| `SMTP_URL`                      | No       | SMTP connection URL (see below)                                                                                                                           |
+| `SMTP_HOST`                     | No       | SMTP server hostname (see below)                                                                                                                          |
+| `SMTP_PORT`                     | No       | SMTP server port                                                                                                                                          |
+| `SMTP_USER`                     | No       | SMTP username                                                                                                                                             |
+| `SMTP_PASSWORD`                 | No       | SMTP password                                                                                                                                             |
+| `SMTP_SECURE`                   | No       | `true`, `false`, or `requireTLS` (default)                                                                                                                |
+| `SITE_URL`                      | No\*     | Public base URL of the site, e.g. `https://sessions.example.org`                                                                                          |
+| `SB_ENABLE_DEV_TOOLS`           | No       | Set to `1` to enable the dev fake clock on a staging/demo instance. Leave unset in production                                                             |
+| `REMINDER_DISPATCH_INTERVAL_MS` | No       | How often to deliver due attendee-count reminders, in milliseconds (default: `60000`). `0` turns them off entirely — nothing else does, email or no email |
 
 ## Email
 
@@ -44,6 +45,8 @@ to the site.
 
 Leaving email unconfigured also disables
 [attendee name protection](../organizers/how-it-works.md#attendee-identity),
-since it relies on emailed login codes. For which messages SchellingBoard
-sends and when, see
+since it relies on emailed login codes. It does **not** disable in-app
+notifications, including the reminders to record attendance: those are
+delivered whether or not the instance can send mail. For which messages
+SchellingBoard sends and when, see
 [How it works § Email](../organizers/how-it-works.md#email).

--- a/drizzle/0034_session_attendee_count.sql
+++ b/drizzle/0034_session_attendee_count.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `session_reminders` (
+	`session_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`due_time` text NOT NULL,
+	`claimed_at` text,
+	`sent_at` text,
+	`first_failed_at` text,
+	`notified_at` text,
+	PRIMARY KEY(`session_id`, `guest_id`, `kind`),
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `session_reminders_session_idx` ON `session_reminders` (`session_id`);--> statement-breakpoint
+ALTER TABLE `guests` ADD `email_on_session_heads_up` integer DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `guests` ADD `email_on_attendee_count_reminder` integer DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `sessions` ADD `attendee_count` integer;--> statement-breakpoint
+-- Hand-written backfill (see docs/dev/migrations.md): settle the follow-up for
+-- every session whose reminder was already due before this feature existed. A
+-- follow-up is deliberately never dropped for being late, so without this the
+-- first dispatch tick after an upgrade would notify and mail every host of
+-- every uncounted session in the event history. The due time must match
+-- followUpDueTime() to the millisecond or the row reads as a reschedule.
+INSERT INTO `session_reminders` (`session_id`, `guest_id`, `kind`, `due_time`, `claimed_at`, `notified_at`)
+SELECT
+	h.`session_id`,
+	h.`guest_id`,
+	'followUp',
+	strftime('%Y-%m-%dT%H:%M:%fZ', s.`end_time`, '+15 minutes'),
+	strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+	strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM `session_hosts` h
+JOIN `sessions` s ON s.`id` = h.`session_id`
+WHERE s.`end_time` IS NOT NULL
+	AND strftime('%Y-%m-%dT%H:%M:%fZ', s.`end_time`, '+15 minutes') <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,2063 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5376f0b2-dff9-4318-8ad8-4f2566bf1334",
+  "prevId": "68d938a4-d53a-4811-b3d9-46cde9e4d5a9",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meetings_enabled": {
+          "name": "meetings_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "meeting_slot_minutes": {
+          "name": "meeting_slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "meeting_day_start": {
+          "name": "meeting_day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_day_end": {
+          "name": "meeting_day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_open_meeting_requests": {
+          "name": "max_open_meeting_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_session_comment": {
+          "name": "email_on_session_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_profile_comment": {
+          "name": "email_on_profile_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_on_meeting_request": {
+          "name": "email_on_meeting_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_meeting_response": {
+          "name": "email_on_meeting_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_session_heads_up": {
+          "name": "email_on_session_heads_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_attendee_count_reminder": {
+          "name": "email_on_attendee_count_reminder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_availability": {
+      "name": "meeting_availability",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_availability_slot_idx": {
+          "name": "meeting_availability_slot_idx",
+          "columns": ["event_id", "slot_start"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_availability_event_id_events_id_fk": {
+          "name": "meeting_availability_event_id_events_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_availability_guest_id_guests_id_fk": {
+          "name": "meeting_availability_guest_id_guests_id_fk",
+          "tableFrom": "meeting_availability",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meeting_availability_event_id_guest_id_slot_start_pk": {
+          "columns": ["event_id", "guest_id", "slot_start"],
+          "name": "meeting_availability_event_id_guest_id_slot_start_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_points": {
+      "name": "meeting_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "meeting_points_event_idx": {
+          "name": "meeting_points_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_points_event_id_events_id_fk": {
+          "name": "meeting_points_event_id_events_id_fk",
+          "tableFrom": "meeting_points",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_start": {
+          "name": "slot_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_end": {
+          "name": "slot_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_point": {
+          "name": "meeting_point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cancel_note": {
+          "name": "cancel_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meetings_event_requester_idx": {
+          "name": "meetings_event_requester_idx",
+          "columns": ["event_id", "requester_id"],
+          "isUnique": false
+        },
+        "meetings_event_recipient_idx": {
+          "name": "meetings_event_recipient_idx",
+          "columns": ["event_id", "recipient_id"],
+          "isUnique": false
+        },
+        "meetings_no_duplicate_request": {
+          "name": "meetings_no_duplicate_request",
+          "columns": ["event_id", "requester_id", "recipient_id", "slot_start"],
+          "isUnique": true,
+          "where": "\"meetings\".\"status\" in ('pending', 'accepted')"
+        }
+      },
+      "foreignKeys": {
+        "meetings_event_id_events_id_fk": {
+          "name": "meetings_event_id_events_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_requester_id_guests_id_fk": {
+          "name": "meetings_requester_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_recipient_id_guests_id_fk": {
+          "name": "meetings_recipient_id_guests_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "guests",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_guest_created_idx": {
+          "name": "notifications_guest_created_idx",
+          "columns": ["guest_id", "created_at"],
+          "isUnique": false
+        },
+        "notifications_guest_read_idx": {
+          "name": "notifications_guest_read_idx",
+          "columns": ["guest_id", "read_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_guest_id_guests_id_fk": {
+          "name": "notifications_guest_id_guests_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_comments": {
+      "name": "profile_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_comments_profile_idx": {
+          "name": "profile_comments_profile_idx",
+          "columns": ["profile_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_comments_comment_id_comments_id_fk": {
+          "name": "profile_comments_comment_id_comments_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_comments_profile_id_guests_id_fk": {
+          "name": "profile_comments_profile_id_guests_id_fk",
+          "tableFrom": "profile_comments",
+          "tableTo": "guests",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_keys": {
+      "name": "push_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "columns": ["endpoint"],
+          "isUnique": true
+        },
+        "push_subscriptions_guest_idx": {
+          "name": "push_subscriptions_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_guest_id_guests_id_fk": {
+          "name": "push_subscriptions_guest_id_guests_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_comments": {
+      "name": "session_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_comments_session_idx": {
+          "name": "session_comments_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_comments_comment_id_comments_id_fk": {
+          "name": "session_comments_comment_id_comments_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_comments_session_id_sessions_id_fk": {
+          "name": "session_comments_session_id_sessions_id_fk",
+          "tableFrom": "session_comments",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_reminders": {
+      "name": "session_reminders",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_time": {
+          "name": "due_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_failed_at": {
+          "name": "first_failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_reminders_session_idx": {
+          "name": "session_reminders_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_reminders_session_id_sessions_id_fk": {
+          "name": "session_reminders_session_id_sessions_id_fk",
+          "tableFrom": "session_reminders",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_reminders_guest_id_guests_id_fk": {
+          "name": "session_reminders_guest_id_guests_id_fk",
+          "tableFrom": "session_reminders",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_reminders_session_id_guest_id_kind_pk": {
+          "columns": ["session_id", "guest_id", "kind"],
+          "name": "session_reminders_session_id_guest_id_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attendee_count": {
+          "name": "attendee_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1788697709228,
       "tag": "0033_meeting_cancel_note",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1788703476668,
+      "tag": "0034_session_attendee_count",
+      "breakpoints": true
     }
   ]
 }

--- a/emails/attendee-count-followup.tsx
+++ b/emails/attendee-count-followup.tsx
@@ -1,0 +1,32 @@
+import type { EmailMessage } from "@/utils/mailer";
+
+// Sent to each host fifteen minutes after their session ends. `recordUrl` is a
+// plain deep link carrying no identity or token, like every other notification
+// — a host on an unfamiliar browser selects their name first, exactly as with
+// any other host-only control.
+export function attendeeCountFollowUpEmail(props: {
+  title: string;
+  time: string;
+  recordUrl: string;
+}): EmailMessage {
+  return {
+    subject: `How many people came to "${props.title}"?`,
+    body: (
+      <>
+        <h1>{props.title}</h1>
+        <p>
+          Your session finished at {props.time}. If you counted the room, record
+          the number now &mdash; it only takes a moment. Only you and your
+          co-hosts will see it, not the attendees.
+        </p>
+        <p>
+          <a href={props.recordUrl}>Record the attendee count</a>
+        </p>
+        <p>
+          It&rsquo;s optional, and you can come back and change it whenever you
+          like.
+        </p>
+      </>
+    ),
+  };
+}

--- a/emails/attendee-count-headsup.tsx
+++ b/emails/attendee-count-headsup.tsx
@@ -1,0 +1,36 @@
+import type { EmailMessage } from "@/utils/mailer";
+
+// Sent to each host an hour before their session's displayed start. It does
+// double duty (FR-009): the reminder that they are hosting shortly, and the
+// ask to count the room while they are in it. Time comes preformatted in the
+// event's zone.
+export function attendeeCountHeadsUpEmail(props: {
+  title: string;
+  time: string;
+  location: string;
+  sessionUrl: string;
+}): EmailMessage {
+  return {
+    subject: `You're hosting "${props.title}" shortly`,
+    body: (
+      <>
+        <h1>{props.title}</h1>
+        <p>You&rsquo;re hosting this session in about an hour.</p>
+        <p>
+          <strong>Time:</strong> {props.time}
+        </p>
+        <p>
+          <strong>Location:</strong> {props.location}
+        </p>
+        <p>
+          While you&rsquo;re there, please count how many people attend. Once
+          the session has finished you&rsquo;ll be able to record the number,
+          and we&rsquo;ll email you a link when it&rsquo;s time.
+        </p>
+        <p>
+          <a href={props.sessionUrl}>View the session</a>
+        </p>
+      </>
+    ),
+  };
+}

--- a/emails/attendee-count-headsup.tsx
+++ b/emails/attendee-count-headsup.tsx
@@ -25,7 +25,7 @@ export function attendeeCountHeadsUpEmail(props: {
         <p>
           While you&rsquo;re there, please count how many people attend. Once
           the session has finished you&rsquo;ll be able to record the number,
-          and we&rsquo;ll email you a link when it&rsquo;s time.
+          and we&rsquo;ll remind you when it&rsquo;s time.
         </p>
         <p>
           <a href={props.sessionUrl}>View the session</a>

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,4 +1,5 @@
 import { initMailer } from "@/utils/mailer";
+import { startReminderScheduler } from "@/utils/reminder-scheduler";
 
 export function register() {
   // If we run this app in an edge runtime[1] in future, it won't support email.
@@ -6,5 +7,7 @@ export function register() {
   // [1]: https://nextjs.org/docs/app/api-reference/edge
   if (process.env.NEXT_RUNTIME === "nodejs") {
     initMailer();
+    // After the mailer: a tick that ran first would find it uninitialised.
+    startReminderScheduler();
   }
 }

--- a/model/attendee-count.ts
+++ b/model/attendee-count.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// Client-safe: the attendee-count control imports this into a client bundle,
+// so nothing here may reach db/, next/headers or the mailer.
+
+export const MIN_ATTENDEE_COUNT = 0;
+export const MAX_ATTENDEE_COUNT = 1000;
+
+const RANGE_MESSAGE = `Enter a whole number between ${MIN_ATTENDEE_COUNT} and ${MAX_ATTENDEE_COUNT}`;
+
+// A blank field clears the count; anything else must be a whole number in
+// range. The form hint and the server validator share this one definition, so
+// the message a host sees cannot drift from the rule that rejects them.
+export const attendeeCountSchema = z
+  .union([z.string(), z.number(), z.null(), z.undefined()])
+  .transform((value) =>
+    value === null || value === undefined || String(value).trim() === ""
+      ? null
+      : Number(String(value).trim())
+  )
+  .refine(
+    (value) =>
+      value === null ||
+      (Number.isInteger(value) &&
+        value >= MIN_ATTENDEE_COUNT &&
+        value <= MAX_ATTENDEE_COUNT),
+    { message: RANGE_MESSAGE }
+  );
+
+// The same rule as a one-field form, so a rejection carries the field name
+// the control knows it by and the message lands on the input rather than
+// above the form (ADR 0003). The server action validates through this too, so
+// a client-side bypass produces the identical field-level issue.
+export const attendeeCountFormSchema = z.object({
+  count: attendeeCountSchema,
+});

--- a/model/guest.ts
+++ b/model/guest.ts
@@ -34,6 +34,8 @@ export const emailSettingsSchema = z.object({
   commentThread: z.boolean(),
   meetingRequest: z.boolean(),
   meetingResponse: z.boolean(),
+  sessionHeadsUp: z.boolean(),
+  attendeeCountReminder: z.boolean(),
 });
 
 // Length caps are sanity limits only a malicious user would hit; entry caps

--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -62,7 +62,11 @@ to_container_host() {
 }
 
 env_args=()
+# Only the variables named here reach the container, so a new one the suite
+# depends on must be added — REMINDER_DISPATCH_INTERVAL_MS=0 in particular,
+# without which the container ticks live against a configured mailpit.
 for var in SITE_PASSWORD ADMIN_PASSWORD AUTH_SECRET SB_ENABLE_DEV_TOOLS \
+  REMINDER_DISPATCH_INTERVAL_MS \
   SMTP_FROM SMTP_PORT SMTP_USER SMTP_PASSWORD SMTP_SECURE; do
   if [ -n "${!var:-}" ]; then
     env_args+=(-e "$var=${!var}")

--- a/tests/e2e/attendee-count.spec.ts
+++ b/tests/e2e/attendee-count.spec.ts
@@ -1,0 +1,268 @@
+import { Page } from "@playwright/test";
+import { DateTime } from "luxon";
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { setDevClock } from "./helpers/dev-clock";
+import { selectUser } from "./helpers/user";
+import {
+  getMessage,
+  searchBySubject,
+  skipWithoutMailpit,
+} from "../helpers/mailpit";
+
+// A host records how many people came to a session of theirs once it has
+// finished. Only the browser reveals what is tested here: that the control
+// appears for a host and not for an attendee, its idle → pending → saved
+// feedback, a field-level error, and the phone layout (SC-006). The
+// authorization and validation rules live in
+// tests/integration/attendee-count.test.ts, where no browser is needed.
+//
+// Getting to a *finished* session means time travel: the seeded schedule is
+// two weeks out. That goes through the dev fake clock (?dev=1), not the
+// browser clock, because the entry gate is decided server-side by serverNow()
+// (docs/dev/adr/0004-dev-fake-clock.md).
+//
+// Every test below claims a *different* seeded session, because the suite
+// runs in parallel against one shared database: two tests recording into the
+// same session would see each other's numbers.
+test.use({ timezoneId: "Europe/Berlin" });
+
+// Gamma's days run 09:00–18:00 Berlin from today+14
+// (scripts/seed/seed-database.ts, scripts/seed/data/gamma-schedule.ts). 17:00
+// is after every session scheduled on a day, and before the day itself ends —
+// a day that has ended folds shut, taking its session links with it.
+const lateOnGammaDay = (day: number) =>
+  DateTime.now()
+    .setZone("Europe/Berlin")
+    .plus({ days: 14 + day })
+    .set({ hour: 17, minute: 0, second: 0, millisecond: 0 });
+
+const countInput = (page: Page) => page.getByLabel("How many people attended?");
+const saveButton = (page: Page) =>
+  page.getByRole("button", { name: "Save attendee count" });
+const dialog = (page: Page) =>
+  page.getByRole("dialog", { name: "Session details" });
+
+// Land on Gamma's schedule as `who`, with the fake clock past the first day's
+// sessions so the server-side gate is open from first paint. Also used to
+// change identity mid-test: selectUser logs out and back in on its own.
+async function landAs(page: Page, who: string, day = 0) {
+  await page.goto("/Conference-Gamma?dev=1");
+  await selectUser(page, who);
+  await setDevClock(page, lateOnGammaDay(day));
+  await page.reload();
+}
+
+async function openSession(page: Page, title: RegExp) {
+  await page.getByRole("link", { name: title }).first().click();
+  await expect(dialog(page)).toBeVisible();
+}
+
+test("a host records a count on a finished session and it persists", async ({
+  page,
+}) => {
+  await login(page);
+  await landAs(page, "Yuki Tanaka");
+  await openSession(page, /The Future of AI/);
+
+  // Empty state: optional, with the FR-008 copy that stops a host guessing
+  // what 0 means or recording 0 for a session that never happened.
+  await expect(countInput(page)).toHaveValue("");
+  await expect(
+    page.getByText(/0 if the session was held but nobody came/i)
+  ).toBeVisible();
+  await expect(page.getByText(/delete the session instead/i)).toBeVisible();
+
+  await countInput(page).fill("12");
+  await saveButton(page).click();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(countInput(page)).toHaveValue("12");
+
+  // Clearing the field puts the session back to no recorded count.
+  await countInput(page).fill("");
+  await saveButton(page).click();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+  await page.reload();
+  await expect(countInput(page)).toHaveValue("");
+});
+
+test("saving announces that it is in progress before it confirms", async ({
+  page,
+}) => {
+  await login(page);
+  await landAs(page, "Isabella Rossi");
+  await openSession(page, /Design Systems/);
+
+  // Hold the server action open so the pending state is observable rather
+  // than a race — it is a real state the control owes the user
+  // (Constitution VI), not an implementation detail.
+  let release = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route(
+    (url) => url.pathname.startsWith("/Conference-Gamma"),
+    async (route, request) => {
+      if (request.method() !== "POST") return route.continue();
+      await held;
+      return route.continue();
+    }
+  );
+
+  await countInput(page).fill("7");
+  await saveButton(page).click();
+
+  await expect(page.getByText("Saving…")).toBeVisible();
+  await expect(saveButton(page)).toBeDisabled();
+
+  release();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+});
+
+test("an out-of-range value is reported on the field itself", async ({
+  page,
+}) => {
+  await login(page);
+  await landAs(page, "Arjun Nair");
+  await openSession(page, /API Design/);
+
+  await countInput(page).fill("1001");
+  await saveButton(page).click();
+
+  await expect(countInput(page)).toHaveAttribute("aria-invalid", "true");
+  const messageId = await countInput(page).getAttribute("aria-describedby");
+  expect(messageId).toBeTruthy();
+  await expect(page.locator(`#${messageId}`)).toContainText("1000");
+
+  // A value inside the range clears the error and saves.
+  await countInput(page).fill("30");
+  await saveButton(page).click();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+  await expect(countInput(page)).not.toHaveAttribute("aria-invalid", "true");
+});
+
+test("an attendee who is not a host sees no count", async ({ page }) => {
+  await login(page);
+  await landAs(page, "Tereza Nováková");
+  await openSession(page, /Open Source Sustainability/);
+  await countInput(page).fill("42");
+  await saveButton(page).click();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+
+  await landAs(page, "Alice Test");
+  await openSession(page, /Open Source Sustainability/);
+
+  await expect(countInput(page)).toHaveCount(0);
+  await expect(dialog(page)).not.toContainText("42");
+  await expect(dialog(page)).not.toContainText(/how many people attended/i);
+});
+
+// SC-001: the whole point of the follow-up email. Carlos Silva hosts this
+// session and no other spec touches him, so the mailbox search below cannot
+// collide with a parallel worker.
+test("a host follows the link in the follow-up email and records the count", async ({
+  page,
+}) => {
+  test.skip(
+    skipWithoutMailpit(),
+    "mail env vars unset — start Mailpit (make mailpit) and set them in .env.test.local to run this test (see docs/dev/testing.md § Running tests)"
+  );
+
+  await login(page);
+  // Day 2, 14:00–15:00 Berlin: by 17:00 the follow-up has long come due.
+  await landAs(page, "Carlos Silva", 1);
+
+  // The scheduler is off in E2E (REMINDER_DISPATCH_INTERVAL_MS=0, see
+  // docs/dev/testing.md), so the dev toolbar's button stands in for the tick
+  // that would run on a real deployment.
+  await page.getByRole("button", { name: "Send due reminders" }).click();
+  // Let the tick finish before navigating: an aborted dispatch would leave the
+  // reminder claimed but unsent.
+  await expect(page.getByText(/sent \d+ reminders/)).toBeVisible();
+
+  const title = "Sustainable Software Development";
+  const html = await followUpHtml(title, "carlos.silva@example.com");
+  const link = /href="([^"]*record=count)"/.exec(html)?.[1];
+  expect(link, "the follow-up must carry a record link").toBeTruthy();
+
+  await page.goto(link!.replaceAll("&amp;", "&"));
+  await expect(dialog(page)).toBeVisible();
+
+  // Arriving from the email puts the cursor in the field: one interaction to
+  // record (SC-001).
+  await expect(countInput(page)).toBeFocused();
+  await page.keyboard.type("23");
+  await saveButton(page).click();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(countInput(page)).toHaveValue("23");
+});
+
+// Mailpit keeps mail from earlier runs, so read the newest match rather than
+// insisting the mailbox holds exactly one.
+async function followUpHtml(title: string, email: string): Promise<string> {
+  const matching = async () =>
+    (await searchBySubject(title)).filter(
+      (m) =>
+        m.Subject.startsWith("How many people came to") &&
+        m.To.some((t) => t.Address === email)
+    );
+  await expect.poll(matching, { timeout: 10000 }).not.toHaveLength(0);
+  return (await getMessage((await matching())[0].ID)).HTML;
+}
+
+// Story 3 was a prompt at the top of the schedule listing the sessions a host
+// still owed a count for. It is withdrawn (FR-025): the notification list says
+// the same thing in the place hosts already look, and it says it without
+// nagging every schedule view. What is left to pin is its absence.
+test("the schedule no longer nags a host about uncounted sessions", async ({
+  page,
+}) => {
+  // Charlie Test hosts two Gamma sessions that have finished by 17:00 on day 1
+  // — the opening keynote (day 0) and the React talk (day 1) — so this is the
+  // host the prompt used to appear for.
+  await login(page);
+  await landAs(page, "Charlie Test", 1);
+
+  const prompt = page.getByRole("region", {
+    name: /sessions you haven.t counted/i,
+  });
+
+  // Both schedule views mounted the prompt, so check both: deleting one render
+  // site would pass a test that only looked at the other.
+  await expect(prompt).toHaveCount(0);
+  await page.getByRole("button", { name: "Text" }).click();
+  await expect(page.getByPlaceholder("Search sessions")).toBeVisible();
+  await expect(prompt).toHaveCount(0);
+});
+
+test.describe("on a phone", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("the control fits without scrolling the page sideways (SC-006)", async ({
+    page,
+  }) => {
+    await login(page);
+    await landAs(page, "Min-jun Kim", 1);
+
+    await openSession(page, /CRDT Show & Tell/);
+
+    await expect(countInput(page)).toBeVisible();
+    await expect(saveButton(page)).toBeVisible();
+
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth
+    );
+    // A pixel of slack for sub-pixel rounding; anything more is a real
+    // sideways scroll.
+    expect(overflow).toBeLessThanOrEqual(1);
+
+    const box = (await saveButton(page).boundingBox())!;
+    expect(box.x + box.width).toBeLessThanOrEqual(390);
+  });
+});

--- a/tests/e2e/helpers/dev-clock.ts
+++ b/tests/e2e/helpers/dev-clock.ts
@@ -26,30 +26,35 @@ export const duringGammaDayOne = DateTime.now()
 /**
  * Move the dev fake clock to `target` via the toolbar's datetime picker, then
  * wait for the simulated date to show so the override cookie is committed.
+ * The page must already carry `?dev=1`.
  */
 export async function setDevClock(page: Page, target: DateTime) {
   await expect(page.getByText("Dev clock")).toBeVisible();
+  const picker = page.getByLabel("Pick date and time");
+  const value = target.toFormat("yyyy-MM-dd'T'HH:mm");
+  // Filling in the value the picker already holds fires no change event, so
+  // the toolbar applies nothing and there is no refresh to wait for below.
+  // A test that lands on the same simulated moment twice hits exactly this —
+  // the override cookie survives the user switch in between.
+  if ((await picker.inputValue()) === value) return;
   // Applying the clock triggers a router.refresh(); a navigation started while
   // its RSC payload is still streaming aborts it, which logs an RSC-payload
   // error the console guard fails on. So wait for that very response, body and
   // all — "networkidle" is both later and less certain, since Next goes on
   // prefetching in the background. A refresh asks for RSC without the
   // prefetch header, which is what tells it apart from those prefetches.
-  const [refreshed] = await Promise.all([
-    page.waitForResponse(
-      (res) =>
-        res.ok() &&
-        res.request().headers()["rsc"] === "1" &&
-        !res.request().headers()["next-router-prefetch"]
-    ),
-    page
-      .getByLabel("Pick date and time")
-      .fill(target.toFormat("yyyy-MM-dd'T'HH:mm")),
-  ]);
-  // The toolbar prints the simulated instant in UTC; the calendar date is the
-  // same as Berlin's for a 16:00 target, so match on the date alone.
+  const refreshed = page.waitForResponse(
+    (res) =>
+      res.ok() &&
+      res.request().headers()["rsc"] === "1" &&
+      !res.request().headers()["next-router-prefetch"]
+  );
+  await picker.fill(value);
+  // The toolbar prints the simulated instant in UTC; for the afternoon targets
+  // these tests use, the calendar date is the same as Berlin's, so match on
+  // the date alone.
   await expect(page.getByText(target.toFormat("yyyy-MM-dd"))).toBeVisible();
-  await refreshed.finished();
+  await (await refreshed).finished();
 }
 
 /**

--- a/tests/e2e/helpers/user.ts
+++ b/tests/e2e/helpers/user.ts
@@ -67,7 +67,11 @@ export async function openNameSwitcher(page: Page): Promise<Locator> {
 // guests: a protected one answers the pick with a password form instead, which
 // keeps the modal open (see user-auth.spec.ts, which drives that by hand).
 export async function selectUser(page: Page, name: string | RegExp) {
-  await openNameSwitcher(page);
+  const nameBox = await openNameSwitcher(page);
+  // The picker lists only the first 20 matching names (see SelectHosts), so a
+  // name late in the alphabet is absent until the query narrows the list.
+  // Only an exact string can be typed; a pattern has to already be in view.
+  if (typeof name === "string") await nameBox.fill(name);
   await page.getByRole("option", { name }).click();
   // Picking a name is a server round trip (selectUserAction); only once it
   // lands does the modal close and the header chip take the new name.

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -1,6 +1,8 @@
 import type { Page } from "@playwright/test";
+import { DateTime } from "luxon";
 import { expect, test } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
+import { setDevClock } from "./helpers/dev-clock";
 import { selectUser } from "./helpers/user";
 
 // The suite shares one database, so each test notifies a different guest:
@@ -189,4 +191,91 @@ test("closing a session opened from a notification stays on the schedule", async
     page.getByRole("heading", { name: "Notifications" })
   ).toBeHidden();
   await expect(page.getByRole("link", { name: GREEN_SESSION })).toBeVisible();
+});
+
+// The attendee-count reminder reaches its host in the app, whatever the state
+// of the instance's mail configuration. Only a browser shows the rest: that it
+// lands in the notification list unread, is counted by the nav badge, and
+// opens the session with the count field ready to type into.
+//
+// Charlie Test hosts exactly two Gamma sessions that have finished by 17:00 on
+// day 1 — the opening keynote (day 0) and the React talk (day 1) — so they are
+// owed two follow-ups and no heads-up, which is dropped once a session has
+// ended.
+test.describe("attendee-count reminders", () => {
+  test.use({ timezoneId: "Europe/Berlin" });
+
+  // Gamma's days run 09:00–18:00 Berlin from today+14; 17:00 on day 1 is after
+  // both sessions and before the day folds shut.
+  const lateOnGammaDay = (day: number) =>
+    DateTime.now()
+      .setZone("Europe/Berlin")
+      .plus({ days: 14 + day })
+      .set({ hour: 17, minute: 0, second: 0, millisecond: 0 });
+
+  const KEYNOTE = /Opening Keynote/;
+  const REACT = /Building Scalable Web Applications/;
+
+  const noticeFor = (page: Page, title: RegExp) =>
+    page.getByRole("button", { name: title });
+
+  test("a host finds the reminder in their notification list and records the count", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/Conference-Gamma?dev=1");
+    await selectUser(page, "Charlie Test");
+    await setDevClock(page, lateOnGammaDay(1));
+    await page.reload();
+
+    // The scheduler is off in E2E (REMINDER_DISPATCH_INTERVAL_MS=0, see
+    // docs/dev/testing.md), so the dev toolbar's button stands in for the tick
+    // a real deployment runs.
+    await page.getByRole("button", { name: "Send due reminders" }).click();
+    await expect(page.getByText(/sent \d+ reminders/)).toBeVisible();
+
+    await expect(bell(page)).toHaveAccessibleName(/unread/);
+    await bell(page).click();
+    await expect(
+      page.getByRole("heading", { name: "Notifications" })
+    ).toBeVisible();
+    await expect(noticeFor(page, KEYNOTE)).toBeVisible();
+    await expect(noticeFor(page, REACT)).toBeVisible();
+
+    // Opening it lands on the session with the cursor already in the field:
+    // one interaction to record.
+    await noticeFor(page, KEYNOTE).click();
+    const dialog = page.getByRole("dialog", { name: "Session details" });
+    await expect(dialog).toBeVisible();
+    const countInput = page.getByLabel("How many people attended?");
+    await expect(countInput).toBeFocused();
+    await countInput.fill("40");
+    await page.getByRole("button", { name: "Save attendee count" }).click();
+    await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+
+    // FR-023: recording a count settles nothing in the notification list. The
+    // reminder for the *other* session is still there, and still unread —
+    // nothing retracts, edits or auto-reads a notification after the fact.
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    // The follow-up's auto-focus belongs to the session it arrived for. Left
+    // in the query it rides along into every session opened from the schedule
+    // afterwards (modal-nav copies the current params), stealing the scroll
+    // position and popping the keyboard open on a phone.
+    await page.getByRole("link", { name: REACT }).first().click();
+    await expect(dialog).toBeVisible();
+    await expect(countInput).not.toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    await bell(page).click();
+    const outstanding = page
+      .getByRole("listitem")
+      .filter({ has: noticeFor(page, REACT) });
+    await expect(outstanding).toBeVisible();
+    await expect(
+      outstanding.getByRole("button", { name: "Mark as read" })
+    ).toBeVisible();
+  });
 });

--- a/tests/e2e/user-settings.spec.ts
+++ b/tests/e2e/user-settings.spec.ts
@@ -51,7 +51,13 @@ test("header user menu reaches profile, edit profile, and settings; email prefer
       /comments on a proposal, session or profile I.ve commented on/i
     )
   ).not.toBeChecked();
+  const headsUpToggle = page.getByLabel(/hosting starts in an hour/i);
+  await expect(headsUpToggle).toBeChecked();
+  const countToggle = page.getByLabel(/record how many people attended/i);
+  await expect(countToggle).toBeChecked();
+
   await rsvpToggle.uncheck();
+  await countToggle.uncheck();
   await page.getByRole("button", { name: /^Save$/ }).click();
   await expect(page.getByText(/saved/i)).toBeVisible();
 
@@ -65,6 +71,12 @@ test("header user menu reaches profile, edit profile, and settings; email prefer
   await expect(
     page.getByLabel(/RSVP.d to changes time or location/i)
   ).not.toBeChecked();
+  await expect(
+    page.getByLabel(/record how many people attended/i)
+  ).not.toBeChecked();
+  // The two reminders have their own switches: turning one off leaves the
+  // other alone.
+  await expect(page.getByLabel(/hosting starts in an hour/i)).toBeChecked();
 });
 
 test("settings page asks to select a name when none is chosen", async ({

--- a/tests/integration/action-auth-guard.test.ts
+++ b/tests/integration/action-auth-guard.test.ts
@@ -169,6 +169,21 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       await import("@/app/actions/meetings");
     return saveMeetingAvailabilityAction({ eventId: "e", slotStarts: [] });
   },
+  "actions/attendee-count.ts:getAttendeeCountAction": async () => {
+    const { getAttendeeCountAction } =
+      await import("@/app/actions/attendee-count");
+    return getAttendeeCountAction("s");
+  },
+  "actions/attendee-count.ts:setAttendeeCountAction": async () => {
+    const { setAttendeeCountAction } =
+      await import("@/app/actions/attendee-count");
+    return setAttendeeCountAction("s", 1);
+  },
+  "actions/dev-reminders.ts:dispatchRemindersAction": async () => {
+    const { dispatchRemindersAction } =
+      await import("@/app/actions/dev-reminders");
+    return dispatchRemindersAction();
+  },
   "actions/profile.ts:updateProfileAction": async () => {
     const { updateProfileAction } = await import("@/app/actions/profile");
     return updateProfileAction({ name: "N" });
@@ -213,6 +228,8 @@ const SITE_GUARDED: Record<string, () => Promise<unknown>> = {
       commentThread: true,
       meetingRequest: true,
       meetingResponse: true,
+      sessionHeadsUp: true,
+      attendeeCountReminder: true,
     });
   },
   "actions/user-auth.ts:requestLoginCodeAction": async () => {

--- a/tests/integration/attendee-count-visibility.test.ts
+++ b/tests/integration/attendee-count-visibility.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// FR-005/FR-020: a recorded attendee count is host-only. The enforcement is
+// structural — `attendeeCount` is absent from the `Session` type, which the
+// event layout serialises into every visitor's browser (docs/dev/adr/0006).
+// "Structurally impossible" is a claim a test should hold, not something a
+// reviewer has to remember, so this pins both payloads that carry sessions:
+// the attendee-facing event layout and the admin session list.
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+const captured: { sessions?: unknown } = {};
+vi.mock("@/app/(site)/[eventSlug]/event-provider-wrapper", () => ({
+  EventProviderWrapper: ({
+    eventContextValue,
+  }: {
+    eventContextValue: { sessions: unknown };
+  }) => {
+    captured.sessions = eventContextValue.sessions;
+    return "PROVIDER_STUB";
+  },
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+
+const HOUR_MS = 60 * 60 * 1000;
+const RECORDED_COUNT = 137;
+
+/** Every key anywhere in the payload, however deeply nested. */
+function allKeys(value: unknown, into = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) allKeys(item, into);
+  } else if (value && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      into.add(key);
+      allKeys(nested, into);
+    }
+  }
+  return into;
+}
+
+/** Every primitive value anywhere in the payload. */
+function allValues(value: unknown, into: unknown[] = []): unknown[] {
+  if (Array.isArray(value)) {
+    for (const item of value) allValues(item, into);
+  } else if (value && typeof value === "object") {
+    for (const nested of Object.values(value)) allValues(nested, into);
+  } else {
+    into.push(value);
+  }
+  return into;
+}
+
+function expectNoCount(payload: unknown): void {
+  for (const key of allKeys(payload)) {
+    expect(key.toLowerCase()).not.toContain("attendeecount");
+    expect(key.toLowerCase()).not.toContain("attendee_count");
+  }
+  // Belt and braces: the number itself must not appear under some other name.
+  // Value by value rather than as a substring of the JSON, where a seeded
+  // title or a millisecond stamp can carry the same digits by coincidence.
+  for (const value of allValues(payload)) {
+    expect(value).not.toBe(RECORDED_COUNT);
+    expect(value).not.toBe(String(RECORDED_COUNT));
+  }
+}
+
+async function seed() {
+  const event = await createEvent({ phase: "scheduling" });
+  const host = await createGuest({ eventId: event.id });
+  const attendee = await createGuest({ eventId: event.id });
+  const now = Date.now();
+  const session = await createSession(event.id, {
+    hostIds: [host.id],
+    startTime: new Date(now - 3 * HOUR_MS),
+    endTime: new Date(now - HOUR_MS),
+  });
+  await getRepositories().sessions.setAttendeeCount(session.id, RECORDED_COUNT);
+  return { event, host, attendee, session };
+}
+
+describe("a recorded attendee count never reaches a session payload", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    captured.sessions = undefined;
+  });
+
+  it("is absent from the event layout payload served to a non-host (FR-005)", async () => {
+    const { event, attendee } = await seed();
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(attendee.id));
+
+    const { EventLayoutContent } =
+      await import("@/app/(site)/[eventSlug]/layout-content");
+    renderToStaticMarkup(
+      await EventLayoutContent({ eventSlug: event.slug, children: null })
+    );
+
+    expect(captured.sessions).toBeDefined();
+    expectNoCount(captured.sessions);
+  });
+
+  it("is absent even from the payload served to the host who recorded it", async () => {
+    const { event, host } = await seed();
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(host.id));
+
+    const { EventLayoutContent } =
+      await import("@/app/(site)/[eventSlug]/layout-content");
+    renderToStaticMarkup(
+      await EventLayoutContent({ eventSlug: event.slug, children: null })
+    );
+
+    // The host reads their count through the server action, never off the
+    // shared payload — otherwise the field would exist on `Session` and every
+    // other visitor would receive it too.
+    expectNoCount(captured.sessions);
+  });
+
+  it("is absent from the admin session read surface (FR-020)", async () => {
+    const { event } = await seed();
+
+    const page = await getRepositories().sessions.searchByEvent(event.id, {
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(page.rows).toHaveLength(1);
+    expectNoCount(page.rows);
+  });
+
+  it("is absent from every other session listing", async () => {
+    const { event, host } = await seed();
+    const { sessions } = getRepositories();
+
+    for (const rows of [
+      await sessions.list(),
+      await sessions.listByEvent(event.id),
+      await sessions.listScheduled(),
+      await sessions.listScheduledByEvent(event.id),
+      await sessions.listHostedByGuest(host.id),
+    ]) {
+      expect(rows.length).toBeGreaterThan(0);
+      expectNoCount(rows);
+    }
+  });
+});

--- a/tests/integration/attendee-count-visibility.test.ts
+++ b/tests/integration/attendee-count-visibility.test.ts
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 // FR-005/FR-020: a recorded attendee count is host-only. The enforcement is
 // structural — `attendeeCount` is absent from the `Session` type, which the
-// event layout serialises into every visitor's browser (docs/dev/adr/0006).
+// event layout serialises into every visitor's browser (docs/dev/adr/0007).
 // "Structurally impossible" is a claim a test should hold, not something a
 // reviewer has to remember, so this pins both payloads that carry sessions:
 // the attendee-facing event layout and the admin session list.

--- a/tests/integration/attendee-count.test.ts
+++ b/tests/integration/attendee-count.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { siteAuthenticate } from "../helpers/site-auth";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { GUEST_COOKIE_NAME, openGuestValue } from "../helpers/guest-cookie";
+import { getRepositories } from "@/db/container";
+import {
+  getAttendeeCountAction,
+  setAttendeeCountAction,
+} from "@/app/actions/attendee-count";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function actAs(guestId: string): void {
+  cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guestId));
+}
+
+/** A session that ended an hour ago, so the entry gate is open. */
+async function finishedSession(eventId: string, hostIds: string[]) {
+  const now = Date.now();
+  return createSession(eventId, {
+    hostIds,
+    startTime: new Date(now - 3 * HOUR_MS),
+    endTime: new Date(now - HOUR_MS),
+  });
+}
+
+describe("attendee count server action", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    await siteAuthenticate(cookieJar);
+  });
+
+  it("records a count a host can read back", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+    actAs(host.id);
+
+    expect(await setAttendeeCountAction(session.id, "12")).toEqual({
+      ok: true,
+      count: 12,
+    });
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: 12,
+    });
+  });
+
+  it("lets a co-host read and change the same value (FR-003)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const cohost = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id, cohost.id]);
+
+    actAs(host.id);
+    await setAttendeeCountAction(session.id, "12");
+
+    actAs(cohost.id);
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: 12,
+    });
+    expect(await setAttendeeCountAction(session.id, "15")).toEqual({
+      ok: true,
+      count: 15,
+    });
+
+    actAs(host.id);
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: 15,
+    });
+  });
+
+  it("keeps 0 as a recorded value and a blank field as 'not recorded' (FR-001)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+    actAs(host.id);
+
+    expect(await setAttendeeCountAction(session.id, "0")).toEqual({
+      ok: true,
+      count: 0,
+    });
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: 0,
+    });
+
+    expect(await setAttendeeCountAction(session.id, "")).toEqual({
+      ok: true,
+      count: null,
+    });
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: null,
+    });
+  });
+
+  it("refuses a non-host rather than reporting no count (FR-005)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const stranger = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+
+    actAs(host.id);
+    await setAttendeeCountAction(session.id, "12");
+
+    actAs(stranger.id);
+    const read = await getAttendeeCountAction(session.id);
+    // Not { ok: true, count: null }: that would let a prober tell "no count
+    // recorded" apart from "not your session".
+    expect(read.ok).toBe(false);
+    const write = await setAttendeeCountAction(session.id, "99");
+    expect(write.ok).toBe(false);
+
+    actAs(host.id);
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: 12,
+    });
+  });
+
+  it("refuses a host whose session has not finished yet (FR-002)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const now = Date.now();
+    const session = await createSession(event.id, {
+      hostIds: [host.id],
+      startTime: new Date(now + HOUR_MS),
+      endTime: new Date(now + 2 * HOUR_MS),
+    });
+    actAs(host.id);
+
+    expect((await setAttendeeCountAction(session.id, "12")).ok).toBe(false);
+    expect((await getAttendeeCountAction(session.id)).ok).toBe(false);
+  });
+
+  it("rejects out-of-range and non-whole values with a field-level issue (FR-004)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+    actAs(host.id);
+
+    for (const bad of ["-1", "1.5", "1001"]) {
+      const result = await setAttendeeCountAction(session.id, bad);
+      expect(result.ok).toBe(false);
+      // An array of Zod issues, not a bare string: the message has to attach
+      // to the input (ADR 0003).
+      expect(Array.isArray(result.ok === false && result.error)).toBe(true);
+    }
+
+    expect(await getAttendeeCountAction(session.id)).toEqual({
+      ok: true,
+      count: null,
+    });
+    // The boundaries themselves are accepted.
+    expect(await setAttendeeCountAction(session.id, "1000")).toEqual({
+      ok: true,
+      count: 1000,
+    });
+  });
+
+  it("lets a host record on an admin-managed session (FR-007)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+    await getRepositories().sessions.update(session.id, {
+      adminManaged: true,
+    });
+    actAs(host.id);
+
+    expect(await setAttendeeCountAction(session.id, "7")).toEqual({
+      ok: true,
+      count: 7,
+    });
+  });
+
+  it("converges on one stored value when two saves overlap (SC-007)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+    actAs(host.id);
+
+    const [first, second] = await Promise.all([
+      setAttendeeCountAction(session.id, "12"),
+      setAttendeeCountAction(session.id, "15"),
+    ]);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+
+    // One value survives, not two, and it is one of the two submitted.
+    const stored = await getAttendeeCountAction(session.id);
+    expect(stored.ok).toBe(true);
+    expect([12, 15]).toContain(stored.ok === true && stored.count);
+  });
+
+  it("discards the count when the session is deleted (FR-019)", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+    actAs(host.id);
+    await setAttendeeCountAction(session.id, "12");
+
+    const { sessions } = getRepositories();
+    await sessions.delete(session.id);
+
+    expect(await sessions.findById(session.id)).toBeUndefined();
+    expect(await sessions.getAttendeeCount(session.id)).toBeNull();
+    expect((await getAttendeeCountAction(session.id)).ok).toBe(false);
+  });
+
+  it("refuses when no user is selected", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const session = await finishedSession(event.id, [host.id]);
+
+    expect((await setAttendeeCountAction(session.id, "12")).ok).toBe(false);
+    expect((await getAttendeeCountAction(session.id)).ok).toBe(false);
+  });
+});

--- a/tests/integration/mailer.test.tsx
+++ b/tests/integration/mailer.test.tsx
@@ -1,10 +1,22 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
 import {
   getMessage,
   searchBySubject,
   skipWithoutMailpit,
 } from "../helpers/mailpit";
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createLocation } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { dispatchDueReminders } from "@/utils/reminder-dispatch";
 
 // This suite runs only when MAILPIT_API_URL points at a mailpit instance
 // (start one with `make mailpit`, see docs/dev/testing.md § Running tests). Skips
@@ -63,3 +75,97 @@ describe.skipIf(skipWithoutMailpit())("sendMail via mailpit", () => {
     expect(message.Text.trim()).toBe("test body line 1\r\n\r\nline 2");
   });
 });
+
+// The event runs in Berlin (UTC+2 on this date) while the process may not, so
+// every asserted time doubles as an FR-018 check: an ambient-zone bug would
+// print 10:10 instead of 12:10.
+describe.skipIf(skipWithoutMailpit())(
+  "attendee-count reminders via mailpit",
+  () => {
+    const START = new Date("2026-09-01T10:00:00Z"); // displayed 12:10 in Berlin
+    const END = new Date("2026-09-01T11:00:00Z"); // 13:00 in Berlin
+    const HEADS_UP_AT = new Date("2026-09-01T09:10:00Z");
+    const FOLLOW_UP_AT = new Date("2026-09-01T11:15:00Z");
+
+    beforeAll(() => setupTestDb());
+
+    beforeEach(() => {
+      resetTestDb();
+      vi.stubEnv("SMTP_FROM", "Test Sender <sender@test.example>");
+      vi.stubEnv("SITE_URL", "https://site.example");
+      resetMailer();
+      initMailer();
+    });
+
+    afterEach(() => vi.unstubAllEnvs());
+
+    // A unique title so each run finds its own message without wiping a mailbox
+    // that may hold a developer's other mail.
+    async function berlinSession(title: string) {
+      const event = await createEvent({ phase: "scheduling" });
+      await getRepositories().events.update(event.id, {
+        timezone: "Europe/Berlin",
+      });
+      const room = await createLocation({ name: "The Big Tent" });
+      const host = await createGuest({ email: "host@test.example" });
+      const session = await getRepositories().sessions.create({
+        title,
+        description: "",
+        startTime: START,
+        endTime: END,
+        capacity: 30,
+        adminManaged: false,
+        blocker: false,
+        closed: false,
+        eventId: event.id,
+        hostIds: [host.id],
+        locationIds: [room.id],
+      });
+      const slug = (await getRepositories().events.findById(event.id))!.slug;
+      return { session, slug };
+    }
+
+    // Searched by the unique title alone: both subjects quote the title, and
+    // mailpit's `subject:"…"` query cannot carry nested quotes.
+    async function receive(title: string, subject: string) {
+      await expect
+        .poll(() => searchBySubject(title), { timeout: 2000 })
+        .toHaveLength(1);
+      const [summary] = await searchBySubject(title);
+      expect(summary.Subject).toBe(subject);
+      expect(summary.To).toEqual([
+        expect.objectContaining({ Address: "host@test.example" }),
+      ]);
+      return getMessage(summary.ID);
+    }
+
+    it("delivers a heads-up naming the start time and location in the event's zone", async () => {
+      const title = `Heads-up session ${Date.now()}`;
+      await berlinSession(title);
+
+      await dispatchDueReminders(HEADS_UP_AT);
+
+      const message = await receive(title, `You're hosting "${title}" shortly`);
+      expect(message.HTML).toContain("12:10");
+      expect(message.HTML).not.toContain("10:10");
+      expect(message.HTML).toContain("The Big Tent");
+    });
+
+    it("delivers a follow-up carrying the record link", async () => {
+      const title = `Follow-up session ${Date.now()}`;
+      const { session, slug } = await berlinSession(title);
+
+      await dispatchDueReminders(FOLLOW_UP_AT);
+
+      const message = await receive(
+        title,
+        `How many people came to "${title}"?`
+      );
+      expect(message.HTML).toContain(
+        `https://site.example/${slug}?viewSession=${session.id}&amp;record=count`
+      );
+      expect(message.HTML).toContain("13:00");
+      expect(message.HTML).not.toContain("11:00");
+    });
+  }
+);

--- a/tests/integration/reminder-backfill-migration.test.ts
+++ b/tests/integration/reminder-backfill-migration.test.ts
@@ -1,0 +1,139 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { runMigrations } from "@/db/migrate";
+import { followUpDueTime } from "@/utils/reminder-schedule";
+
+// The migration that adds the reminder machinery has to settle the follow-up
+// for every session that had already finished when it ran. Without that, the
+// first dispatch tick after an upgrade finds an entire event history owed a
+// follow-up — a notification and an email per host per past session — because
+// a follow-up is deliberately never dropped for being late.
+//
+// Exercised by migrating a database that already holds those sessions, which
+// means running the migrations in two passes: up to the one before, then all
+// of them.
+
+const MIGRATIONS = path.join(process.cwd(), "drizzle");
+const BACKFILL_IDX = 33;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/** A copy of drizzle/ whose journal stops before `idx`. */
+function migrationsBefore(idx: number, into: string): string {
+  const folder = path.join(into, `migrations-before-${idx}`);
+  fs.mkdirSync(path.join(folder, "meta"), { recursive: true });
+  const journal = JSON.parse(
+    fs.readFileSync(path.join(MIGRATIONS, "meta/_journal.json"), "utf8")
+  ) as { entries: { idx: number; tag: string }[] };
+  journal.entries = journal.entries.filter((entry) => entry.idx < idx);
+  fs.writeFileSync(
+    path.join(folder, "meta/_journal.json"),
+    JSON.stringify(journal)
+  );
+  for (const entry of journal.entries) {
+    fs.copyFileSync(
+      path.join(MIGRATIONS, `${entry.tag}.sql`),
+      path.join(folder, `${entry.tag}.sql`)
+    );
+  }
+  return folder;
+}
+
+type Row = {
+  session_id: string;
+  guest_id: string;
+  kind: string;
+  due_time: string;
+  claimed_at: string | null;
+  notified_at: string | null;
+  sent_at: string | null;
+};
+
+const now = Date.now();
+const ENDED = new Date(now - 3 * HOUR_MS);
+const UNDER_WAY_END = new Date(now + HOUR_MS);
+const UPCOMING_START = new Date(now + 24 * HOUR_MS);
+
+let tempDir: string;
+let db: Database.Database;
+
+function addSession(id: string, startTime: Date, endTime: Date): void {
+  db.prepare(
+    "INSERT INTO sessions (id, title, event_id, start_time, end_time) VALUES (?, ?, 'e1', ?, ?)"
+  ).run(id, id, startTime.toISOString(), endTime.toISOString());
+  db.prepare(
+    "INSERT INTO session_hosts (session_id, guest_id) VALUES (?, 'g1'), (?, 'g2')"
+  ).run(id, id);
+}
+
+function rowsFor(sessionId: string): Row[] {
+  return db
+    .prepare("SELECT * FROM session_reminders WHERE session_id = ?")
+    .all(sessionId) as Row[];
+}
+
+describe("the attendee-count migration's follow-up backfill", () => {
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-backfill-"));
+    db = new Database(path.join(tempDir, "data.db"));
+    runMigrations(db, migrationsBefore(BACKFILL_IDX, tempDir));
+
+    db.prepare(
+      "INSERT INTO events (id, name, slug, start, end) VALUES ('e1', 'E', 'e', ?, ?)"
+    ).run(
+      new Date(now - 24 * HOUR_MS).toISOString(),
+      UPCOMING_START.toISOString()
+    );
+    db.prepare(
+      "INSERT INTO guests (id, name, email) VALUES ('g1', 'One', 'one@test.example'), ('g2', 'Two', 'two@test.example')"
+    ).run();
+
+    addSession("finished", new Date(now - 4 * HOUR_MS), ENDED);
+    addSession("under-way", new Date(now - HOUR_MS), UNDER_WAY_END);
+    addSession(
+      "upcoming",
+      UPCOMING_START,
+      new Date(UPCOMING_START.getTime() + HOUR_MS)
+    );
+    db.prepare(
+      "INSERT INTO sessions (id, title, event_id) VALUES ('unscheduled', 'U', 'e1')"
+    ).run();
+
+    runMigrations(db, MIGRATIONS);
+  });
+
+  afterAll(() => {
+    db.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("settles the follow-up for every host of a session that had finished", () => {
+    const rows = rowsFor("finished");
+    expect(rows.map((r) => r.guest_id).sort()).toEqual(["g1", "g2"]);
+    for (const row of rows) {
+      expect(row.kind).toBe("followUp");
+      // The due time dispatch computes, to the millisecond: anything else
+      // reads as a reschedule and re-arms the very reminder this suppresses.
+      expect(row.due_time).toBe(followUpDueTime(ENDED).toISOString());
+      expect(row.claimed_at).not.toBeNull();
+      expect(row.notified_at).not.toBeNull();
+      // Nothing was ever mailed, and the column may not pretend otherwise.
+      expect(row.sent_at).toBeNull();
+    }
+  });
+
+  it("leaves the heads-up alone, which is dropped once a session has ended", () => {
+    expect(rowsFor("finished").filter((r) => r.kind === "headsUp")).toEqual([]);
+  });
+
+  it("says nothing about a session that has not finished yet", () => {
+    expect(rowsFor("under-way")).toEqual([]);
+    expect(rowsFor("upcoming")).toEqual([]);
+    expect(rowsFor("unscheduled")).toEqual([]);
+  });
+});

--- a/tests/integration/reminder-dispatch.test.ts
+++ b/tests/integration/reminder-dispatch.test.ts
@@ -1,0 +1,536 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+  isMailerConfigured: vi.fn(() => true),
+}));
+
+import Database from "better-sqlite3";
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createLocation } from "../helpers/factories";
+import { getRepositories, serializeDb } from "@/db/container";
+import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
+import { isMailerConfigured, sendMail } from "@/utils/mailer";
+import { dispatchDueReminders } from "@/utils/reminder-dispatch";
+import { followUpDueTime } from "@/utils/reminder-schedule";
+
+// The reference session: 10:00–11:00 UTC with the factory's 10-minute break,
+// so the displayed start is 10:10, the heads-up is due at 09:10 and the
+// follow-up at 11:15. Dispatching at either moment isolates one kind: by
+// 11:15 the session has ended, which drops the heads-up (FR-013).
+const START = new Date("2026-09-01T10:00:00Z");
+const END = new Date("2026-09-01T11:00:00Z");
+const HEADS_UP_AT = new Date("2026-09-01T09:10:00Z");
+const FOLLOW_UP_AT = new Date("2026-09-01T11:15:00Z");
+
+const HOUR_MS = 60 * 60 * 1000;
+
+const FIRST = "first@test.example";
+const SECOND = "second@test.example";
+
+function later(from: Date, hours: number): Date {
+  return new Date(from.getTime() + hours * HOUR_MS);
+}
+
+function recipients(): string[] {
+  return vi
+    .mocked(sendMail)
+    .mock.calls.map((call) => call[0].to)
+    .sort();
+}
+
+function subjects(): string[] {
+  return vi.mocked(sendMail).mock.calls.map((call) => call[0].subject);
+}
+
+// Reads the raw reminder rows from a snapshot of the test database. The
+// cascade is a storage-layer guarantee, so it is asserted at the storage
+// layer rather than through a repository method nothing in the app needs.
+function reminderRowCount(sessionId: string): number {
+  const db = new Database(serializeDb());
+  try {
+    const row = db
+      .prepare(
+        "SELECT count(*) AS n FROM session_reminders WHERE session_id = ?"
+      )
+      .get(sessionId) as { n: number };
+    return row.n;
+  } finally {
+    db.close();
+  }
+}
+
+type StoredReminder = {
+  due_time: string;
+  claimed_at: string | null;
+  sent_at: string | null;
+  first_failed_at: string | null;
+  notified_at: string | null;
+};
+
+// Which channels settled, and how — the distinction between "spoken for" and
+// "mailed" is the whole point of the claimed_at/sent_at split, so it is read
+// straight from the row.
+function storedReminder(
+  sessionId: string,
+  guestId: string,
+  kind: string
+): StoredReminder | undefined {
+  const db = new Database(serializeDb());
+  try {
+    return db
+      .prepare(
+        "SELECT due_time, claimed_at, sent_at, first_failed_at, notified_at" +
+          " FROM session_reminders" +
+          " WHERE session_id = ? AND guest_id = ? AND kind = ?"
+      )
+      .get(sessionId, guestId, kind) as StoredReminder | undefined;
+  } finally {
+    db.close();
+  }
+}
+
+async function reminderNotices(guestId: string) {
+  const all = await getRepositories().notifications.listByGuest(guestId);
+  return all.filter(
+    (n) => n.type === "sessionHeadsUp" || n.type === "attendeeCountReminder"
+  );
+}
+
+/** A scheduled session in Room A hosted by every guest in `hosts`. */
+async function scheduledSession(hostIds: string[]) {
+  const event = await createEvent({ phase: "scheduling" });
+  const room = await createLocation({ name: "Room A", eventId: event.id });
+  const session = await getRepositories().sessions.create({
+    title: "Fun Workshop",
+    description: "",
+    startTime: START,
+    endTime: END,
+    capacity: 30,
+    adminManaged: false,
+    blocker: false,
+    closed: false,
+    eventId: event.id,
+    hostIds,
+    locationIds: [room.id],
+  });
+  return { event, session };
+}
+
+async function twoHostSession() {
+  const first = await createGuest({ email: FIRST });
+  const second = await createGuest({ email: SECOND });
+  const { event, session } = await scheduledSession([first.id, second.id]);
+  return { event, session, first, second };
+}
+
+describe("dispatchDueReminders", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+    vi.mocked(isMailerConfigured).mockReset().mockReturnValue(true);
+    vi.stubEnv("SITE_URL", "https://site.example");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("sends every host exactly one heads-up", async () => {
+    await twoHostSession();
+
+    const summary = await dispatchDueReminders(HEADS_UP_AT);
+
+    expect(summary.sent).toBe(2);
+    expect(recipients()).toEqual([FIRST, SECOND].sort());
+    expect(subjects()).toEqual([
+      expect.stringMatching(/hosting/i),
+      expect.stringMatching(/hosting/i),
+    ]);
+  });
+
+  it("sends every host exactly one follow-up", async () => {
+    await twoHostSession();
+
+    const summary = await dispatchDueReminders(FOLLOW_UP_AT);
+
+    expect(summary.sent).toBe(2);
+    expect(recipients()).toEqual([FIRST, SECOND].sort());
+    expect(subjects()).toEqual([
+      expect.stringMatching(/how many people/i),
+      expect.stringMatching(/how many people/i),
+    ]);
+  });
+
+  it("sends nothing more on a second run with the times unchanged (FR-015, SC-003)", async () => {
+    await twoHostSession();
+
+    await dispatchDueReminders(HEADS_UP_AT);
+    const second = await dispatchDueReminders(HEADS_UP_AT);
+
+    expect(second.sent).toBe(0);
+    expect(sendMail).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses the follow-up once a count is recorded, but not the heads-up", async () => {
+    const { session } = await twoHostSession();
+    await getRepositories().sessions.setAttendeeCount(session.id, 12);
+
+    expect((await dispatchDueReminders(HEADS_UP_AT)).sent).toBe(2);
+    vi.mocked(sendMail).mockClear();
+
+    expect((await dispatchDueReminders(FOLLOW_UP_AT)).sent).toBe(0);
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("still notifies a host who turned the reminder emails off (FR-017)", async () => {
+    const { session, second } = await twoHostSession();
+    const { guests } = getRepositories();
+    await guests.updateEmailSettings(second.id, {
+      ...DEFAULT_EMAIL_SETTINGS,
+      sessionHeadsUp: false,
+      attendeeCountReminder: false,
+    });
+
+    await dispatchDueReminders(HEADS_UP_AT);
+    await dispatchDueReminders(FOLLOW_UP_AT);
+
+    // The setting silences the mail, not the reminder: both still reach them
+    // in the app.
+    expect(recipients()).toEqual([FIRST, FIRST]);
+    expect(await reminderNotices(second.id)).toHaveLength(2);
+
+    // The reminder is settled even though nothing was mailed — claimed, never
+    // sent — so opting back in does not resurrect a mail at the same due
+    // time. They are reminded again on the next reschedule, like anyone else.
+    const row = storedReminder(session.id, second.id, "followUp");
+    expect(row?.claimed_at).not.toBeNull();
+    expect(row?.sent_at).toBeNull();
+
+    vi.mocked(sendMail).mockClear();
+    await guests.updateEmailSettings(second.id, DEFAULT_EMAIL_SETTINGS);
+    await dispatchDueReminders(FOLLOW_UP_AT);
+    expect(recipients()).toEqual([]);
+  });
+
+  it("gives each reminder its own email switch", async () => {
+    const { second } = await twoHostSession();
+    const { guests } = getRepositories();
+    await guests.updateEmailSettings(second.id, {
+      ...DEFAULT_EMAIL_SETTINGS,
+      sessionHeadsUp: false,
+    });
+
+    await dispatchDueReminders(HEADS_UP_AT);
+    expect(recipients()).toEqual([FIRST]);
+
+    vi.mocked(sendMail).mockClear();
+    await dispatchDueReminders(FOLLOW_UP_AT);
+    expect(recipients()).toEqual([FIRST, SECOND]);
+
+    expect(await reminderNotices(second.id)).toHaveLength(2);
+  });
+
+  it("notifies a host with no address on file, and mails only the reachable one", async () => {
+    const withAddress = await createGuest({ email: "reachable@test.example" });
+    const withoutAddress = await createGuest({ email: "" });
+    await scheduledSession([withAddress.id, withoutAddress.id]);
+
+    // `sent` counts reminders settled, not emails: the unreachable host's is
+    // settled too, with nothing to mail.
+    const summary = await dispatchDueReminders(HEADS_UP_AT);
+
+    expect(summary.sent).toBe(2);
+    expect(recipients()).toEqual(["reachable@test.example"]);
+    expect(await reminderNotices(withoutAddress.id)).toHaveLength(1);
+  });
+
+  it("produces nothing for a session with no hosts", async () => {
+    await scheduledSession([]);
+
+    const summary = await dispatchDueReminders(HEADS_UP_AT);
+
+    expect(summary.sent).toBe(0);
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("still reminds both hosts when mail is unconfigured (FR-012, FR-021)", async () => {
+    const { session, first, second } = await twoHostSession();
+    vi.mocked(isMailerConfigured).mockReturnValue(false);
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const summary = await dispatchDueReminders(HEADS_UP_AT);
+
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(summary.notified).toBe(2);
+    expect(await reminderNotices(first.id)).toHaveLength(1);
+    expect(await reminderNotices(second.id)).toHaveLength(1);
+    // An instance with no mail is not failing, so nothing is marked failed and
+    // nothing is logged.
+    expect(summary.failed).toBe(0);
+    expect(storedReminder(session.id, first.id, "headsUp")?.sent_at).toBeNull();
+    expect(logged).not.toHaveBeenCalled();
+
+    // The reminder was delivered, so configuring mail later does not re-open
+    // this due time. The next reschedule is what reminds them again.
+    vi.mocked(isMailerConfigured).mockReturnValue(true);
+    expect((await dispatchDueReminders(HEADS_UP_AT)).sent).toBe(0);
+
+    await getRepositories().sessions.update(session.id, {
+      startTime: later(START, 3),
+      endTime: later(END, 3),
+    });
+    expect((await dispatchDueReminders(later(HEADS_UP_AT, 3))).sent).toBe(2);
+    expect(recipients()).toEqual([FIRST, SECOND].sort());
+  });
+
+  it("discards a session's reminder rows when the session is deleted (FR-019)", async () => {
+    const { session } = await twoHostSession();
+    await dispatchDueReminders(HEADS_UP_AT);
+    expect(reminderRowCount(session.id)).toBe(2);
+
+    await getRepositories().sessions.delete(session.id);
+
+    expect(reminderRowCount(session.id)).toBe(0);
+  });
+
+  it("lets only one of two overlapping claims win (FR-015)", async () => {
+    const { session, first } = await twoHostSession();
+    const { reminders } = getRepositories();
+    const key = {
+      sessionId: session.id,
+      guestId: first.id,
+      kind: "headsUp" as const,
+    };
+
+    expect(await reminders.claim(key, HEADS_UP_AT, HEADS_UP_AT)).toEqual({
+      claimed: true,
+      notifyOwed: true,
+    });
+    expect((await reminders.claim(key, HEADS_UP_AT, HEADS_UP_AT)).claimed).toBe(
+      false
+    );
+  });
+
+  // The primitive the duplicate rule rests on: the notification is owed once
+  // per due time, and a re-armed mail retry against the same due time is not a
+  // new due time.
+  it("owes no second notification when a re-armed claim is retried (FR-016)", async () => {
+    const { session, first } = await twoHostSession();
+    const { reminders } = getRepositories();
+    const key = {
+      sessionId: session.id,
+      guestId: first.id,
+      kind: "headsUp" as const,
+    };
+
+    await reminders.claim(key, HEADS_UP_AT, HEADS_UP_AT);
+    await reminders.markNotified(key, HEADS_UP_AT);
+    await reminders.markFailed(key, HEADS_UP_AT, 24 * HOUR_MS);
+
+    expect(await reminders.claim(key, HEADS_UP_AT, HEADS_UP_AT)).toEqual({
+      claimed: true,
+      notifyOwed: false,
+    });
+  });
+
+  // sent_at means "an email went out for this due time" and nothing else, so
+  // a reschedule has to leave it as empty as the reminder it re-arms —
+  // otherwise the row claims a send the new slot never had.
+  it("keeps no record of the mail sent for a superseded due time", async () => {
+    const { session, first } = await twoHostSession();
+    await dispatchDueReminders(FOLLOW_UP_AT);
+    expect(
+      storedReminder(session.id, first.id, "followUp")?.sent_at
+    ).not.toBeNull();
+
+    await getRepositories().sessions.update(session.id, {
+      startTime: later(START, 3),
+      endTime: later(END, 3),
+    });
+    vi.mocked(isMailerConfigured).mockReturnValue(false);
+    await dispatchDueReminders(later(FOLLOW_UP_AT, 3));
+
+    const stored = storedReminder(session.id, first.id, "followUp");
+    expect(stored?.due_time).toBe(followUpDueTime(later(END, 3)).toISOString());
+    expect(stored?.sent_at).toBeNull();
+  });
+
+  describe("the in-app notification", () => {
+    it("reaches every host once, linking to the session (FR-022)", async () => {
+      const { event, session, first, second } = await twoHostSession();
+
+      const summary = await dispatchDueReminders(HEADS_UP_AT);
+
+      expect(summary.notified).toBe(2);
+      for (const host of [first, second]) {
+        const [notice, ...rest] = await reminderNotices(host.id);
+        expect(rest).toEqual([]);
+        expect(notice.type).toBe("sessionHeadsUp");
+        expect(notice.text).toContain("Fun Workshop");
+        // A path, not an absolute URL: notifications must work on an instance
+        // with no SITE_URL at all.
+        expect(notice.url).toBe(`/${event.slug}?viewSession=${session.id}`);
+      }
+    });
+
+    it("points the follow-up at the count field (FR-022)", async () => {
+      const { event, session, first } = await twoHostSession();
+
+      await dispatchDueReminders(FOLLOW_UP_AT);
+
+      const [notice] = await reminderNotices(first.id);
+      expect(notice.type).toBe("attendeeCountReminder");
+      expect(notice.text).toContain("Fun Workshop");
+      expect(notice.url).toBe(
+        `/${event.slug}?viewSession=${session.id}&record=count`
+      );
+    });
+
+    it("is not repeated by a second run at the same due time (FR-015)", async () => {
+      const { first } = await twoHostSession();
+
+      await dispatchDueReminders(HEADS_UP_AT);
+      const second = await dispatchDueReminders(HEADS_UP_AT);
+
+      expect(second.notified).toBe(0);
+      expect(await reminderNotices(first.id)).toHaveLength(1);
+    });
+
+    it("is not repeated when the mail is retried (FR-016)", async () => {
+      const { second } = await twoHostSession();
+      vi.mocked(sendMail).mockImplementation(({ to }) =>
+        to === SECOND
+          ? Promise.reject(new Error("smtp is down"))
+          : Promise.resolve()
+      );
+      await dispatchDueReminders(FOLLOW_UP_AT);
+      expect(await reminderNotices(second.id)).toHaveLength(1);
+
+      vi.mocked(sendMail).mockReset();
+      await dispatchDueReminders(later(FOLLOW_UP_AT, 1));
+
+      // The mail is attempted again; the notification they already have is
+      // left alone.
+      expect(recipients()).toEqual([SECOND]);
+      expect(await reminderNotices(second.id)).toHaveLength(1);
+    });
+
+    it("is created again when the session is rescheduled (FR-024)", async () => {
+      const { session, first } = await twoHostSession();
+      await dispatchDueReminders(FOLLOW_UP_AT);
+
+      await getRepositories().sessions.update(session.id, {
+        startTime: later(START, 3),
+        endTime: later(END, 3),
+      });
+      await dispatchDueReminders(later(FOLLOW_UP_AT, 3));
+
+      expect(await reminderNotices(first.id)).toHaveLength(2);
+    });
+
+    it("survives an abandoned mail", async () => {
+      const { second } = await twoHostSession();
+      vi.mocked(sendMail).mockRejectedValue(new Error("smtp is down"));
+      await dispatchDueReminders(FOLLOW_UP_AT);
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const summary = await dispatchDueReminders(later(FOLLOW_UP_AT, 25));
+
+      expect(summary.abandoned).toBe(2);
+      expect(await reminderNotices(second.id)).toHaveLength(1);
+    });
+
+    it("carries neither a recorded count nor an address (FR-022)", async () => {
+      const { session, first, second } = await twoHostSession();
+      await getRepositories().sessions.setAttendeeCount(session.id, 12);
+
+      await dispatchDueReminders(HEADS_UP_AT);
+
+      for (const host of [first, second]) {
+        const [notice] = await reminderNotices(host.id);
+        // Only the text could carry the number; the url is a fixed path shape
+        // whose session id would match a bare "12" by accident.
+        expect(notice.text).not.toContain("12");
+        for (const rendered of [notice.text, notice.url]) {
+          expect(rendered).not.toContain(FIRST);
+          expect(rendered).not.toContain(SECOND);
+        }
+      }
+    });
+  });
+
+  describe("when a send fails", () => {
+    function failFor(address: string): void {
+      vi.mocked(sendMail).mockImplementation(({ to }) =>
+        to === address
+          ? Promise.reject(new Error("smtp is down"))
+          : Promise.resolve()
+      );
+    }
+
+    it("still mails the other hosts and leaves the failed one eligible", async () => {
+      await twoHostSession();
+      failFor(SECOND);
+
+      const summary = await dispatchDueReminders(FOLLOW_UP_AT);
+
+      expect(summary.sent).toBe(1);
+      expect(summary.failed).toBe(1);
+      expect(recipients()).toEqual([FIRST, SECOND].sort());
+
+      // The next run retries only the one that failed.
+      vi.mocked(sendMail).mockReset();
+      await dispatchDueReminders(later(FOLLOW_UP_AT, 1));
+      expect(recipients()).toEqual([SECOND]);
+    });
+
+    it("retries a reminder whose first failure is under 24 hours old", async () => {
+      await twoHostSession();
+      failFor(SECOND);
+      await dispatchDueReminders(FOLLOW_UP_AT);
+
+      vi.mocked(sendMail).mockReset();
+      const summary = await dispatchDueReminders(later(FOLLOW_UP_AT, 23));
+
+      expect(summary.sent).toBe(1);
+      expect(recipients()).toEqual([SECOND]);
+    });
+
+    it("abandons and logs one whose first failure is more than 24 hours old (FR-016)", async () => {
+      const { session } = await twoHostSession();
+      failFor(SECOND);
+      await dispatchDueReminders(FOLLOW_UP_AT);
+
+      const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+      const summary = await dispatchDueReminders(later(FOLLOW_UP_AT, 25));
+
+      expect(summary.abandoned).toBe(1);
+      const message = logged.mock.calls
+        .map((call) => call.join(" "))
+        .join("\n");
+      expect(message).toContain(session.id);
+      expect(message).toContain("followUp");
+      // The recipient's address is personal data and must never reach a log.
+      expect(message).not.toContain(SECOND);
+      expect(message).not.toContain(FIRST);
+
+      // Abandoned means abandoned: a working mail server does not revive it.
+      vi.mocked(sendMail).mockReset();
+      expect((await dispatchDueReminders(later(FOLLOW_UP_AT, 26))).sent).toBe(
+        0
+      );
+    });
+  });
+});

--- a/tests/integration/reminder-dispatch.test.ts
+++ b/tests/integration/reminder-dispatch.test.ts
@@ -496,6 +496,23 @@ describe("dispatchDueReminders", () => {
       expect(recipients()).toEqual([SECOND]);
     });
 
+    // The heads-up has a retry window too — a short one, closing when the
+    // session ends (FR-013) rather than after 24 hours.
+    it("retries a failed heads-up while the session is still to come", async () => {
+      const { second } = await twoHostSession();
+      failFor(SECOND);
+      await dispatchDueReminders(HEADS_UP_AT);
+
+      vi.mocked(sendMail).mockReset();
+      const summary = await dispatchDueReminders(
+        new Date("2026-09-01T09:20:00Z")
+      );
+
+      expect(summary.sent).toBe(1);
+      expect(recipients()).toEqual([SECOND]);
+      expect(await reminderNotices(second.id)).toHaveLength(1);
+    });
+
     it("retries a reminder whose first failure is under 24 hours old", async () => {
       await twoHostSession();
       failFor(SECOND);
@@ -531,6 +548,76 @@ describe("dispatchDueReminders", () => {
       expect((await dispatchDueReminders(later(FOLLOW_UP_AT, 26))).sent).toBe(
         0
       );
+    });
+  });
+
+  // listCandidates snapshots the whole run up front and each send takes
+  // seconds, so a host or a session deleted inside that window fails the
+  // foreign key on a write the loop is already committed to.
+  describe("when a host is deleted mid-run", () => {
+    const FK = new Error("FOREIGN KEY constraint failed");
+
+    /** Fails the notification write for one host until `stop()` is called. */
+    function failNotificationFor(guestId: string) {
+      const { notifications } = getRepositories();
+      const create = notifications.create.bind(notifications);
+      let failing = true;
+      vi.spyOn(notifications, "create").mockImplementation((input) =>
+        failing && input.guestId === guestId
+          ? Promise.reject(FK)
+          : create(input)
+      );
+      return () => {
+        failing = false;
+      };
+    }
+
+    it("still reminds the hosts behind them", async () => {
+      const { first, second } = await twoHostSession();
+      failNotificationFor(first.id);
+
+      const summary = await dispatchDueReminders(FOLLOW_UP_AT);
+
+      expect(summary.notified).toBe(1);
+      expect(summary.failed).toBe(1);
+      expect(await reminderNotices(second.id)).toHaveLength(1);
+      expect(recipients()).toEqual([SECOND]);
+    });
+
+    it("leaves the reminder owed rather than settling it unsent", async () => {
+      const { first } = await twoHostSession();
+      const stop = failNotificationFor(first.id);
+      await dispatchDueReminders(FOLLOW_UP_AT);
+      expect(await reminderNotices(first.id)).toHaveLength(0);
+
+      stop();
+      vi.mocked(sendMail).mockReset();
+      const summary = await dispatchDueReminders(later(FOLLOW_UP_AT, 1));
+
+      expect(summary.notified).toBe(1);
+      expect(await reminderNotices(first.id)).toHaveLength(1);
+      expect(recipients()).toEqual([FIRST]);
+    });
+
+    it("still reminds the hosts behind them when the claim itself throws", async () => {
+      const { first, second } = await twoHostSession();
+      const { reminders } = getRepositories();
+      const claim = reminders.claim.bind(reminders);
+      vi.spyOn(reminders, "claim")
+        .mockImplementationOnce(() => Promise.reject(FK))
+        .mockImplementation(claim);
+      const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const summary = await dispatchDueReminders(FOLLOW_UP_AT);
+
+      // Which host loses their claim depends on the candidate order; that one
+      // host is the whole cost is what matters.
+      expect(summary.notified).toBe(1);
+      expect([
+        ...(await reminderNotices(first.id)),
+        ...(await reminderNotices(second.id)),
+      ]).toHaveLength(1);
+      expect(logged).toHaveBeenCalled();
     });
   });
 });

--- a/tests/integration/settings-action.test.ts
+++ b/tests/integration/settings-action.test.ts
@@ -42,11 +42,65 @@ describe("updateEmailSettingsAction", () => {
       commentThread: true,
       meetingRequest: false,
       meetingResponse: true,
+      sessionHeadsUp: false,
+      attendeeCountReminder: false,
     };
     const result = await updateEmailSettingsAction(settings);
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
     expect(updated?.info.emailSettings).toEqual(settings);
+  });
+
+  it("defaults both host reminders on and round-trips them independently", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+    const { guests } = getRepositories();
+    const reminders = async () => {
+      const settings = (await guests.findById(guest.id))?.info.emailSettings;
+      return {
+        sessionHeadsUp: settings?.sessionHeadsUp,
+        attendeeCountReminder: settings?.attendeeCountReminder,
+      };
+    };
+    expect(await reminders()).toEqual({
+      sessionHeadsUp: true,
+      attendeeCountReminder: true,
+    });
+
+    await updateEmailSettingsAction({
+      ...DEFAULT_EMAIL_SETTINGS,
+      attendeeCountReminder: false,
+    });
+    expect(await reminders()).toEqual({
+      sessionHeadsUp: true,
+      attendeeCountReminder: false,
+    });
+
+    await updateEmailSettingsAction({
+      ...DEFAULT_EMAIL_SETTINGS,
+      sessionHeadsUp: false,
+    });
+    expect(await reminders()).toEqual({
+      sessionHeadsUp: false,
+      attendeeCountReminder: true,
+    });
+  });
+
+  it("rejects a payload missing the attendee-count reminder key", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+    // The old five-key shape. A required boolean like its siblings, so a stale
+    // form is rejected rather than silently defaulted.
+    const result = await updateEmailSettingsAction({
+      rsvpChange: false,
+      hostChange: false,
+      cohostAdd: false,
+      proposalComment: false,
+      commentThread: false,
+    } as never);
+    expect(result.ok).toBe(false);
+    const unchanged = await getRepositories().guests.findById(guest.id);
+    expect(unchanged?.info.emailSettings).toEqual(DEFAULT_EMAIL_SETTINGS);
   });
 
   it("fails when no user is selected", async () => {
@@ -61,6 +115,8 @@ describe("updateEmailSettingsAction", () => {
       commentThread: false,
       meetingRequest: false,
       meetingResponse: false,
+      sessionHeadsUp: false,
+      attendeeCountReminder: false,
     });
     expect(result).toEqual({ ok: false, error: "No user is logged in" });
     const unchanged = await getRepositories().guests.findById(guest.id);

--- a/tests/integration/user-auth-enforcement.test.ts
+++ b/tests/integration/user-auth-enforcement.test.ts
@@ -284,6 +284,8 @@ describe("write enforcement for protected guests", () => {
         commentThread: false,
         meetingRequest: false,
         meetingResponse: false,
+        sessionHeadsUp: false,
+        attendeeCountReminder: false,
       });
       expect(settingsResult.ok).toBe(false);
     });

--- a/tests/unit/reminder-schedule.test.ts
+++ b/tests/unit/reminder-schedule.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import {
+  followUpDueTime,
+  followUpEligible,
+  headsUpDueTime,
+  headsUpEligible,
+} from "@/utils/reminder-schedule";
+
+const at = (time: string) => new Date(`2026-09-01T${time}:00Z`);
+
+// The reference session: stored start 10:00 with a 10-minute break, so the
+// displayed start is 10:10, the heads-up is due at 09:10 and the follow-up at
+// 11:15.
+const BREAK_MINUTES = 10;
+const startTime = at("10:00");
+const endTime = at("11:00");
+
+const headsUp = {
+  now: at("09:10"),
+  startTime,
+  endTime,
+  breakMinutes: BREAK_MINUTES,
+  storedDueTime: null,
+  alreadyNotifiedHost: false,
+};
+
+const followUp = {
+  now: at("11:15"),
+  endTime,
+  hasRecordedCount: false,
+  storedDueTime: null,
+  storedClaimedAt: null,
+};
+
+describe("due times", () => {
+  it("puts the heads-up an hour before the displayed start, break included", () => {
+    expect(headsUpDueTime(startTime, BREAK_MINUTES)).toEqual(at("09:10"));
+  });
+
+  it("puts the heads-up an hour before the stored start when there is no break", () => {
+    expect(headsUpDueTime(startTime, 0)).toEqual(at("09:00"));
+  });
+
+  it("puts the follow-up a quarter hour after the end", () => {
+    expect(followUpDueTime(endTime)).toEqual(at("11:15"));
+  });
+});
+
+describe("headsUpEligible", () => {
+  it("is not due a minute early", () => {
+    expect(headsUpEligible({ ...headsUp, now: at("09:09") })).toBe(false);
+  });
+
+  it("is due exactly an hour before the displayed start", () => {
+    expect(headsUpEligible(headsUp)).toBe(true);
+  });
+
+  it("still goes out late while the session is under way", () => {
+    expect(headsUpEligible({ ...headsUp, now: at("10:30") })).toBe(true);
+  });
+
+  it("is dropped once the session has ended", () => {
+    expect(headsUpEligible({ ...headsUp, now: at("11:00") })).toBe(false);
+    expect(headsUpEligible({ ...headsUp, now: at("11:01") })).toBe(false);
+  });
+
+  it("is not repeated for a due time the host was already notified of", () => {
+    expect(
+      headsUpEligible({
+        ...headsUp,
+        now: at("09:20"),
+        storedDueTime: at("09:10"),
+        alreadyNotifiedHost: true,
+      })
+    ).toBe(false);
+  });
+
+  it("is retried when the claim for this due time was re-armed", () => {
+    expect(
+      headsUpEligible({
+        ...headsUp,
+        now: at("09:20"),
+        storedDueTime: at("09:10"),
+        alreadyNotifiedHost: false,
+      })
+    ).toBe(true);
+  });
+
+  describe("a session moved three hours out", () => {
+    // Displayed start 13:10, so the new heads-up is due at 12:10.
+    const moved = {
+      ...headsUp,
+      startTime: at("13:00"),
+      endTime: at("14:00"),
+      storedDueTime: at("09:10"),
+      alreadyNotifiedHost: true,
+    };
+
+    it("waits for the new due time", () => {
+      expect(headsUpEligible({ ...moved, now: at("09:31") })).toBe(false);
+    });
+
+    it("sends a fresh heads-up an hour before the new start", () => {
+      expect(headsUpEligible({ ...moved, now: at("12:10") })).toBe(true);
+    });
+  });
+
+  describe("a session moved to start 45 minutes from now", () => {
+    // Displayed start 10:30, so the new heads-up came due at 09:30 and is
+    // already overdue.
+    const moved = {
+      ...headsUp,
+      now: at("09:45"),
+      startTime: at("10:20"),
+      endTime: at("11:20"),
+    };
+
+    it("sends nothing to a host who was already reminded", () => {
+      expect(
+        headsUpEligible({
+          ...moved,
+          storedDueTime: at("09:10"),
+          alreadyNotifiedHost: true,
+        })
+      ).toBe(false);
+    });
+
+    it("still sends the first heads-up to a host who was not", () => {
+      expect(headsUpEligible(moved)).toBe(true);
+    });
+
+    // The defect the rename fixes. The host was notified at 09:10 and the
+    // matching email then failed, which clears the delivery marker that gates
+    // a retry but never `notified_at`. Asked whether they already received a
+    // heads-up, the old input (fed from that cleared marker) answered "no" and
+    // let a second one through 35 minutes later.
+    it("sends nothing to a host whose heads-up mail failed before the move", () => {
+      expect(
+        headsUpEligible({
+          ...moved,
+          storedDueTime: at("09:10"),
+          alreadyNotifiedHost: true,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("the reschedule guard boundary", () => {
+    const reminded = {
+      ...headsUp,
+      now: at("09:45"),
+      storedDueTime: at("09:10"),
+      alreadyNotifiedHost: true,
+    };
+
+    it("suppresses a heads-up sent exactly 90 minutes before the new start", () => {
+      // Displayed start 10:40, 90 minutes after the 09:10 heads-up.
+      expect(
+        headsUpEligible({
+          ...reminded,
+          startTime: at("10:30"),
+          endTime: at("11:40"),
+        })
+      ).toBe(false);
+    });
+
+    it("sends again one minute past that", () => {
+      // Displayed start 10:41.
+      expect(
+        headsUpEligible({
+          ...reminded,
+          startTime: at("10:31"),
+          endTime: at("11:41"),
+        })
+      ).toBe(true);
+    });
+  });
+});
+
+describe("followUpEligible", () => {
+  it("is not due a minute early", () => {
+    expect(followUpEligible({ ...followUp, now: at("11:14") })).toBe(false);
+  });
+
+  it("is due a quarter hour after the end", () => {
+    expect(followUpEligible(followUp)).toBe(true);
+  });
+
+  it("is never dropped for being late", () => {
+    expect(
+      followUpEligible({ ...followUp, now: new Date("2026-09-08T09:00:00Z") })
+    ).toBe(true);
+  });
+
+  it("is suppressed by a count that is already recorded", () => {
+    expect(followUpEligible({ ...followUp, hasRecordedCount: true })).toBe(
+      false
+    );
+  });
+
+  // Claimed, not sent: a reminder can settle with nothing to mail, so the
+  // field that always means "this due time is spoken for" is the claim.
+  it("is not repeated for a due time already claimed", () => {
+    expect(
+      followUpEligible({
+        ...followUp,
+        now: at("11:30"),
+        storedDueTime: at("11:15"),
+        storedClaimedAt: at("11:15"),
+      })
+    ).toBe(false);
+  });
+
+  it("is retried when the claim for this due time was re-armed", () => {
+    expect(
+      followUpEligible({
+        ...followUp,
+        now: at("11:30"),
+        storedDueTime: at("11:15"),
+        storedClaimedAt: null,
+      })
+    ).toBe(true);
+  });
+
+  describe("a session whose end time moved to 12:00", () => {
+    const moved = {
+      ...followUp,
+      endTime: at("12:00"),
+      storedDueTime: at("11:15"),
+      storedClaimedAt: at("11:15"),
+    };
+
+    it("waits for the new due time", () => {
+      expect(followUpEligible({ ...moved, now: at("11:30") })).toBe(false);
+    });
+
+    it("becomes owed again against the new end", () => {
+      expect(followUpEligible({ ...moved, now: at("12:15") })).toBe(true);
+    });
+  });
+});

--- a/tests/unit/reminder-schedule.test.ts
+++ b/tests/unit/reminder-schedule.test.ts
@@ -21,6 +21,7 @@ const headsUp = {
   endTime,
   breakMinutes: BREAK_MINUTES,
   storedDueTime: null,
+  storedClaimedAt: null,
   alreadyNotifiedHost: false,
 };
 
@@ -64,24 +65,39 @@ describe("headsUpEligible", () => {
     expect(headsUpEligible({ ...headsUp, now: at("11:01") })).toBe(false);
   });
 
-  it("is not repeated for a due time the host was already notified of", () => {
+  it("is not repeated for a due time already claimed and notified", () => {
     expect(
       headsUpEligible({
         ...headsUp,
         now: at("09:20"),
         storedDueTime: at("09:10"),
+        storedClaimedAt: at("09:10"),
         alreadyNotifiedHost: true,
       })
     ).toBe(false);
   });
 
-  it("is retried when the claim for this due time was re-armed", () => {
+  it("is retried when the notification for this due time failed", () => {
     expect(
       headsUpEligible({
         ...headsUp,
         now: at("09:20"),
         storedDueTime: at("09:10"),
         alreadyNotifiedHost: false,
+      })
+    ).toBe(true);
+  });
+
+  // markFailed clears the claim and leaves notified_at set, so the host has
+  // their notification and is still owed the mail.
+  it("is retried when the mail for this due time failed", () => {
+    expect(
+      headsUpEligible({
+        ...headsUp,
+        now: at("09:20"),
+        storedDueTime: at("09:10"),
+        storedClaimedAt: null,
+        alreadyNotifiedHost: true,
       })
     ).toBe(true);
   });
@@ -133,12 +149,14 @@ describe("headsUpEligible", () => {
     // matching email then failed, which clears the delivery marker that gates
     // a retry but never `notified_at`. Asked whether they already received a
     // heads-up, the old input (fed from that cleared marker) answered "no" and
-    // let a second one through 35 minutes later.
+    // let a second one through 35 minutes later. The retry the cleared claim
+    // is owed belongs to the old due time, which the move has superseded.
     it("sends nothing to a host whose heads-up mail failed before the move", () => {
       expect(
         headsUpEligible({
           ...moved,
           storedDueTime: at("09:10"),
+          storedClaimedAt: null,
           alreadyNotifiedHost: true,
         })
       ).toBe(false);

--- a/tests/unit/reminder-scheduler.test.ts
+++ b/tests/unit/reminder-scheduler.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/utils/reminder-dispatch", () => ({
+  dispatchDueReminders: vi.fn(),
+}));
+
+import { dispatchDueReminders } from "@/utils/reminder-dispatch";
+import {
+  startReminderScheduler,
+  stopReminderScheduler,
+} from "@/utils/reminder-scheduler";
+
+const SUMMARY = { notified: 0, sent: 0, skipped: 0, failed: 0, abandoned: 0 };
+
+describe("startReminderScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("NEXT_RUNTIME", "nodejs");
+    vi.mocked(dispatchDueReminders).mockReset().mockResolvedValue(SUMMARY);
+  });
+
+  afterEach(() => {
+    stopReminderScheduler();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches once per interval", async () => {
+    vi.stubEnv("REMINDER_DISPATCH_INTERVAL_MS", "1000");
+    startReminderScheduler();
+    expect(dispatchDueReminders).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dispatchDueReminders).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(dispatchDueReminders).toHaveBeenCalledTimes(3);
+  });
+
+  it("starts only one timer however often it is called", async () => {
+    vi.stubEnv("REMINDER_DISPATCH_INTERVAL_MS", "1000");
+    startReminderScheduler();
+    startReminderScheduler();
+    startReminderScheduler();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dispatchDueReminders).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts nothing when the interval is 0", async () => {
+    vi.stubEnv("REMINDER_DISPATCH_INTERVAL_MS", "0");
+    startReminderScheduler();
+
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(dispatchDueReminders).not.toHaveBeenCalled();
+  });
+
+  it("starts nothing outside the nodejs runtime", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "edge");
+    vi.stubEnv("REMINDER_DISPATCH_INTERVAL_MS", "1000");
+    startReminderScheduler();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(dispatchDueReminders).not.toHaveBeenCalled();
+  });
+
+  it("skips a tick while the previous run is still in flight", async () => {
+    vi.stubEnv("REMINDER_DISPATCH_INTERVAL_MS", "1000");
+    let finish = () => {};
+    vi.mocked(dispatchDueReminders).mockReturnValue(
+      new Promise((resolve) => {
+        finish = () => resolve(SUMMARY);
+      })
+    );
+    startReminderScheduler();
+
+    // Three ticks pass, but a slow SMTP server must not stack three runs.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(dispatchDueReminders).toHaveBeenCalledTimes(1);
+
+    finish();
+    vi.mocked(dispatchDueReminders).mockResolvedValue(SUMMARY);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dispatchDueReminders).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs a failing run and keeps ticking", async () => {
+    vi.stubEnv("REMINDER_DISPATCH_INTERVAL_MS", "1000");
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(dispatchDueReminders).mockRejectedValueOnce(
+      new Error("database is locked")
+    );
+    startReminderScheduler();
+
+    // A throwing tick must never take the web server down with it.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(logged).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dispatchDueReminders).toHaveBeenCalledTimes(2);
+  });
+});

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -666,8 +666,10 @@ function proposalCommentPath(
 }
 
 // Deep link to the session, same shape as modal-nav's
-// viewSessionLinkFromElsewhere.
-function sessionPath(eventSlug: string, sessionId: string) {
+// viewSessionLinkFromElsewhere (anchor MnpjIo7Y). Exported because reminder
+// dispatch builds the same link for its notification and its email: one
+// definition, not three copies.
+export function sessionPath(eventSlug: string, sessionId: string) {
   return `/${eventSlug}?viewSession=${sessionId}`;
 }
 

--- a/utils/reminder-dispatch.ts
+++ b/utils/reminder-dispatch.ts
@@ -1,0 +1,184 @@
+import { DateTime } from "luxon";
+import { getRepositories } from "@/db/container";
+import type { DueReminderCandidate } from "@/db/repositories/interfaces";
+import { isMailerConfigured, sendMail } from "@/utils/mailer";
+import { sessionPath } from "@/utils/notifications";
+import { siteUrl } from "@/utils/site-url";
+import { attendeeCountHeadsUpEmail } from "@/emails/attendee-count-headsup";
+import { attendeeCountFollowUpEmail } from "@/emails/attendee-count-followup";
+import {
+  ABANDON_AFTER_HOURS,
+  followUpEligible,
+  headsUpEligible,
+  reminderNoticeText,
+} from "@/utils/reminder-schedule";
+
+export type DispatchSummary = {
+  /** In-app notifications created. */
+  notified: number;
+  /**
+   * Reminders *settled* — a confirmed send, or nothing to mail. Not "emails
+   * sent": what the caller needs is how many this run finished with, whatever
+   * the mail configuration.
+   */
+  sent: number;
+  /** Candidates that never got a claim: ineligible, or the claim was lost. */
+  skipped: number;
+  failed: number;
+  abandoned: number;
+};
+
+const ABANDON_AFTER_MS = ABANDON_AFTER_HOURS * 60 * 60 * 1000;
+
+// One dispatch run. Takes `now` as an argument rather than reading the clock,
+// so tests drive it without a timer.
+//
+// A reminder is delivered on two channels: the in-app notification always,
+// the email only where there is one to send. An instance with no mail
+// configured still reminds its hosts (FR-021).
+export async function dispatchDueReminders(
+  now: Date
+): Promise<DispatchSummary> {
+  const summary: DispatchSummary = {
+    notified: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+    abandoned: 0,
+  };
+
+  const { notifications, reminders } = getRepositories();
+  const base = siteUrl();
+  for (const candidate of await reminders.listCandidates(now)) {
+    if (!eligible(candidate, now)) {
+      summary.skipped += 1;
+      continue;
+    }
+    const key = {
+      sessionId: candidate.sessionId,
+      guestId: candidate.guestId,
+      kind: candidate.kind,
+    };
+    const { claimed, notifyOwed } = await reminders.claim(
+      key,
+      candidate.dueTime,
+      now
+    );
+    if (!claimed) {
+      summary.skipped += 1;
+      continue;
+    }
+
+    if (notifyOwed) {
+      await notifications.create({
+        guestId: candidate.guestId,
+        type:
+          candidate.kind === "headsUp"
+            ? "sessionHeadsUp"
+            : "attendeeCountReminder",
+        text: reminderNoticeText(candidate.kind, candidate.sessionTitle),
+        url: recordPath(candidate),
+        createdAt: now,
+      });
+      await reminders.markNotified(key, now);
+      summary.notified += 1;
+    }
+
+    // Nothing to mail is not a failure and has nothing to retry: the claim
+    // already settled the reminder, so this only drops a stale failure
+    // history. Never markSent — no email went out.
+    const email = candidate.guestEmail;
+    if (
+      email === null ||
+      !candidate.reminderOptIn ||
+      !isMailerConfigured() ||
+      base === null
+    ) {
+      await reminders.markSkipped(key);
+      summary.sent += 1;
+      continue;
+    }
+
+    try {
+      await sendMail({ to: email, ...message(candidate, base) });
+      await reminders.markSent(key, now);
+      summary.sent += 1;
+    } catch (err) {
+      // One host's mail server refusing must not cost the others theirs.
+      const { abandoned } = await reminders.markFailed(
+        key,
+        now,
+        ABANDON_AFTER_MS
+      );
+      if (abandoned) {
+        summary.abandoned += 1;
+        // Names the session and the kind only: a recipient's address is
+        // personal data and never belongs in a log (FR-016).
+        console.error(
+          `Abandoning ${candidate.kind} reminder for session ${candidate.sessionId} after ${ABANDON_AFTER_HOURS}h of failures:`,
+          err
+        );
+      } else {
+        summary.failed += 1;
+      }
+    }
+  }
+  return summary;
+}
+
+function eligible(candidate: DueReminderCandidate, now: Date): boolean {
+  return candidate.kind === "headsUp"
+    ? headsUpEligible({
+        now,
+        startTime: candidate.sessionStartTime,
+        endTime: candidate.sessionEndTime,
+        breakMinutes: candidate.eventBreakMinutes,
+        storedDueTime: candidate.storedDueTime,
+        alreadyNotifiedHost: candidate.storedNotifiedAt !== null,
+      })
+    : followUpEligible({
+        now,
+        endTime: candidate.sessionEndTime,
+        hasRecordedCount: candidate.hasRecordedCount,
+        storedDueTime: candidate.storedDueTime,
+        storedClaimedAt: candidate.storedClaimedAt,
+      });
+}
+
+// Where the reminder points. The follow-up adds the auto-focus parameter only
+// it uses; see research.md §8.
+function recordPath(candidate: DueReminderCandidate): string {
+  const path = sessionPath(candidate.eventSlug, candidate.sessionId);
+  return candidate.kind === "headsUp" ? path : `${path}&record=count`;
+}
+
+function message(candidate: DueReminderCandidate, base: string) {
+  const url = base + recordPath(candidate);
+  if (candidate.kind === "headsUp") {
+    return attendeeCountHeadsUpEmail({
+      title: candidate.sessionTitle,
+      time: formatInEventZone(
+        new Date(
+          candidate.sessionStartTime.getTime() +
+            candidate.eventBreakMinutes * 60 * 1000
+        ),
+        candidate.eventTimezone
+      ),
+      location: candidate.sessionLocationNames.join(", ") || "No location",
+      sessionUrl: url,
+    });
+  }
+  return attendeeCountFollowUpEmail({
+    title: candidate.sessionTitle,
+    time: formatInEventZone(candidate.sessionEndTime, candidate.eventTimezone),
+    recordUrl: url,
+  });
+}
+
+// The shipped container runs in UTC, so a time formatted in the ambient zone
+// is invisible in development and wrong in production (Constitution IV).
+function formatInEventZone(instant: Date, timezone: string): string {
+  return DateTime.fromJSDate(instant)
+    .setZone(timezone)
+    .toFormat("cccc d LLLL, HH:mm");
+}

--- a/utils/reminder-dispatch.ts
+++ b/utils/reminder-dispatch.ts
@@ -1,6 +1,9 @@
 import { DateTime } from "luxon";
 import { getRepositories } from "@/db/container";
-import type { DueReminderCandidate } from "@/db/repositories/interfaces";
+import type {
+  DueReminderCandidate,
+  ReminderKey,
+} from "@/db/repositories/interfaces";
 import { isMailerConfigured, sendMail } from "@/utils/mailer";
 import { sessionPath } from "@/utils/notifications";
 import { siteUrl } from "@/utils/site-url";
@@ -49,6 +52,33 @@ export async function dispatchDueReminders(
 
   const { notifications, reminders } = getRepositories();
   const base = siteUrl();
+
+  // Re-arms the reminder for the next tick, or gives up on it once the first
+  // failure is 24 hours old. Both delivery channels share it: one host's
+  // failure must not cost the others theirs, whichever channel it was on.
+  async function recordFailure(
+    key: ReminderKey,
+    candidate: DueReminderCandidate,
+    err: unknown
+  ): Promise<void> {
+    const { abandoned } = await reminders.markFailed(
+      key,
+      now,
+      ABANDON_AFTER_MS
+    );
+    if (!abandoned) {
+      summary.failed += 1;
+      return;
+    }
+    summary.abandoned += 1;
+    // Names the session and the kind only: a recipient's address is personal
+    // data and never belongs in a log (FR-016).
+    console.error(
+      `Abandoning ${candidate.kind} reminder for session ${candidate.sessionId} after ${ABANDON_AFTER_HOURS}h of failures:`,
+      err
+    );
+  }
+
   for (const candidate of await reminders.listCandidates(now)) {
     if (!eligible(candidate, now)) {
       summary.skipped += 1;
@@ -59,29 +89,51 @@ export async function dispatchDueReminders(
       guestId: candidate.guestId,
       kind: candidate.kind,
     };
-    const { claimed, notifyOwed } = await reminders.claim(
-      key,
-      candidate.dueTime,
-      now
-    );
+
+    // listCandidates snapshots the run up front and each send takes seconds,
+    // so a session or host deleted inside that window fails a foreign key
+    // here. The claim wrote nothing, so there is nothing to re-arm.
+    let claimed: boolean;
+    let notifyOwed: boolean;
+    try {
+      ({ claimed, notifyOwed } = await reminders.claim(
+        key,
+        candidate.dueTime,
+        now
+      ));
+    } catch (err) {
+      console.error(
+        `Could not claim the ${candidate.kind} reminder for session ${candidate.sessionId}:`,
+        err
+      );
+      summary.skipped += 1;
+      continue;
+    }
     if (!claimed) {
       summary.skipped += 1;
       continue;
     }
 
     if (notifyOwed) {
-      await notifications.create({
-        guestId: candidate.guestId,
-        type:
-          candidate.kind === "headsUp"
-            ? "sessionHeadsUp"
-            : "attendeeCountReminder",
-        text: reminderNoticeText(candidate.kind, candidate.sessionTitle),
-        url: recordPath(candidate),
-        createdAt: now,
-      });
-      await reminders.markNotified(key, now);
-      summary.notified += 1;
+      try {
+        await notifications.create({
+          guestId: candidate.guestId,
+          type:
+            candidate.kind === "headsUp"
+              ? "sessionHeadsUp"
+              : "attendeeCountReminder",
+          text: reminderNoticeText(candidate.kind, candidate.sessionTitle),
+          url: recordPath(candidate),
+          createdAt: now,
+        });
+        await reminders.markNotified(key, now);
+        summary.notified += 1;
+      } catch (err) {
+        // Unnotified but claimed would settle the reminder having delivered
+        // nothing, on either channel, for good.
+        await recordFailure(key, candidate, err);
+        continue;
+      }
     }
 
     // Nothing to mail is not a failure and has nothing to retry: the claim
@@ -104,23 +156,7 @@ export async function dispatchDueReminders(
       await reminders.markSent(key, now);
       summary.sent += 1;
     } catch (err) {
-      // One host's mail server refusing must not cost the others theirs.
-      const { abandoned } = await reminders.markFailed(
-        key,
-        now,
-        ABANDON_AFTER_MS
-      );
-      if (abandoned) {
-        summary.abandoned += 1;
-        // Names the session and the kind only: a recipient's address is
-        // personal data and never belongs in a log (FR-016).
-        console.error(
-          `Abandoning ${candidate.kind} reminder for session ${candidate.sessionId} after ${ABANDON_AFTER_HOURS}h of failures:`,
-          err
-        );
-      } else {
-        summary.failed += 1;
-      }
+      await recordFailure(key, candidate, err);
     }
   }
   return summary;
@@ -134,6 +170,7 @@ function eligible(candidate: DueReminderCandidate, now: Date): boolean {
         endTime: candidate.sessionEndTime,
         breakMinutes: candidate.eventBreakMinutes,
         storedDueTime: candidate.storedDueTime,
+        storedClaimedAt: candidate.storedClaimedAt,
         alreadyNotifiedHost: candidate.storedNotifiedAt !== null,
       })
     : followUpEligible({

--- a/utils/reminder-schedule.ts
+++ b/utils/reminder-schedule.ts
@@ -1,0 +1,109 @@
+import type { ReminderKind } from "@/db/repositories/interfaces";
+
+// Pure due-time arithmetic and eligibility for the two attendee-count
+// reminders. No I/O and no next/headers: the whole reschedule matrix from the
+// spec is decided here, in the unit tier, so dispatch needs only a handful of
+// seeded database tests.
+
+export const HEADS_UP_LEAD_MINUTES = 60;
+export const FOLLOW_UP_DELAY_MINUTES = 15;
+export const RESCHEDULE_GUARD_MINUTES = 90;
+export const ABANDON_AFTER_HOURS = 24;
+
+const MINUTE_MS = 60 * 1000;
+
+// An hour before the *displayed* start (stored start plus the event's break),
+// which is the time the email itself prints. Deriving it from the stored start
+// would send the heads-up an hour and one break before that.
+export function headsUpDueTime(startTime: Date, breakMinutes: number): Date {
+  return new Date(
+    startTime.getTime() + (breakMinutes - HEADS_UP_LEAD_MINUTES) * MINUTE_MS
+  );
+}
+
+export function followUpDueTime(endTime: Date): Date {
+  return new Date(endTime.getTime() + FOLLOW_UP_DELAY_MINUTES * MINUTE_MS);
+}
+
+export function headsUpEligible({
+  now,
+  startTime,
+  endTime,
+  breakMinutes,
+  storedDueTime,
+  alreadyNotifiedHost,
+}: {
+  now: Date;
+  startTime: Date;
+  endTime: Date;
+  breakMinutes: number;
+  storedDueTime: Date | null;
+  // Fed from the notification, not from any mail marker: a failed send clears
+  // what gates a retry, and asking "did they already get one" of that field
+  // let a reschedule slip a second heads-up through (research.md §14).
+  alreadyNotifiedHost: boolean;
+}): boolean {
+  const due = headsUpDueTime(startTime, breakMinutes);
+  if (now < due) return false;
+  // Once the session is over the heads-up can serve neither of its purposes,
+  // so a late dispatch drops it (FR-013).
+  if (now >= endTime) return false;
+
+  if (!alreadyNotifiedHost) return true;
+  if (sameInstant(storedDueTime, due)) return false;
+
+  // The reschedule guard (FR-014). Expressed as "the heads-up this host
+  // already received went out 90 minutes or less before the new displayed
+  // start" — it is still a useful warning for the new slot, so a second one
+  // moments later is noise.
+  //
+  // Deliberately not the `now >= displayedStart - 90 min` form sketched in
+  // research.md §5: a heads-up is only ever due from displayedStart - 60 min
+  // onwards, so that condition holds every time it is evaluated and would
+  // suppress *every* re-send, including the three-hours-out move the spec
+  // requires to re-arm (User Story 2, scenario 10).
+  const displayedStart = new Date(
+    startTime.getTime() + breakMinutes * MINUTE_MS
+  );
+  const sentAgo = displayedStart.getTime() - (storedDueTime?.getTime() ?? 0);
+  return sentAgo > RESCHEDULE_GUARD_MINUTES * MINUTE_MS;
+}
+
+export function followUpEligible({
+  now,
+  endTime,
+  hasRecordedCount,
+  storedDueTime,
+  storedClaimedAt,
+}: {
+  now: Date;
+  endTime: Date;
+  hasRecordedCount: boolean;
+  storedDueTime: Date | null;
+  // The claim, not the send: a reminder can settle with nothing to mail, so
+  // the claim is the only field that always means "this due time is handled".
+  storedClaimedAt: Date | null;
+}): boolean {
+  if (hasRecordedCount) return false;
+  if (now < followUpDueTime(endTime)) return false;
+  // A stored due time that no longer matches means the end moved, which
+  // re-arms the follow-up; an equal one with the claim cleared means the last
+  // send failed and is owed a retry. Never dropped for lateness.
+  return !(
+    sameInstant(storedDueTime, followUpDueTime(endTime)) &&
+    storedClaimedAt !== null
+  );
+}
+
+// One line for the notification list, mirroring the matching email's subject.
+// Names the session and the ask and nothing else: a notification renders on a
+// (site) page, where guest switching is unauthenticated (FR-022).
+export function reminderNoticeText(kind: ReminderKind, title: string): string {
+  return kind === "headsUp"
+    ? `You're hosting "${title}" shortly — count the people who come`
+    : `How many people came to "${title}"?`;
+}
+
+function sameInstant(a: Date | null, b: Date): boolean {
+  return a !== null && a.getTime() === b.getTime();
+}

--- a/utils/reminder-schedule.ts
+++ b/utils/reminder-schedule.ts
@@ -31,6 +31,7 @@ export function headsUpEligible({
   endTime,
   breakMinutes,
   storedDueTime,
+  storedClaimedAt,
   alreadyNotifiedHost,
 }: {
   now: Date;
@@ -38,6 +39,7 @@ export function headsUpEligible({
   endTime: Date;
   breakMinutes: number;
   storedDueTime: Date | null;
+  storedClaimedAt: Date | null;
   // Fed from the notification, not from any mail marker: a failed send clears
   // what gates a retry, and asking "did they already get one" of that field
   // let a reschedule slip a second heads-up through (research.md §14).
@@ -50,7 +52,9 @@ export function headsUpEligible({
   if (now >= endTime) return false;
 
   if (!alreadyNotifiedHost) return true;
-  if (sameInstant(storedDueTime, due)) return false;
+  // Same due time, notified, claim cleared: markFailed re-armed a send that
+  // failed, and the retry window runs to the end of the session above.
+  if (sameInstant(storedDueTime, due)) return storedClaimedAt === null;
 
   // The reschedule guard (FR-014). Expressed as "the heads-up this host
   // already received went out 90 minutes or less before the new displayed

--- a/utils/reminder-scheduler.ts
+++ b/utils/reminder-scheduler.ts
@@ -1,0 +1,61 @@
+// The recurring dispatch tick. Started from instrumentation.ts, which is the
+// only hook that runs once per server process regardless of traffic — see
+// docs/dev/adr/0006.
+//
+// The dispatcher is imported inside the tick, not at the top of this module:
+// Next compiles instrumentation.ts for the Edge runtime as well, and a static
+// import would pull db/container — and with it better-sqlite3, `path` and
+// `process.cwd()` — into a bundle that supports none of them. The
+// NEXT_RUNTIME guard below is a runtime check; it does not keep the module
+// graph out of the edge build.
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+// Singletons need to be assigned to globalThis, not simply module-level
+// variables. See https://github.com/vercel/next.js/discussions/68572.
+const g = globalThis as typeof globalThis & {
+  __reminderScheduler?: ReturnType<typeof setInterval>;
+};
+
+export function startReminderScheduler(): void {
+  // Same guard as the mailer: the Edge runtime has neither a database nor SMTP.
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  if (g.__reminderScheduler) return;
+
+  const configured = process.env.REMINDER_DISPATCH_INTERVAL_MS;
+  const period =
+    configured === undefined || configured === ""
+      ? DEFAULT_INTERVAL_MS
+      : Number(configured);
+  // 0 disables the scheduler outright, which is how a self-hoster turns the
+  // reminders off and how both E2E tiers keep stray sends out of the mailbox.
+  if (!Number.isFinite(period) || period <= 0) return;
+
+  let running = false;
+  const timer = setInterval(() => {
+    // Correctness does not rest on this — claim() is the real guarantee — but
+    // a slow mail server must not stack runs.
+    if (running) return;
+    running = true;
+    void import("@/utils/reminder-dispatch")
+      .then(({ dispatchDueReminders }) =>
+        // eslint-disable-next-line no-restricted-syntax -- the tick runs outside any request, so there is no time-override cookie to read; dispatching against a fake clock is what the dev toolbar's button is for
+        dispatchDueReminders(new Date())
+      )
+      .catch((err: unknown) => {
+        console.error("Reminder dispatch failed:", err);
+      })
+      .finally(() => {
+        running = false;
+      });
+  }, period);
+  // Never hold the process open for a tick.
+  timer.unref();
+  g.__reminderScheduler = timer;
+}
+
+/** For tests only. */
+export function stopReminderScheduler(): void {
+  if (g.__reminderScheduler) clearInterval(g.__reminderScheduler);
+  delete g.__reminderScheduler;
+}

--- a/utils/reminder-scheduler.ts
+++ b/utils/reminder-scheduler.ts
@@ -1,6 +1,6 @@
 // The recurring dispatch tick. Started from instrumentation.ts, which is the
 // only hook that runs once per server process regardless of traffic — see
-// docs/dev/adr/0006.
+// docs/dev/adr/0007.
 //
 // The dispatcher is imported inside the tick, not at the top of this module:
 // Next compiles instrumentation.ts for the Edge runtime as well, and a static


### PR DESCRIPTION
RSVPs are a promise, not a record of what happened; there was nowhere to
put the real number. A finished session now offers its hosts a
self-saving field for it, and two reminders — an hour before it starts
and a quarter of an hour after it ends — nudge them to fill it in.

Each reminder gets its own email switch, not one for the pair: "your
session starts in an hour" is worth having on its own even to a host who
never counts the room, and a host who finds that one redundant should
not have to give up the link that records the count.

The count is deliberately absent from the Session type: that type is
serialised to every visitor by the [eventSlug] layout, so a field there
would publish host-only data no matter what the UI rendered. Host-scoped
repository methods and a server action that re-checks host membership
and the end time are the whole read path. See ADR 0006.

The migration ends with a hand-written backfill. A follow-up is never
dropped for being late, so without it the first dispatch tick after an
upgrade would notify and mail every host of every uncounted session in
the event history.

closes schellingboard/schellingboard#852