### PR TITLE
fix: picking a meeting spot pushed the 1-on-1 form down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Picking a meeting spot no longer shifts the 1-on-1 form**: the spot's description
+  appeared only once it was picked, pushing the rest of the form down under your finger
 - **Event names a site page would hide are rejected**: an event named "Guests", "Settings"
   or "Notifications" got a web address the site's own page of that name answers, so the
   event could never be opened

--- a/app/components/meeting-request-fields.tsx
+++ b/app/components/meeting-request-fields.tsx
@@ -32,7 +32,7 @@ export function MeetingRequestFields({
   onCancel: () => void;
   cancelLabel?: string;
 }) {
-  const selectedPoint = meetingPoints.find((p) => p.name === meetingPoint);
+  const describedPoints = meetingPoints.filter((p) => p.description);
 
   return (
     <>
@@ -58,13 +58,22 @@ export function MeetingRequestFields({
             ))}
           </ul>
         )}
-        {/* Below the chips rather than a title= on them: a tooltip is the one
-            place a touch user never reaches, and the description is how the
-            organizer says where the place actually is. */}
-        {selectedPoint?.description && (
-          <p className="mb-1 text-xs text-fg-muted">
-            {selectedPoint.description}
-          </p>
+        {/* Not a title= on the chips: a tooltip is the one place a touch user
+            never reaches. All descriptions share one grid cell, so the box is
+            already as tall as the longest and a chip can't push the form down. */}
+        {describedPoints.length > 0 && (
+          <div className="mb-1 grid">
+            {describedPoints.map((point) => (
+              <p
+                key={point.id}
+                className={`col-start-1 row-start-1 text-xs text-fg-muted ${
+                  point.name === meetingPoint ? "" : "invisible"
+                }`}
+              >
+                {point.description}
+              </p>
+            ))}
+          </div>
         )}
         <Input
           value={meetingPoint}

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -20,6 +20,8 @@ const isoDay = (offsetDays: number) => {
 const EVENT_START = isoDay(30);
 const EVENT_END = isoDay(32);
 
+const POINT_DESCRIPTION = "By the main staircase, open all day.";
+
 /** How the picker heads that day's slots: luxon's "EEE d LLL". */
 const DAY_HEADING = new RegExp(
   new Date(`${EVENT_START}T09:00:00Z`).toLocaleDateString("en-GB", {
@@ -95,6 +97,7 @@ async function meetingsEvent(page: Page, eventName: string, names: string[]) {
   await meetings.getByLabel("Enable meetings").check();
   await meetings.getByRole("button", { name: /add meeting point/i }).click();
   await meetings.getByLabel("Name *").fill("Coffee bar");
+  await meetings.getByLabel("Description").fill(POINT_DESCRIPTION);
   await meetings.getByRole("button", { name: /add meeting point/i }).click();
   await meetings.getByRole("button", { name: "Save meetings" }).click();
   await expect(meetings.getByText("Saved!")).toBeVisible();
@@ -262,8 +265,16 @@ test.describe("1-on-1 meetings", () => {
     await expect(
       picker.getByRole("heading", { name: new RegExp(`1-on-1 with ${askee}`) })
     ).toBeVisible();
+    // A meeting point's description is already allowed for, so picking one
+    // fills the space instead of pushing the rest of the form down under the
+    // pointer that is on its way to Send.
+    const send = picker.getByRole("button", { name: "Send request" });
+    const sendBefore = await send.boundingBox();
     await picker.getByRole("button", { name: "Coffee bar" }).click();
-    await picker.getByRole("button", { name: "Send request" }).click();
+    await expect(picker.getByText(POINT_DESCRIPTION)).toBeVisible();
+    expect((await send.boundingBox())?.y).toBe(sendBefore?.y);
+
+    await send.click();
     await expect(picker.getByText(new RegExp(`Asked ${askee}`))).toBeVisible();
     await picker.getByRole("button", { name: "Done" }).click();
 


### PR DESCRIPTION
The spot's description was only rendered once its chip was picked, so the
input, the message field and Send all slid down as you reached for them.
Reserving the tallest description's space up front keeps the form still.

<!-- jip:pushed-commit=4537aa14867d0cd284e845f9b5fa39fdfecaa6fb -->