### PR TITLE
fix(e2e): type late-alphabet names into the picker

### DIFF
--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -9,8 +9,10 @@ import { selectUser } from "./helpers/user";
 // two tests watching the same person's badge would see each other's counts.
 
 // selectUser logs out and back in; navigating before that settles aborts the
-// request and drops the selection.
-async function actAs(page: Page, name: RegExp) {
+// request and drops the selection. The name is typed, not matched: the picker
+// shows 20 names, and specs running alongside add guests that push the later
+// names (Hana, Isabella) off the list.
+async function actAs(page: Page, name: string) {
   await selectUser(page, name);
   await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
 }
@@ -37,12 +39,12 @@ test("a comment on your profile becomes a notification you can open", async ({
   await login(page);
   await page.goto("/guests");
 
-  await actAs(page, /Anna Kowalska/i);
+  await actAs(page, "Anna Kowalska");
   await commentOnProfile(page, "Isabella Rossi", "great to meet you");
 
   // Isabella hosts a session other specs comment on, so this test reads its
   // own row rather than the badge's count: unread is not hers alone.
-  await actAs(page, /Isabella Rossi/i);
+  await actAs(page, "Isabella Rossi");
   await expect(bell(page)).toHaveAccessibleName(/unread/);
 
   await bell(page).click();
@@ -74,12 +76,12 @@ test("marks a notification read without opening it", async ({ page }) => {
   await login(page);
   await page.goto("/guests");
 
-  await actAs(page, /Anna Kowalska/i);
+  await actAs(page, "Anna Kowalska");
   await commentOnProfile(page, "Hana Kobayashi", "hello from Anna");
 
   // Hana hosts proposals other specs comment on, so this test reads its own
   // row rather than the badge: the count is not hers alone.
-  await actAs(page, /Hana Kobayashi/i);
+  await actAs(page, "Hana Kobayashi");
   await bell(page).click();
   const row = page
     .getByRole("listitem")
@@ -102,12 +104,12 @@ test("acts on the ticked notifications and nothing else", async ({ page }) => {
 
   // Two different commenters, so the two rows read differently and can be
   // told apart by name rather than by position.
-  await actAs(page, /Anna Kowalska/i);
+  await actAs(page, "Anna Kowalska");
   await commentOnProfile(page, "Freya Nielsen", "Anna says hello");
-  await actAs(page, /Isabella Rossi/i);
+  await actAs(page, "Isabella Rossi");
   await commentOnProfile(page, "Freya Nielsen", "Isabella says hello");
 
-  await actAs(page, /Freya Nielsen/i);
+  await actAs(page, "Freya Nielsen");
   await bell(page).click();
   const actions = page.getByRole("group", { name: "Notification actions" });
 
@@ -154,7 +156,7 @@ test("closing a session opened from a notification stays on the schedule", async
   await login(page);
   await page.goto("/Conference-Gamma");
 
-  await actAs(page, /Anna Kowalska/i);
+  await actAs(page, "Anna Kowalska");
   const commented = await openSession(page, GREEN_SESSION);
   await commented.getByPlaceholder("Add a comment").fill("count me in");
   await commented.getByRole("button", { name: "Comment", exact: true }).click();
@@ -164,7 +166,7 @@ test("closing a session opened from a notification stays on the schedule", async
   await page.keyboard.press("Escape");
   await expect(commented).toBeHidden();
 
-  await actAs(page, /Carlos Silva/i);
+  await actAs(page, "Carlos Silva");
 
   // Opening a session from the schedule arms "dismiss by going back" (see
   // modal-nav.ts, anchor MnpjIo7Y). That must not still be armed for the modal
@@ -174,8 +176,10 @@ test("closing a session opened from a notification stays on the schedule", async
   await expect(fromSchedule).toBeHidden();
 
   await bell(page).click();
+  // .first(): a retry comments again, and the earlier notification remains.
   await page
     .getByRole("button", { name: /Anna Kowalska commented on/ })
+    .first()
     .click();
 
   const fromNotification = page.getByRole("dialog", {
@@ -234,6 +238,10 @@ test.describe("attendee-count reminders", () => {
     await page.getByRole("button", { name: "Send due reminders" }).click();
     await expect(page.getByText(/sent \d+ reminders/)).toBeVisible();
 
+    // The badge is rendered by the layout and the dev button refreshes nothing,
+    // so only a reload shows the count. (In a full run attendee-count.spec.ts
+    // usually dispatches first, which is why this passed without one.)
+    await page.reload();
     await expect(bell(page)).toHaveAccessibleName(/unread/);
     await bell(page).click();
     await expect(

--- a/tests/e2e/proposals.spec.ts
+++ b/tests/e2e/proposals.spec.ts
@@ -296,7 +296,7 @@ test("filters the proposal list down to your own proposals", async ({
   // delete in Conference Alpha can't shift the count this one reads. Hana
   // Kobayashi hosts the first of these; nobody hosts the second.
   await loginAndGoto(page, "/Conference-Gamma/proposals");
-  await selectUser(page, /Hana Kobayashi/i);
+  await selectUser(page, "Hana Kobayashi");
 
   const hers = page.getByRole("row", {
     name: /Writing Documentation People Actually Read/,

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -222,7 +222,7 @@ test("a host sees the vote breakdown of their own proposal", async ({
   page,
 }) => {
   await loginAndGoto(page, "/Conference-Gamma/proposals");
-  await selectUser(page, /Hana Kobayashi/i);
+  await selectUser(page, "Hana Kobayashi");
 
   const modal = await openGammaProposal(page, HOSTED_PROPOSAL);
   const breakdown = modal.getByRole("region", { name: "Vote breakdown" });


### PR DESCRIPTION
The name switcher lists only the first 20 names, and a regex cannot be
typed to narrow it. While meetings-request.spec.ts's transient guests
exist, Isabella Rossi is 22nd and Hana Kobayashi exactly 20th, so the
option never rendered.

Also reload before asserting the reminder badge: the layout renders it
and the dev toolbar refreshes nothing, so on its own the spec only ever
passed because attendee-count.spec.ts had dispatched first.

<!-- jip:pushed-commit=58aed2dbef547c9ef66536e88e2289096e7ec967 -->