### PR TITLE
chore: CI trigger probe (ignore, will be closed)

### DIFF
--- a/ci-probe.md
+++ b/ci-probe.md
@@ -1,0 +1,4 @@
+# CI trigger probe
+
+Temporary file for a throwaway pull request that checks whether GitHub creates
+workflow runs for this repository. Delete with the branch.


### PR DESCRIPTION
**Throwaway — do not review, do not merge.** I will close this and delete the branch as soon as it has answered its question.

No workflow run has been created for #1001 or #1002 since their base branches moved: not for force-pushes, not for a close-and-reopen, not for a fresh SHA. Merge refs exist and the branches pass everything locally, so this draft PR against `main` checks whether `pull_request` creates runs in this repository at all right now.

<sub>Opened by Claude Code on Patrick's behalf.</sub>
