### PR TITLE
chore: reopen changelog and release notes after 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > If the change is a highlight of the coming release, it also belongs in
 > [`app/release-notes.ts`](app/release-notes.ts), which holds 3-5 of them.
 
+## [Unreleased]
+
 ## [3.6.0] - 2026-09-08
 
 ### Added
@@ -609,6 +611,7 @@ This version corresponds to commit [9aa2a273](https://github.com/LWCW-Europe/sch
 
 The version number 1.0.0 is a retroactive label assigned here purely as a reference point to mark the upstream baseline — it was never designated as such. This is the upstream codebase at the point the fork was created, taken from commit [babcd627](https://github.com/rachelweinberg12/scheduling-app/commit/babcd6275a853f1911cd48bbdaf4f2b1725c3d47) of [rachelweinberg12/scheduling-app](https://github.com/rachelweinberg12/scheduling-app) ([full log](https://github.com/rachelweinberg12/scheduling-app/commits/babcd6275a853f1911cd48bbdaf4f2b1725c3d47/)). It was never properly released since it was deployed directly from the Git repository.
 
+[Unreleased]: https://github.com/LWCW-Europe/schellingboard/compare/v3.6.0...HEAD
 [3.6.0]: https://github.com/LWCW-Europe/schellingboard/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/LWCW-Europe/schellingboard/compare/v3.4.2...v3.5.0
 [3.4.2]: https://github.com/LWCW-Europe/schellingboard/compare/v3.4.1...v3.4.2

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -43,6 +43,10 @@ export const SHOWN_RELEASES = 3;
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: "Unreleased",
+    highlights: [],
+  },
+  {
     version: "3.6.0",
     date: "2026-09-08",
     highlights: [


### PR DESCRIPTION
<!-- jip:pushed-commit=27a3e02741f1198dc9fc1c320700dcaf6c2b0cf2 -->