### PR TITLE
fix: list the viewer's 1-on-1s in the Text and RSVP'd views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Your 1-on-1s in the Text and RSVP'd views** (#1023): Text lists them among the sessions and
+  RSVP'd the confirmed ones, where until now only the Grid view showed them
 - **Links to another attendee open their profile** (#1022): following one from inside an open
   profile — a comment's author, say — left the old one on screen. Closing still returns to the list
 

--- a/app/(site)/[eventSlug]/day-text.tsx
+++ b/app/(site)/[eventSlug]/day-text.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { useSearchParams } from "next/navigation";
 import { SessionText } from "./session-text";
+import { MeetingText } from "./meeting-text";
+import { useMyMeetings } from "./use-meetings";
 import { DateTime } from "luxon";
 import { useContext } from "react";
 import { UserContext, EventContext } from "../context";
 import type { DayWithSessions } from "@/app/(site)/context";
 import type { Rsvp, Location, Session } from "@/db/repositories/interfaces";
+import { dayTextEntries } from "@/utils/day-text-entries";
 import { containsIgnoringAccents } from "@/utils/utils";
 
 export function DayText(props: {
@@ -21,6 +24,7 @@ export function DayText(props: {
   const searchParams = useSearchParams();
   const { user: currentUser } = useContext(UserContext);
   const { event } = useContext(EventContext);
+  const { meetings } = useMyMeetings();
   const timezone = event?.timezone ?? "UTC";
   const locParams = searchParams?.getAll("loc");
   const locationsFromParams = locations.filter((loc) =>
@@ -56,6 +60,14 @@ export function DayText(props: {
         (currentUser && session.hosts.some((h) => h.id === currentUser))
     );
   }
+  // Past the ?loc= filter, as on the grid: a 1-on-1 is in no room.
+  const entries = dayTextEntries({
+    sessions,
+    meetings: meetings ?? [],
+    day,
+    search,
+    rsvpOnly,
+  });
   return (
     <div className="flex flex-col max-w-3xl mx-auto">
       <h2 className="text-2xl font-bold w-full text-left">
@@ -64,23 +76,34 @@ export function DayText(props: {
           .toFormat("EEEE, MMMM d")}{" "}
       </h2>
       <div className="flex flex-col divide-y divide-line-subtle">
-        {sessions.length > 0 ? (
+        {entries.length > 0 ? (
           <>
-            {sessions.map((session) => (
-              <SessionText
-                key={`${session.title}+${session.startTime?.toISOString()}+${session.endTime?.toISOString()}`}
-                session={session}
-                locations={locations.filter((loc) =>
-                  session.locations.some((l) => l.id === loc.id)
-                )}
-                eventSlug={eventSlug}
-              />
-            ))}
+            {entries.map(({ key, session, meeting }) =>
+              session ? (
+                <SessionText
+                  key={key}
+                  session={session}
+                  locations={locations.filter((loc) =>
+                    session.locations.some((l) => l.id === loc.id)
+                  )}
+                  eventSlug={eventSlug}
+                />
+              ) : (
+                <MeetingText
+                  key={key}
+                  meeting={meeting}
+                  eventSlug={eventSlug}
+                />
+              )
+            )}
           </>
         ) : (
-          <p className="text-fg-subtle italic text-sm w-full text-left">
-            No sessions
-          </p>
+          // Not before the 1-on-1s are in: one of them may yet fill the day.
+          meetings !== null && (
+            <p className="text-fg-subtle italic text-sm w-full text-left">
+              No sessions
+            </p>
+          )
         )}
       </div>
     </div>

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/app/input";
 import { ModalCloseButton } from "@/app/components/modal-close-button";
 import { EventContext } from "@/app/(site)/context";
 import { clashLines } from "@/utils/meeting-clash-text";
-import { canCancel, statusLine } from "@/utils/meeting-rules";
+import { canCancel, meetingTitle, statusLine } from "@/utils/meeting-rules";
 import { dismissViewMeeting } from "./modal-nav";
 import { useMyMeetings } from "./use-meetings";
 
@@ -110,7 +110,7 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
         ) : (
           <div className="flex flex-col gap-4">
             <h2 className="text-xl font-bold text-fg pr-8">
-              1-on-1 with {meeting.otherName}
+              {meetingTitle(meeting)}
             </h2>
 
             <dl className="flex flex-col gap-1 text-sm">

--- a/app/(site)/[eventSlug]/meeting-state-classes.ts
+++ b/app/(site)/[eventSlug]/meeting-state-classes.ts
@@ -1,0 +1,8 @@
+import type { MeetingViewStatus } from "@/utils/meeting-views";
+
+// Pending reads as unfinished business, not a plan.
+export function meetingStateClasses(status: MeetingViewStatus): string {
+  return status === "accepted"
+    ? "bg-brand-tint border-brand-accent"
+    : "bg-surface-muted border-dashed border-line";
+}

--- a/app/(site)/[eventSlug]/meeting-text.tsx
+++ b/app/(site)/[eventSlug]/meeting-text.tsx
@@ -1,0 +1,66 @@
+import clsx from "clsx";
+import { DateTime } from "luxon";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useContext } from "react";
+import { UserGroupIcon } from "@heroicons/react/24/solid";
+import type { MeetingView } from "@/utils/meeting-views";
+import { blockStatus, meetingTitle } from "@/utils/meeting-rules";
+import { EventContext } from "../context";
+import { meetingStateClasses } from "./meeting-state-classes";
+import { viewMeetingLinkFromOwner } from "./modal-nav";
+
+export function MeetingText({
+  meeting,
+  eventSlug,
+}: {
+  meeting: MeetingView;
+  eventSlug: string;
+}) {
+  const searchParams = useSearchParams();
+  const { event } = useContext(EventContext);
+  const timezone = event?.timezone ?? "UTC";
+  const weekday = DateTime.fromISO(meeting.slotStart)
+    .setZone(timezone)
+    .toFormat("EEEE");
+
+  return (
+    <div className="px-1.5 rounded h-full min-h-10 pt-5 pb-8 relative">
+      <div className="flex items-start gap-2">
+        <h1 className="font-bold leading-tight flex-1 flex items-center gap-1">
+          <Link
+            {...viewMeetingLinkFromOwner(searchParams, eventSlug, meeting.id)}
+            className="cursor-pointer hover:text-link transition-colors flex items-center gap-1"
+          >
+            {meetingTitle(meeting)}
+          </Link>
+        </h1>
+        <div className="flex items-center" title="Only you see this 1-on-1">
+          <UserGroupIcon className="h-4 w-4" />
+        </div>
+      </div>
+      <div className="flex flex-col sm:flex-row justify-between mt-2 sm:items-center gap-2">
+        <div className="flex gap-2 text-sm text-fg-subtle">
+          <span>
+            {weekday}, {meeting.timeLabel}
+          </span>
+          •<span>{meeting.meetingPoint}</span>
+        </div>
+        <span
+          className={clsx(
+            "rounded-full py-0.5 px-2 text-xs font-semibold w-fit border-2",
+            meetingStateClasses(meeting.status),
+            meeting.status === "accepted" ? "text-fg" : "text-fg-muted"
+          )}
+        >
+          {blockStatus(meeting)}
+        </span>
+      </div>
+      {meeting.message && (
+        <p className="text-sm mt-2 whitespace-pre-line line-clamp-3">
+          “{meeting.message}”
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/(site)/[eventSlug]/meetings-col.tsx
+++ b/app/(site)/[eventSlug]/meetings-col.tsx
@@ -15,22 +15,18 @@ import { EventContext, useSlotIncrement } from "@/app/(site)/context";
 import { Modal } from "@/app/components/modal";
 import { clashLines } from "@/utils/meeting-clash-text";
 import {
+  blockStatus,
   blockTimeLabel,
+  meetingTitle,
+  needsReply,
   slotSummaryLine,
   statusLine,
 } from "@/utils/meeting-rules";
+import { meetingStateClasses } from "./meeting-state-classes";
 import { isPlainLeftClick, viewMeetingLinkFromOwner } from "./modal-nav";
 import { NowLine } from "./now-line";
 import { BookMeeting } from "./book-meeting";
 import { Tooltip } from "./tooltip";
-
-/** The word of status a block has room for; the tooltip says the rest. */
-function blockStatus(meeting: MeetingView): string {
-  if (meeting.status === "accepted") return "confirmed";
-  return meeting.role === "recipient"
-    ? "needs your reply"
-    : "waiting for reply";
-}
 
 /** "14:30", in the event's zone, for a control's accessible name. */
 function slotLabel(start: string, timezone: string): string {
@@ -92,17 +88,12 @@ function SlotCell({
   );
 }
 
-const needsReply = (meeting: MeetingView) =>
-  meeting.status === "pending" && meeting.role === "recipient";
-
 // What the block has no room for, on hover -- the pattern a session block
 // already follows. A tap still opens the modal, where all of it is anyway.
 function MeetingSummary({ meeting }: { meeting: MeetingView }) {
   return (
     <div className="p-2 space-y-1">
-      <p className="text-sm font-semibold text-fg">
-        1-on-1 with {meeting.otherName}
-      </p>
+      <p className="text-sm font-semibold text-fg">{meetingTitle(meeting)}</p>
       <p className="text-xs text-fg-muted">
         {meeting.timeLabel} · {meeting.meetingPoint}
       </p>
@@ -169,11 +160,8 @@ function MeetingBlock({
       <Link
         {...viewMeetingLinkFromOwner(searchParams, eventSlug, meeting.id)}
         className={clsx(
-          "flex-1 min-w-0 rounded px-1 py-0.5 overflow-hidden font-roboto",
-          meeting.status === "accepted"
-            ? "bg-brand-tint border-2 border-brand-accent"
-            : // Pending reads as unfinished business, not a plan.
-              "bg-surface-muted border-2 border-dashed border-line"
+          "flex-1 min-w-0 rounded border-2 px-1 py-0.5 overflow-hidden font-roboto",
+          meetingStateClasses(meeting.status)
         )}
       >
         <p className="font-medium text-xs leading-[1.15] line-clamp-1 text-fg">
@@ -226,15 +214,13 @@ function StackEntry({
     >
       <Link
         {...viewMeetingLinkFromOwner(searchParams, eventSlug, meeting.id)}
-        aria-label={`1-on-1 with ${meeting.otherName} at ${slotLabel(
+        aria-label={`${meetingTitle(meeting)} at ${slotLabel(
           meeting.slotStart,
           timezone
         )} — ${blockStatus(meeting)}`}
         className={clsx(
           "flex flex-1 min-w-0 items-center gap-1 overflow-hidden rounded-sm border-l-4 px-1 font-roboto",
-          meeting.status === "accepted"
-            ? "bg-brand-tint border-brand-accent"
-            : "bg-surface-muted border-dashed border-line"
+          meetingStateClasses(meeting.status)
         )}
       >
         <span className="truncate text-[11px] leading-none font-medium text-fg">

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -311,6 +311,9 @@ same time is ordinary. They sit one above the other, and where there are more
 of them than the slot has room to name, the block says how many there are and
 opens the list of them instead.
 
+The **Text** view lists them too, in among the sessions by time, with the same
+name, place and state. **RSVP'd** lists only the confirmed ones.
+
 The column is yours alone — nobody else sees it, and it stays put when you
 filter the schedule down to one room. It is there on every day of the event
 once you take part at all — open to 1-on-1s, or with one arranged — so the

--- a/tests/e2e/meetings-column.spec.ts
+++ b/tests/e2e/meetings-column.spec.ts
@@ -3,10 +3,11 @@ import { loginAndGoto } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
 
 /**
- * The schedule's 1-on-1 column when several share a slot. The fixture is
- * seeded rather than booked through the UI here — arranging five 1-on-1s takes
- * five attendees and five user switches, and what is under test is how the
- * column draws them. Booking one is covered by meetings-request.spec.ts.
+ * The viewer's 1-on-1s on the schedule: the grid's column when several share a
+ * slot, and the text views. The fixture is seeded rather than booked through
+ * the UI here — arranging five 1-on-1s takes five attendees and five user
+ * switches, and what is under test is how the schedule draws them. Booking one
+ * is covered by meetings-request.spec.ts.
  *
  * Conference Gamma is the seeded event in its scheduling phase, and Zanele's
  * first morning there holds two 1-on-1s at 10:00 and three at 11:00
@@ -66,6 +67,43 @@ test.describe("parallel 1-on-1s on the schedule", () => {
     await listed[1].click();
     await expect(
       details.getByRole("heading", { name: `1-on-1 with ${AT_ELEVEN[1]}` })
+    ).toBeVisible();
+  });
+});
+
+// The Text and RSVP'd views used to list sessions only, so switching to either
+// made the viewer's own 1-on-1s vanish from the schedule (#1023).
+test.describe("1-on-1s in the Text and RSVP'd views", () => {
+  test("Text lists them all, RSVP'd only the confirmed", async ({ page }) => {
+    await loginAndGoto(page, "/guests");
+    await selectUser(page, VIEWER);
+    await page.getByRole("link", { name: "Conference Gamma" }).first().click();
+
+    const [confirmed, waiting] = AT_TEN.map((name) =>
+      page.getByRole("link", { name: `1-on-1 with ${name}`, exact: true })
+    );
+    const details = page.getByRole("dialog", { name: "1-on-1 details" });
+
+    await page.getByRole("button", { name: "Text" }).click();
+    // Only the text views have a search box, so the grid is gone.
+    await expect(page.getByPlaceholder("Search sessions")).toBeVisible();
+    await expect(confirmed).toBeVisible();
+    await expect(waiting).toBeVisible();
+    await waiting.click();
+    await expect(
+      details.getByRole("heading", { name: `1-on-1 with ${AT_TEN[1]}` })
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(details).toBeHidden();
+
+    // Waiting on an answer is no commitment yet; its going also shows the
+    // Text view has given way.
+    await page.getByRole("button", { name: "RSVP'd" }).click();
+    await expect(waiting).toBeHidden();
+    await expect(confirmed).toBeVisible();
+    await confirmed.click();
+    await expect(
+      details.getByRole("heading", { name: `1-on-1 with ${AT_TEN[0]}` })
     ).toBeVisible();
   });
 });

--- a/tests/unit/day-text-entries.test.ts
+++ b/tests/unit/day-text-entries.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+
+import { dayTextEntries } from "@/utils/day-text-entries";
+import type { MeetingView } from "@/utils/meeting-views";
+
+const DAY = {
+  start: new Date("2026-10-01T09:00:00.000Z"),
+  end: new Date("2026-10-01T18:00:00.000Z"),
+};
+
+const at = (hour: number) =>
+  new Date(DAY.start.getTime() + (hour - 9) * 60 * 60 * 1000).toISOString();
+
+const session = (id: string, hour: number) => ({
+  id,
+  startTime: new Date(at(hour)),
+});
+
+function meeting(
+  id: string,
+  hour: number,
+  patch?: Partial<MeetingView>
+): MeetingView {
+  return {
+    id,
+    status: "accepted",
+    role: "requester",
+    otherName: "Grace",
+    slotStart: at(hour),
+    slotEnd: at(hour + 1),
+    dayLabel: "Thu 1 Oct",
+    timeLabel: "10:00 – 11:00",
+    meetingPoint: "Coffee bar",
+    message: "",
+    cancelNote: "",
+    clashes: [],
+    ...patch,
+  };
+}
+
+const keys = (
+  sessions: ReturnType<typeof session>[],
+  meetings: MeetingView[],
+  { search = "", rsvpOnly = false } = {}
+) =>
+  dayTextEntries({ sessions, meetings, day: DAY, search, rsvpOnly }).map(
+    (entry) => entry.key
+  );
+
+describe("dayTextEntries", () => {
+  it("puts the viewer's 1-on-1s in among the sessions by time", () => {
+    expect(
+      keys([session("s10", 10), session("s12", 12)], [meeting("m11", 11)])
+    ).toEqual(["s10", "m11", "s12"]);
+  });
+
+  // The order the grid stacks a slot in, so both views list it alike.
+  it("orders 1-on-1s that share a start by name", () => {
+    expect(
+      keys(
+        [],
+        [
+          meeting("a", 10, { otherName: "Samuel" }),
+          meeting("b", 10, { otherName: "Leilani" }),
+        ]
+      )
+    ).toEqual(["b", "a"]);
+  });
+
+  it("leaves out 1-on-1s that are over with or on another day", () => {
+    expect(
+      keys(
+        [],
+        [
+          meeting("declined", 10, { status: "declined" }),
+          meeting("expired", 11, { status: "expired" }),
+          meeting("tomorrow", 33),
+          meeting("pending", 12, { status: "pending" }),
+        ]
+      )
+    ).toEqual(["pending"]);
+  });
+
+  // RSVP'd lists what the viewer is committed to; a request is not that yet.
+  it("keeps only the confirmed 1-on-1s in RSVP'd", () => {
+    expect(
+      keys(
+        [],
+        [
+          meeting("confirmed", 10),
+          meeting("asked", 11, { status: "pending", role: "recipient" }),
+          meeting("asking", 12, { status: "pending", role: "requester" }),
+        ],
+        { rsvpOnly: true }
+      )
+    ).toEqual(["confirmed"]);
+  });
+
+  it("finds a 1-on-1 by its title, meeting point or message", () => {
+    const one = [
+      meeting("m", 10, {
+        otherName: "Leilani",
+        meetingPoint: "Library",
+        message: "About the slides",
+      }),
+    ];
+
+    for (const search of ["1-on-1 with leilani", "library", "slides"]) {
+      expect(keys([], one, { search })).toEqual(["m"]);
+    }
+    expect(keys([], one, { search: "Samuel" })).toEqual([]);
+  });
+});

--- a/tests/unit/meeting-rules.test.ts
+++ b/tests/unit/meeting-rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  blockStatus,
   blockTimeLabel,
   canCancel,
   slotSummaryLine,
@@ -114,6 +115,26 @@ describe("blockTimeLabel", () => {
 
     expect(blockTimeLabel(uneven, BERLIN)).toBe("10:00 – 11:30");
     expect(blockTimeLabel([...uneven].reverse(), BERLIN)).toBe("10:00 – 11:30");
+  });
+});
+
+describe("blockStatus", () => {
+  it("tells each side whose turn it is", () => {
+    expect(blockStatus({ status: "pending", role: "recipient" })).toBe(
+      "needs your reply"
+    );
+    expect(blockStatus({ status: "pending", role: "requester" })).toBe(
+      "waiting for reply"
+    );
+  });
+
+  it("names what became of it, the same to both sides", () => {
+    for (const role of ["requester", "recipient"] as const) {
+      expect(blockStatus({ status: "accepted", role })).toBe("confirmed");
+      expect(blockStatus({ status: "declined", role })).toBe("declined");
+      expect(blockStatus({ status: "canceled", role })).toBe("canceled");
+      expect(blockStatus({ status: "expired", role })).toBe("unanswered");
+    }
   });
 });
 

--- a/utils/day-text-entries.ts
+++ b/utils/day-text-entries.ts
@@ -1,0 +1,55 @@
+import type { Session } from "@/db/repositories/interfaces";
+import { compareMeetings, meetingsForDay } from "@/utils/meeting-column";
+import { meetingTitle } from "@/utils/meeting-rules";
+import type { MeetingView } from "@/utils/meeting-views";
+import { containsIgnoringAccents } from "@/utils/utils";
+
+type ListedSession = Pick<Session, "id" | "startTime">;
+
+export type DayTextEntry<S extends ListedSession> =
+  | { key: string; session: S; meeting: null }
+  | { key: string; session: null; meeting: MeetingView };
+
+/**
+ * A day of the Text and RSVP'd views, 1-on-1s among the sessions by time.
+ * RSVP'd lists commitments, so it keeps only the confirmed ones (#1023).
+ */
+export function dayTextEntries<S extends ListedSession>({
+  sessions,
+  meetings,
+  day,
+  search,
+  rsvpOnly,
+}: {
+  sessions: S[];
+  meetings: MeetingView[];
+  day: { start: Date; end: Date };
+  search: string;
+  rsvpOnly: boolean;
+}): DayTextEntry<S>[] {
+  const mine = meetingsForDay(meetings, day)
+    .filter((meeting) => !rsvpOnly || meeting.status === "accepted")
+    .filter((meeting) => meetingMatchesSearch(meeting, search))
+    .sort(compareMeetings);
+  const entries: DayTextEntry<S>[] = [
+    ...sessions.map((session) => ({
+      key: session.id,
+      session,
+      meeting: null,
+    })),
+    ...mine.map((meeting) => ({ key: meeting.id, session: null, meeting })),
+  ];
+  const startOf = (entry: DayTextEntry<S>) =>
+    entry.meeting === null
+      ? (entry.session.startTime?.getTime() ?? 0)
+      : new Date(entry.meeting.slotStart).getTime();
+  return entries.sort((a, b) => startOf(a) - startOf(b));
+}
+
+function meetingMatchesSearch(meeting: MeetingView, search: string) {
+  return (
+    containsIgnoringAccents(meetingTitle(meeting), search) ||
+    containsIgnoringAccents(meeting.meetingPoint, search) ||
+    containsIgnoringAccents(meeting.message, search)
+  );
+}

--- a/utils/meeting-column.ts
+++ b/utils/meeting-column.ts
@@ -20,6 +20,18 @@ export function meetingsForDay(
 }
 
 /**
+ * Earliest first, then by name: an order the reader can predict, and one a
+ * list keeps from one read to the next.
+ */
+export function compareMeetings(a: MeetingView, b: MeetingView): number {
+  return (
+    a.slotStart.localeCompare(b.slotStart) ||
+    a.otherName.localeCompare(b.otherName) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+/**
  * Whether the viewer gets the column at all. Decided for the whole event
  * rather than day by day, so the rooms line up from one day to the next.
  */
@@ -112,14 +124,7 @@ export function meetingColumnRows({
       const row = rowOf(meeting.slotStart);
       return { meeting, row, end: row + spanOf(meeting, row) };
     })
-    // Earliest first, then by name: an order the reader can predict, and one a
-    // block keeps from one read to the next.
-    .sort(
-      (a, b) =>
-        a.meeting.slotStart.localeCompare(b.meeting.slotStart) ||
-        a.meeting.otherName.localeCompare(b.meeting.otherName) ||
-        a.meeting.id.localeCompare(b.meeting.id)
-    );
+    .sort((a, b) => compareMeetings(a.meeting, b.meeting));
 
   // Everything that overlaps goes in one block: two grid items in the same
   // column draw over each other, and unequal lengths make that a wider net

--- a/utils/meeting-rules.ts
+++ b/utils/meeting-rules.ts
@@ -44,7 +44,7 @@ export function slotSummaryLine(
   meetings: Pick<MeetingView, "status" | "role">[]
 ): string {
   const pending = meetings.filter((m) => m.status === "pending");
-  const yours = pending.filter((m) => m.role === "recipient").length;
+  const yours = pending.filter(needsReply).length;
   if (yours > 0) {
     return yours === 1 ? "1 needs your reply" : `${yours} need your reply`;
   }
@@ -54,6 +54,34 @@ export function slotSummaryLine(
       : `${pending.length} waiting for reply`;
   }
   return "all confirmed";
+}
+
+export function meetingTitle(meeting: Pick<MeetingView, "otherName">): string {
+  return `1-on-1 with ${meeting.otherName}`;
+}
+
+export function needsReply(
+  meeting: Pick<MeetingView, "status" | "role">
+): boolean {
+  return meeting.status === "pending" && meeting.role === "recipient";
+}
+
+/** The state in a couple of words, where `statusLine` would not fit. */
+export function blockStatus(
+  meeting: Pick<MeetingView, "status" | "role">
+): string {
+  switch (meeting.status) {
+    case "pending":
+      return needsReply(meeting) ? "needs your reply" : "waiting for reply";
+    case "accepted":
+      return "confirmed";
+    case "declined":
+      return "declined";
+    case "canceled":
+      return "canceled";
+    case "expired":
+      return "unanswered";
+  }
 }
 
 /** What has become of the request, in the words of whoever is reading. */


### PR DESCRIPTION
DayText only ever rendered day.sessions, so switching away from the grid
made a guest's own 1-on-1s disappear. Text now interleaves the live ones
by time, each as a MeetingText entry shaped like the sessions around it
and opening the same 1-on-1 modal. RSVP'd lists commitments, so it keeps
only the confirmed ones. As on the grid they ignore the room filter and
same-slot ones sort by name; the search matches on the other person's
name, the meeting point and their message. "No sessions" waits for the
meetings to load, and sessions are keyed by id: title and time are not
unique.

blockStatus, now shared, covers every state; the 1-on-1 title and the
confirmed/pending classes each have one definition.

fixes schellingboard/schellingboard#1023

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=57910eec03206e19a6508e63a2090d3797c67fa8 -->