### PR TITLE
fix: open the profile a link inside an open profile points at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Links to another attendee open their profile** (#1022): following one from inside an open
+  profile — a comment's author, say — left the old one on screen. Closing still returns to the list
+
 ## [3.6.0] - 2026-09-08
 
 ### Added

--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -46,7 +46,7 @@ type Drag = { guestId: string } & Slide;
  * collection is never invisible state.
  */
 export function ProfileModal({
-  guestId: initialGuestId,
+  guestId: urlGuestId,
   view,
   currentUserId,
 }: {
@@ -56,11 +56,31 @@ export function ProfileModal({
 }) {
   // Which profile is on screen, ahead of the URL rather than read off it: a
   // slide has to know where it is going while it is going there. `advanceTo`
-  // keeps the two in step, and the popstate listener below picks up the
-  // navigations that move the URL on their own.
-  const [guestId, setGuestId] = useState(initialGuestId);
-
+  // moves both together; when something else moves the URL — a link to another
+  // profile, Back — the effect below follows it, the popstate listener sooner.
+  const [guestId, setGuestId] = useState(urlGuestId);
+  const [dragged, setDrag] = useState<Drag | null>(null);
   const { matches, everyone, listQuery } = view;
+  // A link to another profile carries no list query, so the one the profile
+  // was opened over is kept here and put back, or closing lands elsewhere.
+  const [openedOver] = useState(listQuery);
+  // The router echoes `advanceTo`'s own pushState back through the prop a render
+  // later; a prop the URL no longer agrees with is such an echo, not a move.
+  useEffect(() => {
+    if (urlGuestId === guestId) return;
+    if (guestIdFromPath(window.location.pathname) !== urlGuestId) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setGuestId(urlGuestId);
+    setDrag(null);
+    if (openedOver && !window.location.search) {
+      window.history.replaceState(
+        null,
+        "",
+        profileHref(urlGuestId, openedOver)
+      );
+    }
+  }, [urlGuestId, guestId, openedOver]);
+
   const collection = matches.some((a) => a.id === guestId) ? matches : everyone;
   const index = collection.findIndex((a) => a.id === guestId);
   const guest = index >= 0 ? collection[index] : null;
@@ -104,7 +124,6 @@ export function ProfileModal({
 
   const viewport = useRef<HTMLDivElement>(null);
   const row = useRef<HTMLDivElement>(null);
-  const [dragged, setDrag] = useState<Drag | null>(null);
   // The row's styling needs the viewport width even when nothing is being
   // dragged, so it lives as state instead of riding along on each Drag.
   const [width, setWidth] = useState(0);
@@ -119,10 +138,9 @@ export function ProfileModal({
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
-  // Browser Back/Forward moves through the history, not through this state.
-  // Reading through pushes one entry per profile, so going back has to land the
-  // modal on the profile the URL names; pushState does not fire popstate, so
-  // only genuine navigations sync here.
+  // Back/Forward could wait for the effect above, but that runs only once the
+  // router's transition commits — after a fetch, for a profile it has let go
+  // of. Reading the URL here lands the modal the moment the entry changes.
   useEffect(() => {
     const onPop = () => {
       const id = guestIdFromPath(window.location.pathname);

--- a/tests/e2e/profile-comments.spec.ts
+++ b/tests/e2e/profile-comments.spec.ts
@@ -16,7 +16,7 @@ async function openProfile(page: Page, name: string) {
 
 // selectUser logs out and back in; navigating before that settles aborts the
 // request and drops the selection.
-async function actAs(page: Page, name: RegExp) {
+async function actAs(page: Page, name: string | RegExp) {
   await selectUser(page, name);
   await expect(page.getByRole("button", { name: /^Your name:/ })).toBeVisible();
 }
@@ -156,6 +156,41 @@ test("leaves a deep-linked profile scrollable back to its top", async ({
   await expect
     .poll(async () => (await photo.boundingBox())?.y)
     .toBeCloseTo(top, 0);
+});
+
+// Linh and Jean-Pierre are nobody else's subject, so the comment count here is
+// this test's alone.
+test("opens a comment author's profile from the profile it was left on", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await actAs(page, "Linh Nguyen");
+
+  await page.getByLabel("Search").fill("Dubois");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(page).toHaveURL(/[?&]q=Dubois/);
+
+  const profile = await openProfile(page, "Jean-Pierre Dubois");
+  await profile.getByPlaceholder("Add a comment").fill("hello from Linh");
+  await profile.getByRole("button", { name: "Comment", exact: true }).click();
+  await expect(postedComment(profile, "hello from Linh").first()).toBeVisible();
+
+  // The author's name is a real link to their profile, not a Prev/Next step,
+  // so the modal has to pick the new profile up off the URL.
+  await profile.getByRole("link", { name: "Linh Nguyen" }).first().click();
+  const author = page.getByRole("dialog", { name: "Linh Nguyen" });
+  await expect(author).toBeVisible();
+  await expect(
+    author.getByRole("heading", { name: "0 comments" })
+  ).toBeVisible();
+
+  // The link carries no list context, so the modal has to keep the search it
+  // was opened over: closing still lands on the list reading started from.
+  await author.getByRole("button", { name: "Close" }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page).toHaveURL(/\/guests\?q=Dubois/);
+  await expect(page.getByLabel("Search")).toHaveValue("Dubois");
 });
 
 // A section that can't reach its endpoint used to sit on a "Loading


### PR DESCRIPTION
Fixes schellingboard/schellingboard#1022

`ProfileModal` seeded its guest from a `useState` initializer and only ever moved it through its own Prev/Next, so a router navigation to another profile — a comment author's link, say — changed the URL and nothing else.

The state now follows the `guestId` prop, guarded against the router echoing the modal's own `pushState` back a render late (which must not snap a slide in flight back to where it started). New E2E test posts a comment on a profile, follows the author's link from inside it and expects the author's profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
