### PR TITLE
fix: stack parallel 1-on-1s rather than shrinking them side by side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   under Settings, ask someone from their profile, and accept or decline what they are
   asked. Both sides are told the outcome; an unanswered request lapses at its slot
 - **Your 1-on-1s on the schedule** (#392): the grid's first column is yours alone — agreed
-  1-on-1s and open requests. Hover for what it clashes with, tap to open or cancel it
+  1-on-1s and open requests, stacked where several share a slot. Hover for what it clashes
+  with, tap to open or cancel it
 - **Arrange a 1-on-1 straight from the schedule** (#945): tapping an empty slot in your 1-on-1
   column lists who is free then, profile links included, and the request form follows on
 - **Say why, when you call a 1-on-1 off** (#946): cancelling takes an optional note, which the

--- a/app/(site)/[eventSlug]/meetings-col.tsx
+++ b/app/(site)/[eventSlug]/meetings-col.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import clsx from "clsx";
+import { Dialog } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/24/outline";
 import { DateTime } from "luxon";
 import Link from "next/link";
@@ -11,9 +12,14 @@ import type { MeetingView } from "@/utils/meeting-views";
 import { meetingColumnRows } from "@/utils/meeting-column";
 import type { DayWithSessions } from "@/app/(site)/context";
 import { EventContext, useSlotIncrement } from "@/app/(site)/context";
+import { Modal } from "@/app/components/modal";
 import { clashLines } from "@/utils/meeting-clash-text";
-import { statusLine } from "@/utils/meeting-rules";
-import { viewMeetingLinkFromOwner } from "./modal-nav";
+import {
+  blockTimeLabel,
+  slotSummaryLine,
+  statusLine,
+} from "@/utils/meeting-rules";
+import { isPlainLeftClick, viewMeetingLinkFromOwner } from "./modal-nav";
 import { NowLine } from "./now-line";
 import { BookMeeting } from "./book-meeting";
 import { Tooltip } from "./tooltip";
@@ -86,6 +92,9 @@ function SlotCell({
   );
 }
 
+const needsReply = (meeting: MeetingView) =>
+  meeting.status === "pending" && meeting.role === "recipient";
+
 // What the block has no room for, on hover -- the pattern a session block
 // already follows. A tap still opens the modal, where all of it is anyway.
 function MeetingSummary({ meeting }: { meeting: MeetingView }) {
@@ -114,6 +123,229 @@ function MeetingSummary({ meeting }: { meeting: MeetingView }) {
   );
 }
 
+/** The slot's 1-on-1s at a glance, for a block with no room to name them. */
+function SlotSummary({
+  meetings,
+  timezone,
+}: {
+  meetings: MeetingView[];
+  timezone: string;
+}) {
+  return (
+    <div className="p-2 space-y-1">
+      <p className="text-sm font-semibold text-fg">
+        {meetings.length} 1-on-1s · {blockTimeLabel(meetings, timezone)}
+      </p>
+      <ul className="space-y-0.5">
+        {meetings.map((meeting) => (
+          <li key={meeting.id} className="text-xs text-fg-muted">
+            <span className="font-medium text-fg">{meeting.otherName}</span> —{" "}
+            {statusLine(meeting)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** One 1-on-1, alone in its slot: room for the place and the state as well. */
+function MeetingBlock({
+  meeting,
+  span,
+  eventSlug,
+}: {
+  meeting: MeetingView;
+  span: number;
+  eventSlug: string;
+}) {
+  const searchParams = useSearchParams();
+  return (
+    <Tooltip
+      content={<MeetingSummary meeting={meeting} />}
+      className="flex flex-1 min-w-0"
+      triggerClassName="flex flex-1 min-w-0"
+      noTap
+    >
+      <Link
+        {...viewMeetingLinkFromOwner(searchParams, eventSlug, meeting.id)}
+        className={clsx(
+          "flex-1 min-w-0 rounded px-1 py-0.5 overflow-hidden font-roboto",
+          meeting.status === "accepted"
+            ? "bg-brand-tint border-2 border-brand-accent"
+            : // Pending reads as unfinished business, not a plan.
+              "bg-surface-muted border-2 border-dashed border-line"
+        )}
+      >
+        <p className="font-medium text-xs leading-[1.15] line-clamp-1 text-fg">
+          {meeting.otherName}
+        </p>
+        {span > 1 ? (
+          <>
+            <p className="text-[10px] leading-[1.15] line-clamp-1 text-fg-muted">
+              {meeting.meetingPoint}
+            </p>
+            <p className="text-[10px] leading-[1.15] text-fg-subtle">
+              {blockStatus(meeting)}
+            </p>
+          </>
+        ) : (
+          // One slot fits a name and one more line; the place gives way first,
+          // since the state is what may want answering.
+          <p className="flex gap-1 text-[10px] leading-[1.15] text-fg-subtle">
+            <span className="truncate text-fg-muted">
+              {meeting.meetingPoint}
+            </span>
+            <span className="shrink-0">· {blockStatus(meeting)}</span>
+          </p>
+        )}
+      </Link>
+    </Tooltip>
+  );
+}
+
+/**
+ * One of several 1-on-1s stacked in a slot: full width and a name only, which
+ * is what tells them apart. The dot marks one waiting on the reader.
+ */
+function StackEntry({
+  meeting,
+  eventSlug,
+  timezone,
+}: {
+  meeting: MeetingView;
+  eventSlug: string;
+  timezone: string;
+}) {
+  const searchParams = useSearchParams();
+  return (
+    <Tooltip
+      content={<MeetingSummary meeting={meeting} />}
+      className="flex flex-1 min-h-0"
+      triggerClassName="flex flex-1 min-w-0"
+      noTap
+    >
+      <Link
+        {...viewMeetingLinkFromOwner(searchParams, eventSlug, meeting.id)}
+        aria-label={`1-on-1 with ${meeting.otherName} at ${slotLabel(
+          meeting.slotStart,
+          timezone
+        )} — ${blockStatus(meeting)}`}
+        className={clsx(
+          "flex flex-1 min-w-0 items-center gap-1 overflow-hidden rounded-sm border-l-4 px-1 font-roboto",
+          meeting.status === "accepted"
+            ? "bg-brand-tint border-brand-accent"
+            : "bg-surface-muted border-dashed border-line"
+        )}
+      >
+        <span className="truncate text-[11px] leading-none font-medium text-fg">
+          {meeting.otherName}
+        </span>
+        {needsReply(meeting) && (
+          <span
+            aria-hidden="true"
+            className="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-warning-fg"
+          />
+        )}
+      </Link>
+    </Tooltip>
+  );
+}
+
+/**
+ * A slot holding more 1-on-1s than the block can name: one full-size control
+ * for the slot, which opens the list, rather than a row of unreadable slivers.
+ */
+function SlotBlock({
+  meetings,
+  timezone,
+  onOpen,
+}: {
+  meetings: MeetingView[];
+  timezone: string;
+  onOpen: () => void;
+}) {
+  return (
+    <Tooltip
+      content={<SlotSummary meetings={meetings} timezone={timezone} />}
+      className="flex flex-1 min-w-0"
+      triggerClassName="flex flex-1 min-w-0"
+      noTap
+    >
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`${meetings.length} 1-on-1s, ${blockTimeLabel(
+          meetings,
+          timezone
+        )} — ${slotSummaryLine(meetings)}`}
+        className="flex flex-1 min-w-0 flex-col justify-center overflow-hidden rounded border-2 border-line bg-surface-muted px-1 text-left font-roboto hover:border-brand-accent"
+      >
+        <span className="text-xs leading-[1.15] font-semibold text-fg">
+          {meetings.length} 1-on-1s
+        </span>
+        <span className="truncate text-[10px] leading-[1.15] text-fg-subtle">
+          {slotSummaryLine(meetings)}
+        </span>
+      </button>
+    </Tooltip>
+  );
+}
+
+/** Everything in one slot, where there is room for it: name, time and state. */
+function SlotMeetings({
+  meetings,
+  timezone,
+  eventSlug,
+  onClose,
+}: {
+  meetings: MeetingView[];
+  timezone: string;
+  eventSlug: string;
+  onClose: () => void;
+}) {
+  const searchParams = useSearchParams();
+  return (
+    <Modal open setOpen={onClose} zIndex="z-[60]" portal maxWidth="sm:max-w-md">
+      <Dialog.Title className="pr-8 text-base font-semibold text-fg">
+        {meetings.length} 1-on-1s, {blockTimeLabel(meetings, timezone)}
+      </Dialog.Title>
+      <p className="text-sm text-fg-muted">{meetings[0].dayLabel}</p>
+      <ul className="mt-3 flex max-h-72 flex-col gap-1 overflow-y-auto">
+        {meetings.map((meeting) => {
+          const link = viewMeetingLinkFromOwner(
+            searchParams,
+            eventSlug,
+            meeting.id
+          );
+          return (
+            <li key={meeting.id}>
+              <Link
+                {...link}
+                onClick={(e) => {
+                  const plain = isPlainLeftClick(e);
+                  link.onClick(e);
+                  // A modifier click opens the 1-on-1 in a tab of its own and
+                  // leaves this list where it was.
+                  if (plain) onClose();
+                }}
+                className="flex flex-col gap-0.5 rounded-md bg-surface-sunken p-2 hover:bg-surface-muted"
+              >
+                <span className="font-medium text-fg">{meeting.otherName}</span>
+                <span className="text-xs text-fg-muted">
+                  {meeting.timeLabel} · {meeting.meetingPoint}
+                </span>
+                <span className="text-xs text-fg-subtle">
+                  {statusLine(meeting)}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </Modal>
+  );
+}
+
 /**
  * The viewer's own 1-on-1s for one day, as the grid's first column, beside
  * the slots they cleared and the ones still open. Personal: never anyone
@@ -136,7 +368,6 @@ export function MeetingsCol({
   onBooked: () => void;
 }) {
   const slotIncrement = useSlotIncrement();
-  const searchParams = useSearchParams();
   // Never missing here: the column only renders once meetings for this event
   // have been fetched, which takes the event being in context.
   const { event, now } = useContext(EventContext);
@@ -144,17 +375,22 @@ export function MeetingsCol({
   const timezone = event?.timezone ?? "UTC";
   // Which slot the booking modal is open on, if any.
   const [booking, setBooking] = useState<string | null>(null);
+  // And which slot's list of its 1-on-1s is open, if any.
+  const [openSlot, setOpenSlot] = useState<string | null>(null);
   const rows = meetingColumnRows({
     meetings,
     availability,
     day,
     slotIncrement,
   });
+  const openRow = rows.find(
+    (candidate) => candidate.kind === "meetings" && candidate.start === openSlot
+  );
 
   return (
     <div className="relative px-0.5">
       <div className="grid h-full auto-rows-[44px]">
-        {rows.map(({ row, span, start, kind, meetings: atRow }) =>
+        {rows.map(({ row, span, start, kind, display, meetings: atRow }) =>
           kind !== "meetings" ? (
             <SlotCell
               key={row}
@@ -172,61 +408,46 @@ export function MeetingsCol({
               // Placed by row rather than in document order, so a gap between
               // two meetings needs no filler blocks.
               style={{ gridRowStart: row }}
-              className={`row-span-${span} flex gap-0.5 my-0.5`}
+              className={clsx(
+                `row-span-${span} flex gap-0.5 my-0.5`,
+                // Stacked, never side by side: this column is 96–160px wide.
+                display === "stack" && "flex-col"
+              )}
             >
-              {atRow.map((meeting) => (
-                <Tooltip
-                  key={meeting.id}
-                  content={<MeetingSummary meeting={meeting} />}
-                  className="flex flex-1 min-w-0"
-                  triggerClassName="flex flex-1 min-w-0"
-                  noTap
-                >
-                  <Link
-                    {...viewMeetingLinkFromOwner(
-                      searchParams,
-                      eventSlug,
-                      meeting.id
-                    )}
-                    className={clsx(
-                      "flex-1 min-w-0 rounded px-1 py-0.5 overflow-hidden font-roboto",
-                      meeting.status === "accepted"
-                        ? "bg-brand-tint border-2 border-brand-accent"
-                        : // Pending reads as unfinished business, not a plan.
-                          "bg-surface-muted border-2 border-dashed border-line"
-                    )}
-                  >
-                    <p className="font-medium text-xs leading-[1.15] line-clamp-1 text-fg">
-                      {meeting.otherName}
-                    </p>
-                    {span > 1 ? (
-                      <>
-                        <p className="text-[10px] leading-[1.15] line-clamp-1 text-fg-muted">
-                          {meeting.meetingPoint}
-                        </p>
-                        <p className="text-[10px] leading-[1.15] text-fg-subtle">
-                          {blockStatus(meeting)}
-                        </p>
-                      </>
-                    ) : (
-                      // One slot fits a name and one more line; the place gives
-                      // way first, since the state is what may want answering.
-                      <p className="flex gap-1 text-[10px] leading-[1.15] text-fg-subtle">
-                        <span className="truncate text-fg-muted">
-                          {meeting.meetingPoint}
-                        </span>
-                        <span className="shrink-0">
-                          · {blockStatus(meeting)}
-                        </span>
-                      </p>
-                    )}
-                  </Link>
-                </Tooltip>
-              ))}
+              {display === "summary" ? (
+                <SlotBlock
+                  meetings={atRow}
+                  timezone={timezone}
+                  onOpen={() => setOpenSlot(start)}
+                />
+              ) : display === "stack" ? (
+                atRow.map((meeting) => (
+                  <StackEntry
+                    key={meeting.id}
+                    meeting={meeting}
+                    eventSlug={eventSlug}
+                    timezone={timezone}
+                  />
+                ))
+              ) : (
+                <MeetingBlock
+                  meeting={atRow[0]}
+                  span={span}
+                  eventSlug={eventSlug}
+                />
+              )}
             </div>
           )
         )}
       </div>
+      {openRow && (
+        <SlotMeetings
+          meetings={openRow.meetings}
+          timezone={timezone}
+          eventSlug={eventSlug}
+          onClose={() => setOpenSlot(null)}
+        />
+      )}
       {booking && event && (
         <BookMeeting
           eventId={event.id}

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -300,6 +300,11 @@ you agreed to meet, and whether it is confirmed, waiting for your reply, or
 waiting for theirs. Each sits in its own time slot, next to whatever it would
 clash with.
 
+More than one can share a slot — an agreed 1-on-1 and someone asking for the
+same time is ordinary. They sit one above the other, and where there are more
+of them than the slot has room to name, the block says how many there are and
+opens the list of them instead.
+
 The column is yours alone — nobody else sees it, and it stays put when you
 filter the schedule down to one room. It is there on every day of the event
 once you take part at all — open to 1-on-1s, or with one arranged — so the

--- a/scripts/seed/seed-database.ts
+++ b/scripts/seed/seed-database.ts
@@ -42,6 +42,11 @@ const SLOT_INCREMENT_MINUTES = 30;
 // profile gives her the 1-on-1s to photograph (docs/screenshots/README.md).
 const SCREENSHOT_GUEST = "Hana Kobayashi";
 
+// The attendee whose Gamma morning is crowded with 1-on-1s, for
+// tests/e2e/meetings-column.spec.ts. Nothing else acts as her: those meetings
+// give her a column that shifts the rooms of every schedule she looks at.
+const PARALLEL_GUEST = "Zanele Khumalo";
+
 // Returns a UTC Date representing the given clock time on a specific day in Berlin.
 // dayOffset is added to baseDate's Berlin calendar date before setting the time.
 function berlinTime(
@@ -1010,68 +1015,116 @@ async function seedTestData(profile: SeedProfile) {
   insertChunked(rsvpRows, (chunk) => db.insert(schema.rsvps).values(chunk));
   console.log(`  ✅ Created ${rsvpRows.length} RSVPs`);
 
-  // One 1-on-1 of each state for the screenshot guest's column of Gamma's
-  // grid, in the afternoon the others here are bookable. Curated partners
-  // only: bulk guests are named by the generator's RNG, so pinning one here
-  // would break the seed the day bulk.ts's name lists change.
-  if (profile === "large") {
-    console.log("  🤝 Creating test 1-on-1s...");
-    const screenshotGuestId = guestIdByName(SCREENSHOT_GUEST);
-    const gammaDayOne = dayRows.find((d) => d.eventId === gammaEvent.id)!;
-    const slotAt = (hour: number, minute: number) => ({
-      slotStart: berlinTime(
-        new Date(gammaDayOne.start),
-        0,
-        hour,
-        minute
-      ).toISOString(),
-      slotEnd: berlinTime(
-        new Date(gammaDayOne.start),
-        0,
-        hour,
-        minute + SLOT_INCREMENT_MINUTES
-      ).toISOString(),
-    });
-    const meetingRows = [
-      {
-        other: "Rafael Souza",
-        role: "requester" as const,
-        ...slotAt(14, 0),
-        meetingPoint: "Coffee bar",
-        message: "Would love to hear how you mentor the juniors on your team.",
-        status: "accepted" as const,
-      },
-      {
-        other: "Aisha Diallo",
-        role: "recipient" as const,
-        ...slotAt(15, 0),
-        meetingPoint: "Garden bench",
-        message: "Could we compare notes on multilingual research?",
-        status: "pending" as const,
-      },
-      {
-        other: "Wei Chen",
-        role: "requester" as const,
-        ...slotAt(16, 0),
-        meetingPoint: "Coffee bar",
-        message: "Happy to swap documentation war stories.",
-        status: "pending" as const,
-      },
-    ].map(({ other, role, status, ...rest }) => ({
+  // 1-on-1s on Gamma's grid, for the one event in its scheduling phase.
+  // Curated partners only: bulk guests are named by the generator's RNG, so
+  // pinning one here would break the seed the day bulk.ts's name lists change.
+  console.log("  🤝 Creating test 1-on-1s...");
+  const gammaDayOne = dayRows.find((d) => d.eventId === gammaEvent.id)!;
+  const slotAt = (hour: number, minute: number) => ({
+    slotStart: berlinTime(
+      new Date(gammaDayOne.start),
+      0,
+      hour,
+      minute
+    ).toISOString(),
+    slotEnd: berlinTime(
+      new Date(gammaDayOne.start),
+      0,
+      hour,
+      minute + SLOT_INCREMENT_MINUTES
+    ).toISOString(),
+  });
+  type SeededMeeting = {
+    other: string;
+    role: "requester" | "recipient";
+    status: "accepted" | "pending";
+    slotStart: string;
+    slotEnd: string;
+    meetingPoint: string;
+    message: string;
+  };
+  const meetingsOf = (guestName: string, rows: SeededMeeting[]) =>
+    rows.map(({ other, role, status, ...rest }) => ({
       id: nanoid(),
       eventId: gammaEvent.id,
       requesterId:
-        role === "requester" ? screenshotGuestId : guestIdByName(other),
+        role === "requester" ? guestIdByName(guestName) : guestIdByName(other),
       recipientId:
-        role === "requester" ? guestIdByName(other) : screenshotGuestId,
+        role === "requester" ? guestIdByName(other) : guestIdByName(guestName),
       status,
       createdAt: new Date().toISOString(),
       respondedAt: status === "accepted" ? new Date().toISOString() : null,
       ...rest,
     }));
-    db.insert(schema.meetings).values(meetingRows).run();
-    console.log(`  ✅ Created ${meetingRows.length} 1-on-1s`);
-  }
+
+  // Two people wanting one slot, and four wanting the next: what the schedule
+  // column stacks, and what it has to collapse into a list. On a guest nothing
+  // else seeds, since it gives her a 1-on-1 column on every Gamma day.
+  const parallelRows = meetingsOf(PARALLEL_GUEST, [
+    {
+      other: "Leilani Kahale",
+      role: "recipient",
+      status: "accepted",
+      ...slotAt(10, 0),
+      meetingPoint: "Coffee bar",
+      message: "Container queries, and where they still bite.",
+    },
+    {
+      other: "Samuel Adeyemi",
+      role: "recipient",
+      status: "pending",
+      ...slotAt(10, 0),
+      meetingPoint: "Garden bench",
+      message: "Could I steal you for the same half hour?",
+    },
+    ...(["Marta Horvat", "Dmitri Volkov", "Chiara Bianchi"] as const).map(
+      (other) => ({
+        other,
+        role: "recipient" as const,
+        status: "pending" as const,
+        ...slotAt(11, 0),
+        meetingPoint: "Coffee bar",
+        message: "Free at eleven?",
+      })
+    ),
+  ]);
+
+  // One of each state for the screenshot guest's column, in the afternoon the
+  // others here are bookable (docs/screenshots/README.md).
+  const screenshotRows =
+    profile === "large"
+      ? meetingsOf(SCREENSHOT_GUEST, [
+          {
+            other: "Rafael Souza",
+            role: "requester",
+            status: "accepted",
+            ...slotAt(14, 0),
+            meetingPoint: "Coffee bar",
+            message:
+              "Would love to hear how you mentor the juniors on your team.",
+          },
+          {
+            other: "Aisha Diallo",
+            role: "recipient",
+            status: "pending",
+            ...slotAt(15, 0),
+            meetingPoint: "Garden bench",
+            message: "Could we compare notes on multilingual research?",
+          },
+          {
+            other: "Wei Chen",
+            role: "requester",
+            status: "pending",
+            ...slotAt(16, 0),
+            meetingPoint: "Coffee bar",
+            message: "Happy to swap documentation war stories.",
+          },
+        ])
+      : [];
+
+  const meetingRows = [...parallelRows, ...screenshotRows];
+  db.insert(schema.meetings).values(meetingRows).run();
+  console.log(`  ✅ Created ${meetingRows.length} 1-on-1s`);
 
   console.log("✅ Test data seeded successfully");
 }

--- a/tests/e2e/meetings-column.spec.ts
+++ b/tests/e2e/meetings-column.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "./helpers/fixtures";
+import { loginAndGoto } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+
+/**
+ * The schedule's 1-on-1 column when several share a slot. The fixture is
+ * seeded rather than booked through the UI here — arranging five 1-on-1s takes
+ * five attendees and five user switches, and what is under test is how the
+ * column draws them. Booking one is covered by meetings-request.spec.ts.
+ *
+ * Conference Gamma is the seeded event in its scheduling phase, and Zanele's
+ * first morning there holds two 1-on-1s at 10:00 and three at 11:00
+ * (scripts/seed/seed-database.ts).
+ */
+const VIEWER = "Zanele Khumalo";
+const AT_TEN = ["Leilani Kahale", "Samuel Adeyemi"];
+const AT_ELEVEN = ["Marta Horvat", "Dmitri Volkov", "Chiara Bianchi"];
+
+test.describe("parallel 1-on-1s on the schedule", () => {
+  test("stacks what fits the slot and collapses what does not", async ({
+    page,
+  }) => {
+    await loginAndGoto(page, "/guests");
+    await selectUser(page, VIEWER);
+    await page.getByRole("link", { name: "Conference Gamma" }).first().click();
+
+    // Two in a slot: both readable at full column width, one above the other
+    // rather than in half-width slivers.
+    const [confirmed, waiting] = AT_TEN.map((name) =>
+      page.getByRole("link", { name: new RegExp(`${name} at 10:00`) })
+    );
+    await expect(confirmed).toBeVisible();
+    await expect(waiting).toBeVisible();
+    const confirmedBox = (await confirmed.boundingBox())!;
+    const waitingBox = (await waiting.boundingBox())!;
+    expect(waitingBox.width).toBe(confirmedBox.width);
+    expect(waitingBox.y).toBeGreaterThanOrEqual(
+      confirmedBox.y + confirmedBox.height
+    );
+
+    // And each opens its own 1-on-1, the request among them still answerable.
+    await waiting.click();
+    const details = page.getByRole("dialog", { name: "1-on-1 details" });
+    await expect(
+      details.getByRole("heading", { name: `1-on-1 with ${AT_TEN[1]}` })
+    ).toBeVisible();
+    await expect(details.getByRole("button", { name: "Accept" })).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(details).toBeHidden();
+
+    // Three in a slot no longer fit, so the block stands for the slot itself
+    // and opens the list.
+    const crowded = page.getByRole("button", {
+      name: "3 1-on-1s, 11:00 – 11:30 — 3 need your reply",
+    });
+    await expect(crowded).toBeVisible();
+    await crowded.click();
+
+    const slotList = page.getByRole("dialog", {
+      name: /3 1-on-1s, 11:00 – 11:30/,
+    });
+    const listed = AT_ELEVEN.map((name) =>
+      slotList.getByRole("link", { name: new RegExp(name) })
+    );
+    for (const row of listed) await expect(row).toBeVisible();
+    await listed[1].click();
+    await expect(
+      details.getByRole("heading", { name: `1-on-1 with ${AT_ELEVEN[1]}` })
+    ).toBeVisible();
+  });
+});

--- a/tests/unit/meeting-column.test.ts
+++ b/tests/unit/meeting-column.test.ts
@@ -61,6 +61,75 @@ describe("meetingColumnRows", () => {
     expect(both[0].meetings).toHaveLength(2);
   });
 
+  // Two meetings of unequal length are placed by their own start row, and two
+  // grid items in the same column draw over each other -- so anything that
+  // overlaps has to end up in one block.
+  it("groups meetings that overlap without sharing a start row", () => {
+    const uneven = rows(
+      [meeting(0, { slotEnd: at(60) }), meeting(30, { id: "second" })],
+      []
+    ).filter((r) => r.kind === "meetings");
+
+    expect(uneven).toHaveLength(1);
+    expect(uneven[0]).toMatchObject({ row: 1, span: 2 });
+    expect(uneven[0].meetings.map((m) => m.id)).toEqual(["m-0", "second"]);
+  });
+
+  // Nothing the reader can predict orders them otherwise, and an order that
+  // changes from one read to the next moves the block under their finger.
+  it("puts the earliest first in a block, then the names in order", () => {
+    const together = rows(
+      [
+        meeting(0, { id: "later", otherName: "Zoë", slotEnd: at(60) }),
+        meeting(30, { id: "second", otherName: "Bea" }),
+        meeting(0, { id: "first", otherName: "Amir" }),
+      ],
+      []
+    ).filter((r) => r.kind === "meetings");
+
+    expect(together[0].meetings.map((m) => m.id)).toEqual([
+      "first",
+      "later",
+      "second",
+    ]);
+  });
+
+  it("leaves meetings that do not overlap in rows of their own", () => {
+    const apart = rows([meeting(0), meeting(30, { id: "second" })], []).filter(
+      (r) => r.kind === "meetings"
+    );
+
+    expect(apart.map((r) => r.row)).toEqual([1, 2]);
+  });
+
+  // The column is 96–160px wide, so blocks side by side stop being readable at
+  // two and stop being tappable at four. Stacked full-width lines fit while
+  // there is height for them; past that the slot is one block that opens a list.
+  it("stacks what fits the block's height and summarises the rest", () => {
+    const parallel = (count: number) =>
+      rows(
+        Array.from({ length: count }, (_, i) =>
+          meeting(0, { id: `m${i}`, otherName: `Guest ${i}` })
+        ),
+        []
+      ).filter((r) => r.kind === "meetings")[0];
+
+    expect(parallel(1).display).toBe("single");
+    expect(parallel(2).display).toBe("stack");
+    expect(parallel(3).display).toBe("summary");
+  });
+
+  it("stacks more of them in a block spanning two slots", () => {
+    const tall = rows(
+      Array.from({ length: 3 }, (_, i) =>
+        meeting(0, { id: `m${i}`, slotEnd: at(60) })
+      ),
+      []
+    ).filter((r) => r.kind === "meetings")[0];
+
+    expect(tall).toMatchObject({ span: 2, display: "stack" });
+  });
+
   // An event whose slot increment changed leaves older meetings longer than
   // one row.
   it("spans a meeting longer than one slot", () => {

--- a/tests/unit/meeting-rules.test.ts
+++ b/tests/unit/meeting-rules.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { canCancel, statusLine } from "@/utils/meeting-rules";
+import {
+  blockTimeLabel,
+  canCancel,
+  slotSummaryLine,
+  statusLine,
+} from "@/utils/meeting-rules";
 
 const NOW = new Date("2026-10-01T09:00:00.000Z");
 const LATER = "2026-10-01T10:00:00.000Z";
@@ -50,6 +55,65 @@ describe("canCancel", () => {
         canCancel({ status, role: "requester", slotStart: LATER }, NOW)
       ).toBe(false);
     }
+  });
+});
+
+// The one line a collapsed slot has room for, under "4 1-on-1s".
+describe("slotSummaryLine", () => {
+  const pending = (role: "requester" | "recipient") =>
+    ({ status: "pending", role }) as const;
+
+  it("leads with what is waiting on the viewer", () => {
+    expect(
+      slotSummaryLine([
+        { status: "accepted", role: "requester" },
+        pending("requester"),
+        pending("recipient"),
+      ])
+    ).toBe("1 needs your reply");
+    expect(slotSummaryLine([pending("recipient"), pending("recipient")])).toBe(
+      "2 need your reply"
+    );
+  });
+
+  it("counts what the viewer is waiting on when nothing is theirs to answer", () => {
+    expect(slotSummaryLine([pending("requester")])).toBe("1 waiting for reply");
+    expect(slotSummaryLine([pending("requester"), pending("requester")])).toBe(
+      "2 waiting for reply"
+    );
+  });
+
+  it("says so when there is nothing left to answer", () => {
+    expect(
+      slotSummaryLine([
+        { status: "accepted", role: "requester" },
+        { status: "accepted", role: "recipient" },
+      ])
+    ).toBe("all confirmed");
+  });
+});
+
+// What a block of several is named by, when the block is all the reader sees.
+describe("blockTimeLabel", () => {
+  const BERLIN = "Europe/Berlin";
+  const slot = (start: string, end: string) => ({
+    slotStart: `2026-10-01T${start}:00.000Z`,
+    slotEnd: `2026-10-01T${end}:00.000Z`,
+  });
+
+  it("reads as the meeting's own time when it is alone", () => {
+    expect(blockTimeLabel([slot("08:00", "08:30")], BERLIN)).toBe(
+      "10:00 – 10:30"
+    );
+  });
+
+  // Overlapping meetings of unequal length share one block, so naming it after
+  // the first of them puts a time on the block the rest do not have.
+  it("covers the earliest start and the latest end", () => {
+    const uneven = [slot("08:00", "09:00"), slot("08:30", "09:30")];
+
+    expect(blockTimeLabel(uneven, BERLIN)).toBe("10:00 – 11:30");
+    expect(blockTimeLabel([...uneven].reverse(), BERLIN)).toBe("10:00 – 11:30");
   });
 });
 

--- a/utils/meeting-column.ts
+++ b/utils/meeting-column.ts
@@ -1,4 +1,4 @@
-import { getNumSlots } from "@/utils/slots";
+import { getNumSlots, SLOT_HEIGHT_PX } from "@/utils/slots";
 import type { MeetingView } from "@/utils/meeting-views";
 
 const LIVE = new Set<MeetingView["status"]>(["pending", "accepted"]);
@@ -31,6 +31,27 @@ export function takesPartInMeetings(
 }
 
 /**
+ * How a block of meetings is drawn. The column is 96–160px wide, so blocks set
+ * side by side are unreadable at two; they stack instead, until the block runs
+ * out of height and the whole slot becomes one block that opens a list.
+ */
+export type MeetingBlockDisplay = "single" | "stack" | "summary";
+
+/** Least height a stacked entry stays legible in, and the gap below it. */
+const ENTRY_PX = 18;
+const ENTRY_GAP_PX = 2;
+/** The block's own vertical margin (my-0.5), top and bottom. */
+const BLOCK_INSET_PX = 4;
+
+function stackCapacity(span: number): number {
+  const height = span * SLOT_HEIGHT_PX - BLOCK_INSET_PX;
+  return Math.max(
+    1,
+    Math.floor((height + ENTRY_GAP_PX) / (ENTRY_PX + ENTRY_GAP_PX))
+  );
+}
+
+/**
  * One row of the schedule's 1-on-1 column: what the viewer has in that slot,
  * or why they have nothing there.
  */
@@ -43,12 +64,15 @@ export type MeetingColumnRow = {
   kind: "meetings" | "unavailable" | "free";
   /** Empty unless `kind` is "meetings". */
   meetings: MeetingView[];
+  /** Set on a "meetings" row, absent on the empty kinds. */
+  display?: MeetingBlockDisplay;
 };
 
 /**
- * The column's rows for one day, one per slot. Nothing merges: what the
- * viewer cleared governs who may book *them*, and they can still arrange a
- * 1-on-1 in it themselves, so every slot stays separately bookable (#945).
+ * The column's rows for one day, one per slot — except where meetings overlap,
+ * which share one block. Nothing else merges: what the viewer cleared governs
+ * who may book *them*, and they can still arrange a 1-on-1 in it themselves,
+ * so every empty slot stays separately bookable (#945).
  */
 export function meetingColumnRows({
   meetings,
@@ -71,31 +95,50 @@ export function meetingColumnRows({
   const rowOf = (start: string) =>
     Math.floor((new Date(start).getTime() - day.start.getTime()) / slotMs) + 1;
 
-  const byRow = new Map<number, MeetingView[]>();
-  for (const meeting of meetings) {
-    const row = rowOf(meeting.slotStart);
-    byRow.set(row, [...(byRow.get(row) ?? []), meeting]);
-  }
   // Measured from the row's start rather than the meeting's, so one that
   // starts mid-row and reaches into the next covers both -- and never past the
   // last row, which a day shortened after the booking would otherwise do,
   // stretching the day's grid row beyond the rooms beside it.
-  const spanOf = (meeting: MeetingView) => {
-    const row = rowOf(meeting.slotStart);
+  const spanOf = (meeting: MeetingView, row: number) => {
     const rowStart = day.start.getTime() + (row - 1) * slotMs;
     const wanted = Math.ceil(
       (new Date(meeting.slotEnd).getTime() - rowStart) / slotMs
     );
     return Math.min(Math.max(1, wanted), Math.max(1, numSlots - row + 1));
   };
-  // Rows are keyed by start, so two such meetings of unequal length that
-  // overlap without sharing a row would draw over each other. Knowingly out
-  // of scope: it takes an increment change *and* two bookings athwart it.
 
+  const placed = meetings
+    .map((meeting) => {
+      const row = rowOf(meeting.slotStart);
+      return { meeting, row, end: row + spanOf(meeting, row) };
+    })
+    // Earliest first, then by name: an order the reader can predict, and one a
+    // block keeps from one read to the next.
+    .sort(
+      (a, b) =>
+        a.meeting.slotStart.localeCompare(b.meeting.slotStart) ||
+        a.meeting.otherName.localeCompare(b.meeting.otherName) ||
+        a.meeting.id.localeCompare(b.meeting.id)
+    );
+
+  // Everything that overlaps goes in one block: two grid items in the same
+  // column draw over each other, and unequal lengths make that a wider net
+  // than sharing a start row.
+  const blocks: { row: number; end: number; meetings: MeetingView[] }[] = [];
+  for (const { meeting, row, end } of placed) {
+    const open = blocks[blocks.length - 1];
+    if (open && row < open.end) {
+      open.end = Math.max(open.end, end);
+      open.meetings.push(meeting);
+      continue;
+    }
+    blocks.push({ row, end, meetings: [meeting] });
+  }
+
+  const byRow = new Map(blocks.map((block) => [block.row, block]));
   const covered = new Set<number>();
-  for (const [row, atRow] of byRow) {
-    const span = Math.max(...atRow.map(spanOf));
-    for (let i = 0; i < span; i++) covered.add(row + i);
+  for (const block of blocks) {
+    for (let row = block.row; row < block.end; row++) covered.add(row);
   }
 
   // Being asked takes no availability of your own, so a guest can hold
@@ -109,14 +152,21 @@ export function meetingColumnRows({
     const start = new Date(
       day.start.getTime() + (row - 1) * slotMs
     ).toISOString();
-    const atRow = byRow.get(row);
-    if (atRow) {
+    const block = byRow.get(row);
+    if (block) {
+      const span = block.end - block.row;
       rows.push({
         row,
-        span: Math.max(...atRow.map(spanOf)),
+        span,
         start,
         kind: "meetings",
-        meetings: atRow,
+        meetings: block.meetings,
+        display:
+          block.meetings.length === 1
+            ? "single"
+            : block.meetings.length <= stackCapacity(span)
+              ? "stack"
+              : "summary",
       });
       continue;
     }

--- a/utils/meeting-rules.ts
+++ b/utils/meeting-rules.ts
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 import type { MeetingView } from "@/utils/meeting-views";
 
 /**
@@ -16,6 +18,42 @@ export function canCancel(
     meeting.status === "accepted" ||
     (meeting.status === "pending" && meeting.role === "requester")
   );
+}
+
+/**
+ * The span a block of 1-on-1s covers, shaped like a meeting's own `timeLabel`.
+ * Meetings that overlap without sharing a start share a block, so the first
+ * one's time is not the block's.
+ */
+export function blockTimeLabel(
+  meetings: Pick<MeetingView, "slotStart" | "slotEnd">[],
+  timezone: string
+): string {
+  const clock = (iso: string) =>
+    DateTime.fromISO(iso).setZone(timezone).toFormat("HH:mm");
+  const starts = meetings.map((m) => m.slotStart).sort();
+  const ends = meetings.map((m) => m.slotEnd).sort();
+  return `${clock(starts[0])} – ${clock(ends[ends.length - 1])}`;
+}
+
+/**
+ * The one line a slot of several 1-on-1s has room for under its count. What is
+ * waiting on the reader comes first: it is the only part they can act on.
+ */
+export function slotSummaryLine(
+  meetings: Pick<MeetingView, "status" | "role">[]
+): string {
+  const pending = meetings.filter((m) => m.status === "pending");
+  const yours = pending.filter((m) => m.role === "recipient").length;
+  if (yours > 0) {
+    return yours === 1 ? "1 needs your reply" : `${yours} need your reply`;
+  }
+  if (pending.length > 0) {
+    return pending.length === 1
+      ? "1 waiting for reply"
+      : `${pending.length} waiting for reply`;
+  }
+  return "all confirmed";
 }
 
 /** What has become of the request, in the words of whoever is reading. */


### PR DESCRIPTION
A slot can hold an agreed 1-on-1 and any number of requests on top of it,
and the column is 96-160px wide: side by side they stop being readable at
two and tappable at four. They stack full width instead, and a slot too
crowded to name them becomes one block that opens the list of them.

Meetings now share a block whenever they overlap rather than only when
they start in the same row, which is what stopped two of unequal length
drawing over each other.

<!-- jip:pushed-commit=7bf20e8ce91811aff2ce2637720ce4eb3e94cd0e -->