### PR TITLE
fix: open schedule tooltips only after the pointer rests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   could never be opened. Creating one now fails with the same message other reserved names give
 - **Session save confirmations clear themselves** (#859): the message confirming a session
   was added, updated or deleted now goes after ten seconds instead of waiting to be closed
+- **Schedule details wait until you stop moving**: the pop-up on a session, 1-on-1 or room name
+  now appears once the mouse rests on it, instead of at every block the cursor crosses on its way
 
 ### Fixed
 

--- a/app/(site)/[eventSlug]/tooltip.tsx
+++ b/app/(site)/[eventSlug]/tooltip.tsx
@@ -21,6 +21,11 @@ import { ReactNode, useRef, useState } from "react";
 
 // See https://floating-ui.com/docs/react-dom
 
+// The schedule grid is wall-to-wall triggers, so opening on mouseenter fires a
+// panel at every block the cursor crosses. Open only once the pointer has come
+// to rest on one.
+const REST_MS = 500;
+
 export function Tooltip(props: {
   content?: ReactNode;
   children: ReactNode;
@@ -79,6 +84,7 @@ export function Tooltip(props: {
       // touch also fires a synthetic hover, and a panel opened by that hover
       // is not one useClick will close, so the next tap does nothing.
       mouseOnly: noTap || toggleable,
+      restMs: REST_MS,
       handleClose: hasSafePolygon ? safePolygon({ buffer: -0.5 }) : null,
     }),
     useFocus(context, { enabled: !!toggleable }),

--- a/tests/e2e/schedule-layout.spec.ts
+++ b/tests/e2e/schedule-layout.spec.ts
@@ -219,14 +219,15 @@ test.describe("on a wide screen", () => {
     const details = roomDetails(page);
     const roomName = page.getByRole("button", { name: "Main Hall" }).first();
     // Hovering once is not enough: under load the mouse can arrive before the
-    // grid has hydrated, and a mouseenter nobody is listening for yet is
+    // grid has hydrated, and a pointer event nobody is listening for yet is
     // simply lost — the cursor then rests on the name with no panel to show
     // for it. Leave and come back until one lands. Re-hovering is safe; unlike
-    // the tap above it doesn't toggle.
+    // the tap above it doesn't toggle. The timeout clears the panel's own rest
+    // delay with room to spare.
     await expect(async () => {
       await page.mouse.move(0, 400);
       await roomName.hover();
-      await expect(details).toContainText(MAIN_HALL_DETAIL, { timeout: 1000 });
+      await expect(details).toContainText(MAIN_HALL_DETAIL, { timeout: 3000 });
     }).toPass();
 
     await page.mouse.move(0, 400);


### PR DESCRIPTION
The grid is wall-to-wall tooltip triggers, so opening on mouseenter fired a
panel at every block the cursor crossed on its way somewhere else.

<!-- jip:pushed-commit=c13aebb6bfd130b248e35b289674a150ced1367c -->