### PR TITLE
fix: dialogs closed with a full-width button that read as the primary action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   was added, updated or deleted now goes after ten seconds instead of waiting to be closed
 - **Schedule details wait until you stop moving**: the pop-up on a session, 1-on-1 or room name
   now appears once the mouse rests on it, instead of at every block the cursor crosses on its way
+- **Every pop-up closes the same way**: a small × in the top right corner. Some used to end
+  instead in a full-width button that looked like the thing to press next
 
 ### Fixed
 

--- a/app/(site)/[eventSlug]/book-meeting.tsx
+++ b/app/(site)/[eventSlug]/book-meeting.tsx
@@ -61,8 +61,6 @@ export function BookMeeting({
       .then(setFound)
       .catch(() => {
         // Closing the modal aborts the request; there is nobody left to tell.
-        // Anything else has to end the spinner, or the modal never leaves it —
-        // and with no close button of its own, that traps the reader.
         if (!controller.signal.aborted) setFound("failed");
       });
     return () => controller.abort();
@@ -75,21 +73,15 @@ export function BookMeeting({
       zIndex="z-[60]"
       portal
       maxWidth="sm:max-w-2xl"
-      hideClose
     >
       {found === null ? (
         <p className="text-fg-muted">Loading…</p>
       ) : found === "gone" || found === "failed" ? (
-        <div className="flex flex-col gap-4">
-          <p className="text-fg">
-            {found === "gone"
-              ? "That slot is no longer open for 1-on-1s."
-              : "Couldn't load who is free then. Try the slot again."}
-          </p>
-          <button type="button" onClick={onClose} className={PRIMARY_BUTTON}>
-            Close
-          </button>
-        </div>
+        <p className="pr-8 text-fg">
+          {found === "gone"
+            ? "That slot is no longer open for 1-on-1s."
+            : "Couldn't load who is free then. Try the slot again."}
+        </p>
       ) : chosen ? (
         <RequestStep
           eventId={eventId}
@@ -101,7 +93,7 @@ export function BookMeeting({
           onClose={onClose}
         />
       ) : (
-        <CandidateStep found={found} onPick={setChosen} onClose={onClose} />
+        <CandidateStep found={found} onPick={setChosen} />
       )}
     </Modal>
   );
@@ -110,15 +102,13 @@ export function BookMeeting({
 function CandidateStep({
   found,
   onPick,
-  onClose,
 }: {
   found: MeetingCandidates;
   onPick: (candidate: MeetingCandidate) => void;
-  onClose: () => void;
 }) {
   return (
     <div className="flex flex-col gap-4">
-      <div>
+      <div className="pr-8">
         <h2 className="text-xl font-bold text-fg">
           Who&apos;s free at {found.slotLabel.split(" – ")[0]}?
         </h2>
@@ -206,14 +196,6 @@ function CandidateStep({
         Only people who marked this slot free are listed. Nobody is told you
         looked.
       </p>
-
-      <button
-        type="button"
-        onClick={onClose}
-        className={`${SECONDARY_BUTTON} self-start`}
-      >
-        Close
-      </button>
     </div>
   );
 }
@@ -268,20 +250,22 @@ function RequestStep({
   if (sent) {
     return (
       <div className="flex flex-col gap-4">
-        <p className="text-fg">
+        <p className="pr-8 text-fg">
           Asked {candidate.name} for {found.slotLabel} on {found.dayLabel}.
           You&apos;ll hear when they answer.
         </p>
-        <button type="button" onClick={onClose} className={PRIMARY_BUTTON}>
-          Done
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={onClose} className={PRIMARY_BUTTON}>
+            Done
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
     <form onSubmit={handleSend} className="flex flex-col gap-4">
-      <h2 className="text-xl font-bold text-fg">
+      <h2 className="pr-8 text-xl font-bold text-fg">
         1-on-1 with {candidate.name}
         <span className="block text-sm font-normal text-fg-muted">
           {found.dayLabel}, {found.slotLabel}

--- a/app/(site)/[eventSlug]/comment-likes.tsx
+++ b/app/(site)/[eventSlug]/comment-likes.tsx
@@ -121,7 +121,7 @@ export function CommentLikes({
 
       {showingLikers && (
         <Modal open setOpen={setShowingLikers} zIndex="z-[60]" portal>
-          <Dialog.Title className="text-base font-semibold text-fg">
+          <Dialog.Title className="pr-8 text-base font-semibold text-fg">
             Liked by
           </Dialog.Title>
           <ul className="mt-3 max-h-72 overflow-y-auto text-sm">

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -14,6 +14,7 @@ import {
   SECONDARY_BUTTON,
 } from "@/app/components/buttons";
 import { Input } from "@/app/input";
+import { ModalCloseButton } from "@/app/components/modal-close-button";
 import { EventContext } from "@/app/(site)/context";
 import { clashLines } from "@/utils/meeting-clash-text";
 import { canCancel, statusLine } from "@/utils/meeting-rules";
@@ -97,26 +98,10 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
     >
       <div className="fixed inset-0 bg-overlay" onClick={dismissViewMeeting} />
       <div className="relative bg-surface-raised rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto p-6">
-        <button
+        <ModalCloseButton
           onClick={dismissViewMeeting}
-          className="absolute top-4 right-4 text-fg-subtle hover:text-fg-muted"
-          aria-label="Close"
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+          className="absolute right-3 top-3 z-10"
+        />
 
         {meetings === null ? (
           <p className="text-fg-muted">Loading…</p>

--- a/app/(site)/[eventSlug]/proposals/proposal-modal.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-modal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
+import { ModalCloseButton } from "@/app/components/modal-close-button";
 import type {
   Comment,
   Event,
@@ -56,26 +57,10 @@ export function ProposalModal({
     >
       <div className="fixed inset-0 bg-overlay" onClick={onDismiss} />
       <div className="relative bg-surface-raised rounded-lg shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto">
-        <button
+        <ModalCloseButton
           onClick={onDismiss}
-          className="absolute top-4 right-4 text-fg-subtle hover:text-fg-muted"
-          aria-label="Close"
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+          className="absolute right-3 top-3 z-10"
+        />
         {!proposal ? (
           <div className="p-6">Proposal not found.</div>
         ) : (

--- a/app/(site)/[eventSlug]/schedule-toolbar.tsx
+++ b/app/(site)/[eventSlug]/schedule-toolbar.tsx
@@ -82,7 +82,7 @@ function EventDetails(props: { event: Event }) {
   const multipleDays = event.start.getTime() !== event.end.getTime();
   return (
     <div className="max-h-[70dvh] overflow-y-auto">
-      <h2 className="text-lg font-bold text-fg">{event.name}</h2>
+      <h2 className="pr-8 text-lg font-bold text-fg">{event.name}</h2>
       <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-sm font-medium text-fg-subtle">
         <span className="flex items-center gap-1">
           <CalendarIcon className="h-4 w-4 stroke-2" />

--- a/app/(site)/[eventSlug]/session-modal.tsx
+++ b/app/(site)/[eventSlug]/session-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useContext, useState } from "react";
 
+import { ModalCloseButton } from "@/app/components/modal-close-button";
 import type { Rsvp } from "@/db/repositories/interfaces";
 import { EventContext } from "../context";
 import { ViewSession } from "./view-session/view-session";
@@ -62,26 +63,10 @@ export function SessionModal({
     >
       <div className="fixed inset-0 bg-overlay" onClick={onDismiss} />
       <div className="relative bg-surface-raised rounded-lg shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto">
-        <button
+        <ModalCloseButton
           onClick={onDismiss}
-          className="absolute top-4 right-4 text-fg-subtle hover:text-fg-muted"
-          aria-label="Close"
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+          className="absolute right-3 top-3 z-10"
+        />
         {!session ? (
           <div className="p-6">Session not found.</div>
         ) : (

--- a/app/(site)/guests/meeting-picker.tsx
+++ b/app/(site)/guests/meeting-picker.tsx
@@ -110,20 +110,22 @@ function RequestForm({
   if (sent) {
     return (
       <div className="flex flex-col gap-4">
-        <p className="text-fg">
+        <p className="pr-8 text-fg">
           Asked {recipientName} for {slot?.label} on {day?.label}. You&apos;ll
           hear when they answer.
         </p>
-        <button type="button" onClick={onDone} className={PRIMARY_BUTTON}>
-          Done
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={onDone} className={PRIMARY_BUTTON}>
+            Done
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
     <form onSubmit={handleSend} className="flex flex-col gap-4">
-      <h2 className="text-xl font-bold text-fg">
+      <h2 className="pr-8 text-xl font-bold text-fg">
         1-on-1 with {recipientName}
         <span className="block text-sm font-normal text-fg-muted">
           {option.eventName}
@@ -203,7 +205,6 @@ export function MeetingPicker({
         zIndex="z-[60]"
         portal
         maxWidth="sm:max-w-2xl"
-        hideClose
       >
         {open && (
           <RequestForm

--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -7,11 +7,8 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import { ModalCloseButton } from "@/app/components/modal-close-button";
 import type { DirectoryView } from "@/app/(site)/guests/directory-view";
 import { ProfileBody } from "@/app/(site)/guests/profile-body";
 import {
@@ -366,14 +363,7 @@ export function ProfileModal({
             <span className="hidden sm:inline">Next</span>
             <ChevronRightIcon className="h-5 w-5 stroke-2" aria-hidden="true" />
           </NavButton>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={close}
-            className="rounded-md p-1.5 text-fg-subtle hover:bg-surface-sunken hover:text-fg-muted"
-          >
-            <XMarkIcon className="h-6 w-6 stroke-2" aria-hidden="true" />
-          </button>
+          <ModalCloseButton onClick={close} />
         </div>
 
         {/* touch-pan-y hands vertical scrolling to the browser and keeps

--- a/app/(site)/modals.tsx
+++ b/app/(site)/modals.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from "react";
 import Image from "next/image";
 import { MapIcon } from "@heroicons/react/24/outline";
 import { Modal } from "@/app/components/modal";
+import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/components/buttons";
 import { UserSelect } from "./user-select";
 import { UserContext } from "./context";
 import type { Guest } from "@/db/repositories/interfaces";
@@ -67,14 +68,8 @@ export function CurrentUserModal(props: {
     close();
   };
   return (
-    <Modal
-      open={open}
-      setOpen={close}
-      hideClose={!!user}
-      zIndex={zIndex}
-      portal={portal}
-    >
-      {sessionInfoDisplay}
+    <Modal open={open} setOpen={close} zIndex={zIndex} portal={portal}>
+      <div className="pr-8">{sessionInfoDisplay}</div>
       {
         <div className="mt-2">
           <span className="text-fg-subtle">RSVPing as...</span>
@@ -82,10 +77,10 @@ export function CurrentUserModal(props: {
         </div>
       }
       {user && (
-        <div className="relative inline-block group">
+        <div className="relative mt-4 inline-block group">
           <button
             type="button"
-            className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm disabled:bg-surface-hover disabled:text-fg-subtle px-4 py-2 bg-brand text-base font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent sm:text-sm mt-4"
+            className={PRIMARY_BUTTON}
             onClick={onClickHandler}
             disabled={isDisabled}
           >
@@ -126,19 +121,19 @@ export function ConfirmDeletionModal(props: {
       >
         Delete
       </button>
-      <Modal open={open} setOpen={setOpen} hideClose={true}>
-        <p>Delete {itemName}?</p>
-        <div className="mt-4">
+      <Modal open={open} setOpen={setOpen}>
+        <p className="pr-8">Delete {itemName}?</p>
+        <div className="mt-4 flex flex-wrap gap-2">
           <button
             type="button"
-            className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-brand font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent"
+            className={PRIMARY_BUTTON}
             onClick={() => void clickHandler()}
           >
             Yes
           </button>
           <button
             type="button"
-            className="ml-4 rounded-md border border-line-strong shadow-sm px-6 py-2 bg-surface-raised font-medium text-fg hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-line"
+            className={SECONDARY_BUTTON}
             onClick={() => setOpen(false)}
           >
             No
@@ -164,27 +159,17 @@ export function ConfirmationModal(props: {
   };
   return (
     <>
-      <Modal
-        open={open}
-        setOpen={close}
-        hideClose={true}
-        zIndex={zIndex}
-        portal={portal}
-      >
-        <p>{message}</p>
-        <div className="mt-4">
+      <Modal open={open} setOpen={close} zIndex={zIndex} portal={portal}>
+        <p className="pr-8">{message}</p>
+        <div className="mt-4 flex flex-wrap gap-2">
           <button
             type="button"
-            className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-brand font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent"
+            className={PRIMARY_BUTTON}
             onClick={clickHandler}
           >
             Yes
           </button>
-          <button
-            type="button"
-            className="ml-4 rounded-md border border-line-strong shadow-sm px-6 py-2 bg-surface-raised font-medium text-fg hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-line"
-            onClick={close}
-          >
+          <button type="button" className={SECONDARY_BUTTON} onClick={close}>
             No
           </button>
         </div>
@@ -202,20 +187,12 @@ export function AlertModal(props: {
 }) {
   const { open, close, message, zIndex, portal } = props;
   return (
-    <Modal
-      open={open}
-      setOpen={close}
-      hideClose={true}
-      zIndex={zIndex}
-      portal={portal}
-    >
-      <p role="alert">{message}</p>
+    <Modal open={open} setOpen={close} zIndex={zIndex} portal={portal}>
+      <p role="alert" className="pr-8">
+        {message}
+      </p>
       <div className="mt-4">
-        <button
-          type="button"
-          className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-brand font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent"
-          onClick={close}
-        >
+        <button type="button" className={PRIMARY_BUTTON} onClick={close}>
           OK
         </button>
       </div>

--- a/app/components/modal-close-button.tsx
+++ b/app/components/modal-close-button.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { XMarkIcon } from "@heroicons/react/24/outline";
+
+// The one way out of a dialog, in the same corner everywhere. Painted the
+// panel's own colour: invisible on a plain modal, legible over the map image.
+export function ModalCloseButton({
+  onClick,
+  className = "",
+}: {
+  onClick: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label="Close"
+      onClick={onClick}
+      className={`rounded-md bg-surface-raised p-1.5 text-fg-subtle hover:bg-surface-sunken hover:text-fg-muted focus:outline-none focus:ring-2 focus:ring-brand-accent ${className}`}
+    >
+      <XMarkIcon className="h-6 w-6 stroke-2" aria-hidden="true" />
+    </button>
+  );
+}

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -2,13 +2,13 @@
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { ModalCloseButton } from "@/app/components/modal-close-button";
 import { useSafeLayoutEffect } from "@/utils/hooks";
 
 export function Modal(props: {
   open: boolean;
   setOpen: (value: boolean) => void;
   children: React.ReactNode;
-  hideClose?: boolean;
   zIndex?: string;
   portal?: boolean; // Explicitly control portaling behavior
   // Passed rather than merged into the panel's classes: two max-width
@@ -20,7 +20,6 @@ export function Modal(props: {
     open,
     setOpen,
     children,
-    hideClose,
     zIndex = "z-10",
     portal = false,
     maxWidth = "sm:max-w-lg",
@@ -89,18 +88,13 @@ export function Modal(props: {
                 <Dialog.Panel
                   className={`relative mb-10 transform overflow-visible rounded-lg bg-surface-raised px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full ${maxWidth} sm:p-6`}
                 >
+                  {/* Overlays the panel's top right corner, so children whose
+                      first line reaches that far need a pr-8 of their own. */}
+                  <ModalCloseButton
+                    onClick={() => setOpen(false)}
+                    className="absolute right-3 top-3 z-10"
+                  />
                   {children}
-                  {!hideClose && (
-                    <div className="mt-4">
-                      <button
-                        type="button"
-                        className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-brand text-base font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent sm:text-sm"
-                        onClick={() => setOpen(false)}
-                      >
-                        Close
-                      </button>
-                    </div>
-                  )}
                 </Dialog.Panel>
               </Transition.Child>
             </div>

--- a/app/whats-new.tsx
+++ b/app/whats-new.tsx
@@ -73,7 +73,7 @@ export function WhatsNew({ className }: { className?: string }) {
         zIndex="z-50"
         maxWidth="sm:max-w-2xl"
       >
-        <Dialog.Title className="text-lg font-semibold text-fg">
+        <Dialog.Title className="pr-8 text-lg font-semibold text-fg">
           What&apos;s new
         </Dialog.Title>
         <p className="mt-1 text-sm text-fg-subtle">


### PR DESCRIPTION
The shared Modal appended a brand-coloured, full-width "Close" bar, so
dismissing looked like the thing to press next -- while the four big modals
each carried their own copy of an X in the corner. One ModalCloseButton now
serves both, and the confirmation after booking a 1-on-1 puts its "Done" in a
normal action row instead of stretching it across the panel.

<!-- jip:pushed-commit=68def41cdf61e5c2e6b81359b2726089716ca38e -->