### PR TITLE
feat: add a session to Google Calendar from its details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Add a session to Google Calendar**: a session's details offer a button that opens Google
+  Calendar with the title, time, room, hosts and description filled in, ready to save
+
 ## [3.6.0] - 2026-09-08
 
 ### Added

--- a/app/(site)/[eventSlug]/view-session/add-to-google-calendar.tsx
+++ b/app/(site)/[eventSlug]/view-session/add-to-google-calendar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { CalendarIcon } from "@heroicons/react/24/outline";
+
+import type { Event, Location, Session } from "@/db/repositories/interfaces";
+import { googleCalendarUrl } from "@/utils/google-calendar";
+import { useSiteOrigin } from "@/utils/hooks";
+
+export function AddToGoogleCalendar(props: {
+  session: Session;
+  event: Event;
+  location: Location | undefined;
+}) {
+  const { session, event, location } = props;
+  const origin = useSiteOrigin();
+
+  if (!session.startTime || !session.endTime) return null;
+
+  const href = googleCalendarUrl({
+    description: session.description,
+    end: session.endTime,
+    hostNames: session.hosts.map((h) => h.name),
+    location: location?.name,
+    start: session.startTime,
+    timezone: event.timezone,
+    title: session.title,
+    url: origin
+      ? `${origin}/${event.slug}?viewSession=${session.id}`
+      : undefined,
+  });
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-brand-accent text-brand-fg hover:bg-brand-tint focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent transition-colors"
+    >
+      <CalendarIcon className="h-3 w-3 mr-1" />
+      Add to Google Calendar
+    </a>
+  );
+}

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -21,6 +21,7 @@ import { viewProposalLinkFromElsewhere } from "../modal-nav";
 import { SessionComments } from "../session-comments";
 import { Markdown } from "@/app/(site)/markdown";
 import { AttendeeCountField } from "./attendee-count-field";
+import { AddToGoogleCalendar } from "./add-to-google-calendar";
 
 export function ViewSession(props: {
   session: Session;
@@ -265,6 +266,12 @@ export function ViewSession(props: {
               Edit
             </Link>
           )}
+
+          <AddToGoogleCalendar
+            session={session}
+            event={event}
+            location={location}
+          />
         </div>
         {rsvpError && (
           <p role="alert" className="mt-2 text-xs text-danger-fg">

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -44,7 +44,9 @@ export const SHOWN_RELEASES = 3;
 export const releaseNotes: ReleaseNote[] = [
   {
     version: "Unreleased",
-    highlights: [],
+    highlights: [
+      "**Add a session to your Google Calendar** from its details: title, time, room, hosts and description arrive filled in, with a link back to the session.",
+    ],
   },
   {
     version: "3.6.0",

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -180,14 +180,6 @@ Unlike votes, hosts plan around it. If you change your mind, take it back with
 - A session marked **closed** warns that you can be at most five minutes late,
   but doesn't block your RSVP.
 
-### Add a session to your calendar
-
-A scheduled session's details have an **"Add to Google Calendar"** button. It
-opens Google Calendar in a new tab with the title, time, room, hosts and
-description filled in, plus a link back to the session; save it there and it is
-in your calendar. The entry is a copy: if the session moves later, the schedule
-here is what counts.
-
 ### Discuss a session
 
 Open a session to find the same comment section proposals have — useful for

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -180,6 +180,14 @@ Unlike votes, hosts plan around it. If you change your mind, take it back with
 - A session marked **closed** warns that you can be at most five minutes late,
   but doesn't block your RSVP.
 
+### Add a session to your calendar
+
+A scheduled session's details have an **"Add to Google Calendar"** button. It
+opens Google Calendar in a new tab with the title, time, room, hosts and
+description filled in, plus a link back to the session; save it there and it is
+in your calendar. The entry is a copy: if the session moves later, the schedule
+here is what counts.
+
 ### Discuss a session
 
 Open a session to find the same comment section proposals have — useful for

--- a/tests/e2e/view-session.spec.ts
+++ b/tests/e2e/view-session.spec.ts
@@ -41,6 +41,36 @@ test("hard-navigating to a session URL renders the modal without hydration error
   await page.waitForLoadState("networkidle");
 });
 
+test("a scheduled session offers to be added to Google Calendar", async ({
+  page,
+  baseURL,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await page.getByRole("link", { name: KEYNOTE }).first().click();
+  const dialog = page.getByRole("dialog", { name: "Session details" });
+  await expect(dialog).toBeVisible();
+
+  const link = dialog.getByRole("link", { name: "Add to Google Calendar" });
+  await expect(link).toHaveAttribute("target", "_blank");
+  // The link back is filled in once the browser knows its own origin, a moment
+  // after hydration, so wait for it rather than reading the href straight away.
+  // It sits inside the details parameter, hence the encoded "=".
+  await expect(link).toHaveAttribute("href", /viewSession%3D/);
+
+  const href = new URL((await link.getAttribute("href"))!);
+  expect(`${href.origin}${href.pathname}`).toBe(
+    "https://calendar.google.com/calendar/render"
+  );
+  expect(href.searchParams.get("text")).toBe(
+    "Opening Keynote - Conference Gamma"
+  );
+  expect(href.searchParams.get("location")).toBe("Main Hall");
+  const details = href.searchParams.get("details") ?? "";
+  expect(details).toContain("Welcome to Conference Gamma");
+  expect(details).toContain(`${baseURL}/Conference-Gamma?viewSession=`);
+});
+
 test("leaving a session modal whose RSVPs are still loading is quiet", async ({
   page,
 }) => {

--- a/tests/unit/google-calendar.test.ts
+++ b/tests/unit/google-calendar.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { googleCalendarUrl } from "@/utils/google-calendar";
+import {
+  DESCRIPTION_MAX_CHARS,
+  googleCalendarUrl,
+} from "@/utils/google-calendar";
 
 const ENTRY = {
   description: "Some **bold** words\n\n- one\n- two",
@@ -43,6 +46,43 @@ describe("googleCalendarUrl", () => {
         "https://sessions.example.org/Conference-Gamma?viewSession=abc",
       ].join("\n\n")
     );
+  });
+
+  it("cuts a long description short and keeps the hosts and link back", () => {
+    const details = new URL(
+      googleCalendarUrl({
+        ...ENTRY,
+        description: "x".repeat(DESCRIPTION_MAX_CHARS + 500),
+      })
+    ).searchParams.get("details");
+
+    const [description, hosts, url] = (details ?? "").split("\n\n");
+    expect(description).toHaveLength(DESCRIPTION_MAX_CHARS);
+    expect(description.endsWith("…")).toBe(true);
+    expect(hosts).toBe("Hosted by Ada Lovelace, Grace Hopper");
+    expect(url).toBe(ENTRY.url);
+  });
+
+  it("cuts between characters, never through an emoji", () => {
+    const details = new URL(
+      googleCalendarUrl({
+        ...ENTRY,
+        description: "😀".repeat(DESCRIPTION_MAX_CHARS + 1),
+      })
+    ).searchParams.get("details");
+
+    const description = (details ?? "").split("\n\n")[0];
+    expect(Array.from(description)).toHaveLength(DESCRIPTION_MAX_CHARS);
+    expect(description).not.toContain("�");
+  });
+
+  it("leaves a description at the limit alone", () => {
+    const description = "y".repeat(DESCRIPTION_MAX_CHARS);
+    const details = new URL(
+      googleCalendarUrl({ ...ENTRY, description })
+    ).searchParams.get("details");
+
+    expect((details ?? "").split("\n\n")[0]).toBe(description);
   });
 
   it("leaves out what the session doesn't have", () => {

--- a/tests/unit/google-calendar.test.ts
+++ b/tests/unit/google-calendar.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { googleCalendarUrl } from "@/utils/google-calendar";
+
+const ENTRY = {
+  description: "Some **bold** words\n\n- one\n- two",
+  end: new Date("2026-10-02T08:30:00.000Z"),
+  hostNames: ["Ada Lovelace", "Grace Hopper"],
+  location: "Main Hall",
+  start: new Date("2026-10-02T07:00:00.000Z"),
+  timezone: "Europe/Berlin",
+  title: "Opening Keynote",
+  url: "https://sessions.example.org/Conference-Gamma?viewSession=abc",
+};
+
+describe("googleCalendarUrl", () => {
+  it("opens Google Calendar's new-event template with the session's basics", () => {
+    const url = new URL(googleCalendarUrl(ENTRY));
+
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://calendar.google.com/calendar/render"
+    );
+    expect(url.searchParams.get("action")).toBe("TEMPLATE");
+    expect(url.searchParams.get("text")).toBe("Opening Keynote");
+    expect(url.searchParams.get("location")).toBe("Main Hall");
+  });
+
+  it("passes the times as UTC instants, shown in the event's zone", () => {
+    const params = new URL(googleCalendarUrl(ENTRY)).searchParams;
+
+    expect(params.get("dates")).toBe("20261002T070000Z/20261002T083000Z");
+    expect(params.get("ctz")).toBe("Europe/Berlin");
+  });
+
+  it("writes the description, hosts and a link back as plain text", () => {
+    const details = new URL(googleCalendarUrl(ENTRY)).searchParams.get(
+      "details"
+    );
+
+    expect(details).toBe(
+      [
+        "Some bold words\none\ntwo",
+        "Hosted by Ada Lovelace, Grace Hopper",
+        "https://sessions.example.org/Conference-Gamma?viewSession=abc",
+      ].join("\n\n")
+    );
+  });
+
+  it("leaves out what the session doesn't have", () => {
+    const params = new URL(
+      googleCalendarUrl({
+        ...ENTRY,
+        description: "",
+        hostNames: [],
+        location: undefined,
+        url: undefined,
+      })
+    ).searchParams;
+
+    expect(params.has("details")).toBe(false);
+    expect(params.has("location")).toBe(false);
+  });
+});

--- a/utils/google-calendar.ts
+++ b/utils/google-calendar.ts
@@ -14,15 +14,28 @@ export type CalendarEntry = {
   url?: string;
 };
 
+// Google answers 400 once the whole URL passes 16 KiB, and its description
+// field holds 8K characters. Percent-encoding can triple a character, so this
+// keeps even all-Unicode text inside both; the link back carries the rest.
+export const DESCRIPTION_MAX_CHARS = 6000;
+
 // Google's "dates" wants basic-format ISO 8601: 20261002T070000Z.
 function utcStamp(date: Date): string {
   return date.toISOString().replace(/[-:]|\.\d{3}/g, "");
 }
 
+// Counted in code points: cutting a string's UTF-16 units can split an emoji,
+// and the lone surrogate left behind encodes as U+FFFD.
+function truncate(text: string): string {
+  const chars = Array.from(text);
+  if (chars.length <= DESCRIPTION_MAX_CHARS) return text;
+  return `${chars.slice(0, DESCRIPTION_MAX_CHARS - 1).join("")}…`;
+}
+
 function details(entry: CalendarEntry): string {
   const hosts =
     entry.hostNames.length > 0 ? `Hosted by ${entry.hostNames.join(", ")}` : "";
-  return [stripMarkdown(entry.description), hosts, entry.url ?? ""]
+  return [truncate(stripMarkdown(entry.description)), hosts, entry.url ?? ""]
     .filter((part) => part !== "")
     .join("\n\n");
 }

--- a/utils/google-calendar.ts
+++ b/utils/google-calendar.ts
@@ -1,0 +1,46 @@
+import { stripMarkdown } from "./markdown";
+
+export type CalendarEntry = {
+  /** Markdown, as the session stores it. */
+  description: string;
+  end: Date;
+  hostNames: string[];
+  location?: string;
+  start: Date;
+  /** The IANA zone the event runs in, so the entry is created in venue time. */
+  timezone: string;
+  title: string;
+  /** Absolute link back to the session, when the caller knows the origin. */
+  url?: string;
+};
+
+// Google's "dates" wants basic-format ISO 8601: 20261002T070000Z.
+function utcStamp(date: Date): string {
+  return date.toISOString().replace(/[-:]|\.\d{3}/g, "");
+}
+
+function details(entry: CalendarEntry): string {
+  const hosts =
+    entry.hostNames.length > 0 ? `Hosted by ${entry.hostNames.join(", ")}` : "";
+  return [stripMarkdown(entry.description), hosts, entry.url ?? ""]
+    .filter((part) => part !== "")
+    .join("\n\n");
+}
+
+/**
+ * A link that opens Google Calendar's new-event form pre-filled with the
+ * session. Nothing is stored on Google's side until the reader saves, so it
+ * needs no account of ours and works behind the site password.
+ */
+export function googleCalendarUrl(entry: CalendarEntry): string {
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    ctz: entry.timezone,
+    dates: `${utcStamp(entry.start)}/${utcStamp(entry.end)}`,
+    text: entry.title,
+  });
+  const text = details(entry);
+  if (text) params.set("details", text);
+  if (entry.location) params.set("location", entry.location);
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}

--- a/utils/hooks.ts
+++ b/utils/hooks.ts
@@ -24,6 +24,19 @@ export function useLocalZone(): string | null {
   );
 }
 
+/**
+ * The site's origin as the browser sees it, or null on the server and during
+ * the first hydration pass. For links that must be absolute to mean anything
+ * once they leave the site, such as a calendar entry's link back.
+ */
+export function useSiteOrigin(): string | null {
+  return useSyncExternalStore(
+    subscribeToNothing,
+    () => window.location.origin,
+    () => null
+  );
+}
+
 export const useScreenWidth = () => {
   const [screenWidth, setScreenWidth] = useState(0);
 


### PR DESCRIPTION
## 👴 Written by Milli

A simple add-on that allows adding events to your google calendar.

Possible extensions:
- Profile setting that hides the button
- `.ics` export of all RSVP'd sessions

Code written by Claude, reviewed and UI tested by me.

<img width="888" height="209" alt="image" src="https://github.com/user-attachments/assets/652b70ca-4319-48a1-9643-44ae04dbe87f" />
<img width="859" height="774" alt="image" src="https://github.com/user-attachments/assets/1a8d982b-4c93-42a8-b4e7-62ccae3c0733" />

## 🤖 Written by [Claude Code](https://claude.com/claude-code)

A scheduled session's details gain an "Add to Google Calendar" link that opens Google's new-event form pre-filled with the title, time, room, hosts, description and a link back to the session. Sessions without a start and end show nothing.

A link into Google's template form rather than an `.ics` download or a subscribable feed: it needs no backend, no exemption from the site password, and the reader sees the entry before saving it. The entry is a copy; a later reschedule does not follow.

- Times travel as UTC instants with the event's zone as `ctz`, so an attendee whose Google Calendar sits in another zone still sees the venue's local time.
- The link back needs the browser's origin, so it is filled in after hydration via `useSyncExternalStore`, the `useLocalZone` idiom; the server-rendered href carries everything else.
- The description goes through `stripMarkdown` and is cut at `DESCRIPTION_MAX_CHARS` with an ellipsis: Google answers 400 once the URL passes 16 KiB and its description field holds 8K characters, while a session description is not capped anywhere; the link back carries the full text.

Files:

- `utils/google-calendar.ts` builds the template URL.
- `utils/hooks.ts` adds `useSiteOrigin`.
- `view-session/add-to-google-calendar.tsx` renders the link; `view-session.tsx` places it next to RSVP and Edit.
- `tests/unit/google-calendar.test.ts` covers the URL builder; `tests/e2e/view-session.spec.ts` gains a case that opens the keynote and inspects the href.
- Changelog and in-app release note.

Testing, on Windows: `bun set-env.ts test bun x playwright test tests/e2e/view-session.spec.ts` passes; `make lint`, `make arch`, `make format-check` and `tsc --noEmit` pass; `make test` passes except four pre-existing path-separator failures in `action-auth-guard.test.ts` and `ci-flaky-summary.test.ts` that are unrelated to this change.

