### PR TITLE
Mobile schedule agenda view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Agenda view (beta)**: a list of sessions and your 1-on-1s in start-time order, all rooms
+  together, as an alternative to the grid on narrow screens
+
 ### Fixed
 
 - **Links to another attendee open their profile** (#1022): following one from inside an open

--- a/app/(site)/[eventSlug]/day-agenda.tsx
+++ b/app/(site)/[eventSlug]/day-agenda.tsx
@@ -1,0 +1,314 @@
+"use client";
+import {
+  Fragment,
+  useContext,
+  useMemo,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import clsx from "clsx";
+import {
+  AcademicCapIcon,
+  CheckCircleIcon,
+  UserIcon,
+} from "@heroicons/react/24/solid";
+import type { Location, Session } from "@/db/repositories/interfaces";
+import type { DayWithSessions } from "@/app/(site)/context";
+import {
+  EventContext,
+  UserContext,
+  useBreakMinutes,
+  useSlotIncrement,
+} from "@/app/(site)/context";
+import { getNowOffsetPx } from "@/utils/slots";
+import {
+  agendaGroups,
+  nowMarkerIndex,
+  timeState,
+  type TimeState,
+} from "@/utils/agenda";
+import type { MeetingView } from "@/utils/meeting-views";
+import { meetingsForDay } from "@/utils/meeting-column";
+import { statusLine } from "@/utils/meeting-rules";
+import { useMyMeetings } from "./use-meetings";
+import {
+  formatDayLabel,
+  formatOptionalTime,
+  formatSlotLabel,
+  TIME_FORMAT,
+} from "@/utils/utils";
+import { LockIcon } from "../lock-icon";
+import {
+  viewMeetingLinkFromOwner,
+  viewSessionLinkFromOwner,
+} from "./modal-nav";
+
+// One day as a list, every session under the time it starts: what a narrow
+// screen can scroll through, where the grid has to be scrolled both ways.
+export function DayAgenda(props: {
+  day: DayWithSessions;
+  locations: Location[];
+  eventSlug: string;
+}) {
+  const { day, locations, eventSlug } = props;
+  const { event, now } = useContext(EventContext);
+  const timezone = event?.timezone ?? "UTC";
+  const searchParams = useSearchParams();
+  const slotIncrement = useSlotIncrement();
+  const breakMinutes = useBreakMinutes();
+  const { meetings } = useMyMeetings();
+  const groups = useMemo(() => {
+    const locParams = searchParams?.getAll("loc") ?? [];
+    const locationsFromParams = locations.filter((loc) =>
+      locParams.includes(loc.name)
+    );
+    const includedLocations =
+      locationsFromParams.length === 0 ? locations : locationsFromParams;
+    return agendaGroups({
+      sessions: day.sessions.filter((session) =>
+        includedLocations.some((loc) =>
+          session.locations.some((l) => l.id === loc.id)
+        )
+      ),
+      meetings: meetingsForDay(meetings ?? [], day),
+      locations,
+      breakMinutes,
+    }).map((group) => ({
+      ...group,
+      label: formatSlotLabel(group.start, day.start, timezone),
+    }));
+  }, [day, locations, searchParams, meetings, breakMinutes, timezone]);
+  // Same condition as the grid's now line, so "Now" in the toolbar always has
+  // something to jump to when it is offered.
+  const nowIndex =
+    getNowOffsetPx(day, now, slotIncrement) === null
+      ? null
+      : nowMarkerIndex(groups, now);
+  const headingId = `agenda-day-${day.id}`;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="w-full max-w-3xl mx-auto px-2"
+    >
+      <h2 id={headingId} className="pt-4 pb-1 text-lg font-bold">
+        {formatDayLabel(day, timezone)}
+      </h2>
+      {groups.length === 0 && (
+        <p className="text-fg-subtle italic text-sm">No sessions</p>
+      )}
+      {groups.map((group, i) => {
+        return (
+          <Fragment key={group.start.getTime()}>
+            {nowIndex === i && <NowMarker now={now} timezone={timezone} />}
+            <section aria-label={group.label}>
+              <h3 className="sticky top-0 z-10 bg-surface border-b border-line-subtle py-1 text-sm font-semibold">
+                {group.label}
+              </h3>
+              <ul className="divide-y divide-line-subtle">
+                {group.meetings.map((meeting) => (
+                  <MeetingRow
+                    key={meeting.id}
+                    meeting={meeting}
+                    eventSlug={eventSlug}
+                    timezone={timezone}
+                  />
+                ))}
+                {group.sessions.map((session) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    start={group.start}
+                    locations={locations}
+                    eventSlug={eventSlug}
+                    timezone={timezone}
+                  />
+                ))}
+              </ul>
+            </section>
+          </Fragment>
+        );
+      })}
+      {nowIndex === groups.length && (
+        <NowMarker now={now} timezone={timezone} />
+      )}
+    </section>
+  );
+}
+
+// The agenda's counterpart of the grid's red now line; carries the same test
+// id so the toolbar's "Now" scrolls to it unchanged.
+function NowMarker(props: { now: Date; timezone: string }) {
+  return (
+    <div
+      data-testid="now-line"
+      className="flex items-center gap-2 py-1 text-xs font-semibold text-danger-fg"
+    >
+      <span aria-hidden className="h-0.5 flex-1 bg-danger" />
+      Now · {formatOptionalTime(props.now, props.timezone, TIME_FORMAT)}
+      <span aria-hidden className="h-0.5 flex-1 bg-danger" />
+    </div>
+  );
+}
+
+function AgendaRow(props: {
+  state: TimeState;
+  swatchClass: string;
+  title: ReactNode;
+  details: ReactNode;
+  trailing?: ReactNode;
+  link?: ComponentProps<typeof Link>;
+}) {
+  const { state, swatchClass, title, details, trailing, link } = props;
+  const body = (
+    <>
+      <span
+        aria-hidden
+        className={clsx(
+          "w-1 shrink-0 rounded-full",
+          swatchClass,
+          state === "ended" && "opacity-40"
+        )}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-start gap-1 text-sm font-medium leading-tight">
+          {title}
+        </span>
+        <span className="block text-xs text-fg-subtle">
+          {state === "running" && (
+            <span className="mr-1 rounded bg-danger px-1 font-semibold text-on-danger">
+              Now
+            </span>
+          )}
+          {details}
+        </span>
+      </span>
+      {trailing && (
+        <span className="flex shrink-0 items-center gap-1 self-start text-xs text-fg-subtle">
+          {trailing}
+        </span>
+      )}
+    </>
+  );
+  const className = clsx(
+    "flex gap-2 py-2",
+    link && "hover:bg-surface-hover",
+    state === "ended" && "text-fg-muted"
+  );
+  return (
+    <li>
+      {link ? (
+        <Link {...link} className={className}>
+          {body}
+        </Link>
+      ) : (
+        <div className={className}>{body}</div>
+      )}
+    </li>
+  );
+}
+
+function SessionRow(props: {
+  session: Session;
+  /** The group's shown start, which is the session's too. */
+  start: Date;
+  locations: Location[];
+  eventSlug: string;
+  timezone: string;
+}) {
+  const { session, start, locations, eventSlug, timezone } = props;
+  const searchParams = useSearchParams();
+  const { user } = useContext(UserContext);
+  const { rsvpdForSession, localSessions, now } = useContext(EventContext);
+  const state = timeState(start, session.endTime ?? start, now);
+  const until = `until ${formatOptionalTime(session.endTime, timezone, TIME_FORMAT)}`;
+  // Through the event's visible rooms, as the other views: a session's own
+  // list can still name a room since hidden.
+  const inRooms = locations.filter((loc) =>
+    session.locations.some((l) => l.id === loc.id)
+  );
+  const rooms =
+    inRooms.length === locations.length && inRooms.length > 1
+      ? "All rooms"
+      : inRooms.map((r) => r.name).join(", ");
+  const color = inRooms[0]?.color;
+
+  if (session.blocker) {
+    return (
+      <AgendaRow
+        state={state}
+        swatchClass="bg-line"
+        title={session.title || "Blocked"}
+        details={`${rooms} · ${until}`}
+      />
+    );
+  }
+
+  const rsvpd = user ? rsvpdForSession(session.id) : false;
+  const isHost = !!user && session.hosts.some((h) => h.id === user);
+  const numRsvps =
+    localSessions.find((s) => s.id === session.id)?.numRsvps ??
+    session.numRsvps;
+  const hosts = session.hosts.map((h) => h.name).join(", ");
+  return (
+    <AgendaRow
+      state={state}
+      swatchClass={clsx("loc-swatch", color && `loc-${color}`)}
+      link={viewSessionLinkFromOwner(searchParams, eventSlug, session.id)}
+      title={
+        <>
+          {session.closed && (
+            <LockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-fg-muted" />
+          )}
+          <span className="line-clamp-2">{session.title}</span>
+        </>
+      }
+      details={[rooms, until, hosts].filter(Boolean).join(" · ")}
+      trailing={
+        <>
+          {isHost && (
+            <AcademicCapIcon
+              className="h-4 w-4"
+              role="img"
+              aria-label="You are hosting this session"
+            />
+          )}
+          {rsvpd && (
+            <CheckCircleIcon
+              className="h-4 w-4"
+              role="img"
+              aria-label="You have RSVP'd to this session"
+            />
+          )}
+          <UserIcon aria-hidden className="h-3 w-3" />
+          {numRsvps}
+        </>
+      }
+    />
+  );
+}
+
+// One of the viewer's own 1-on-1s; opens the same popup as the grid's column.
+function MeetingRow(props: {
+  meeting: MeetingView;
+  eventSlug: string;
+  timezone: string;
+}) {
+  const { meeting, eventSlug, timezone } = props;
+  const searchParams = useSearchParams();
+  const { now } = useContext(EventContext);
+  const end = new Date(meeting.slotEnd);
+  return (
+    <AgendaRow
+      state={timeState(new Date(meeting.slotStart), end, now)}
+      swatchClass={
+        meeting.status === "accepted" ? "bg-brand-accent" : "bg-line"
+      }
+      link={viewMeetingLinkFromOwner(searchParams, eventSlug, meeting.id)}
+      title={`1-on-1 with ${meeting.otherName}`}
+      details={`${meeting.meetingPoint} · until ${formatOptionalTime(end, timezone, TIME_FORMAT)} · ${statusLine(meeting)}`}
+    />
+  );
+}

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -5,6 +5,7 @@ import { ChevronRightIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { DateTime } from "luxon";
 import { useSearchParams } from "next/navigation";
 import { DayText } from "./day-text";
+import { DayAgenda } from "./day-agenda";
 import { Input } from "@/app/input";
 import { useState, useContext, useRef } from "react";
 import { EventContext, useSlotIncrement } from "../context";
@@ -52,8 +53,8 @@ export function EventDisplay() {
     });
   const locationsForEvent = locations;
 
-  // "Now" only makes sense while the event is running, and only in the grid:
-  // it scrolls to the now line, which is drawn there and only on a day the
+  // "Now" only makes sense while the event is running, and only in the grid
+  // and the agenda: it scrolls to the now line, which they draw on the day the
   // current moment falls inside.
   const nowIsOnSchedule = daysForEvent.some(
     (day) => getNowOffsetPx(day, now, slotIncrement) !== null
@@ -61,7 +62,7 @@ export function EventDisplay() {
   const toolbar = (
     <ScheduleToolbar
       event={event}
-      showJumpToNow={view === "grid" && nowIsOnSchedule}
+      showJumpToNow={(view === "grid" || view === "agenda") && nowIsOnSchedule}
     />
   );
 
@@ -115,6 +116,46 @@ export function EventDisplay() {
           </div>
         ))}
         <Footer inline />
+      </div>
+    ) : view === "agenda" ? (
+      // Its own branch rather than a variant of the text view below, so the
+      // beta leaves the text and RSVP'd views untouched.
+      <div
+        data-testid="schedule-scroll"
+        ref={scrollerRef}
+        className="flex-1 w-full overflow-auto flex flex-col items-stretch"
+      >
+        {toolbar}
+        <p className="mx-auto w-full max-w-3xl px-2 pt-3 text-xs text-fg-subtle">
+          Beta: the agenda is new this event. If anything looks off, the Grid
+          view has everything.
+        </p>
+        <div className="flex flex-col gap-4 w-full lg:grow">
+          {daysForEvent.map((day) => (
+            <div key={day.id}>
+              {defaultFoldedDayIds.has(day.id) && (
+                <div className="max-w-3xl mx-auto">
+                  <DayFoldBar
+                    day={day}
+                    timezone={event.timezone}
+                    folded={isFolded(day.id)}
+                    onToggle={() => toggleDayFold(day.id)}
+                  />
+                </div>
+              )}
+              {!isFolded(day.id) && (
+                <DayAgenda
+                  day={day}
+                  locations={locationsForEvent}
+                  eventSlug={event.slug}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="lg:sticky lg:bottom-0">
+          <Footer inline />
+        </div>
       </div>
     ) : (
       <div

--- a/app/(site)/[eventSlug]/schedule-toolbar.tsx
+++ b/app/(site)/[eventSlug]/schedule-toolbar.tsx
@@ -10,6 +10,7 @@ import {
   FlagIcon,
   InformationCircleIcon,
   LinkIcon,
+  QueueListIcon,
   TableCellsIcon,
 } from "@heroicons/react/24/outline";
 import { DateTime } from "luxon";
@@ -24,13 +25,13 @@ const ITEM_CLASS =
   "flex items-center gap-1 rounded-md py-1.5 px-1 text-xs sm:text-sm text-fg-subtle hover:text-brand-fg focus:outline-none focus:ring-2 focus:ring-brand-accent";
 
 // Slim single-row (wrapping on mobile) header for the schedule views. The view
-// toggle (Grid/Text/RSVP'd) sits next to "Now", which jumps the grid to the
-// current time, and two distinct navigation links — "Event details" (opens a
+// toggle (Grid/Agenda/Text/RSVP'd) sits next to "Now", which jumps the grid
+// or agenda to the current time, and two distinct navigation links — "Event details" (opens a
 // popup with dates/description) and "Proposals". The event name is
 // intentionally omitted: the site header already shows it.
 export function ScheduleToolbar(props: {
   event: Event;
-  /** Whether to offer "Now" — only while the grid has a line to jump to. */
+  /** Whether to offer "Now" — only while the view has a line to jump to. */
   showJumpToNow?: boolean;
 }) {
   const { event, showJumpToNow } = props;
@@ -132,6 +133,12 @@ function SelectView() {
       icon: TableCellsIcon,
     },
     {
+      name: "agenda",
+      label: "Agenda",
+      icon: QueueListIcon,
+      beta: true,
+    },
+    {
       name: "text",
       label: "Text",
       icon: DocumentTextIcon,
@@ -143,10 +150,11 @@ function SelectView() {
     },
   ];
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       {VIEWS.map((v) => (
         <button
           key={v.name}
+          aria-pressed={view === v.name}
           className={clsx(
             "flex gap-1 items-center rounded-md text-xs sm:text-sm py-1.5 px-3 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-accent",
             view === v.name
@@ -162,6 +170,11 @@ function SelectView() {
         >
           <v.icon className="h-4 w-4 stroke-2" />
           {v.label}
+          {v.beta && (
+            <span className="rounded-sm px-1 text-[9px] uppercase tracking-wide ring-1 ring-current opacity-80">
+              beta
+            </span>
+          )}
         </button>
       ))}
     </div>

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -44,7 +44,9 @@ export const SHOWN_RELEASES = 3;
 export const releaseNotes: ReleaseNote[] = [
   {
     version: "Unreleased",
-    highlights: [],
+    highlights: [
+      "**Agenda view (beta)**: a list of sessions and your 1-on-1s in start-time order, all rooms together, as an alternative to the grid on narrow screens.",
+    ],
   },
   {
     version: "3.6.0",

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -112,8 +112,14 @@ Proposing and voting close.
 A room name with an **ⓘ** next to it has more to say — tap it (or hover it)
 to read what the room offers: projector, whiteboard, the kind of seating.
 
-While the event is running, a red line across the grid marks the current time,
-and **"Now"** at the top of the schedule jumps straight to it.
+The buttons at the top switch how the schedule is laid out: **Grid** (rooms
+side by side, the day running down), **Agenda** (new, in beta: every session
+under the time it starts, all rooms together — handy on a phone), **Text** (one
+entry per session with its description, and a search box) and **RSVP'd** (the
+sessions you are attending or hosting).
+
+While the event is running, a red line marks the current time in the grid and
+the agenda, and **"Now"** at the top of the schedule jumps straight to it.
 
 On a phone, pull down from the top of the schedule and let go to load the
 latest sessions.

--- a/tests/e2e/now-line.spec.ts
+++ b/tests/e2e/now-line.spec.ts
@@ -42,11 +42,11 @@ test("no now line or Now button outside the event's days", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Now" })).toHaveCount(0);
 });
 
-test("the Now button is only offered by the grid view", async ({ page }) => {
+test("the Now button is not offered by the text view", async ({ page }) => {
   await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
   await expect(page.getByRole("button", { name: "Now" })).toBeVisible();
 
-  // The text view has no grid to jump around in. The toggle is server-rendered,
+  // The text view has no now line to jump to. The toggle is server-rendered,
   // so a click can land before React has attached its handler and be dropped —
   // retry until the view has actually switched (docs/dev/testing.md § E2E
   // conventions). Re-clicking the active view is a no-op, so this is safe.

--- a/tests/e2e/schedule-agenda.spec.ts
+++ b/tests/e2e/schedule-agenda.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "./helpers/fixtures";
+import type { Page } from "@playwright/test";
+import { login, loginAndGoto } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+import { openGammaScheduleDuringEvent } from "./helpers/dev-clock";
+
+// The agenda view: a beta behind its own toolbar button, the grid staying the
+// default everywhere.
+
+const KEYNOTE = /Opening Keynote - Conference Gamma/;
+
+const viewButton = (page: Page, name: string) =>
+  page.getByRole("button", { name });
+
+// The toggle is server-rendered, so a click can land before React has attached
+// its handler and be dropped — retry until the view has actually switched
+// (docs/dev/testing.md § E2E conventions).
+const switchToView = async (page: Page, name: string) => {
+  await expect(async () => {
+    await viewButton(page, name).click();
+    await expect(viewButton(page, name)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+      { timeout: 2000 }
+    );
+  }).toPass();
+};
+
+test.describe("on a phone-sized screen", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("the agenda lists each time's sessions with their room and end", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/Conference-Gamma");
+    await expect(viewButton(page, "Grid")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    await switchToView(page, "Agenda");
+    const keynote = page.getByRole("link", { name: KEYNOTE });
+    await expect(keynote).toBeVisible();
+    await expect(keynote).toContainText("Main Hall");
+    await expect(keynote).toContainText("until 10:30");
+
+    // Lunch blocks every room at once, and is listed once, not once per room.
+    const lunchSlot = page.getByRole("region", { name: "12:30" }).first();
+    await expect(lunchSlot.getByText("Lunch Break")).toHaveCount(1);
+  });
+});
+
+test("the agenda groups sessions by start time and opens their details", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await switchToView(page, "Agenda");
+  // The keynote's slot starts at 09:00; the heading shows when the session
+  // itself starts, after the event's 10-minute break — as its details do.
+  const nineOClock = page.getByRole("region", { name: "09:10" }).first();
+  await nineOClock.getByRole("link", { name: KEYNOTE }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Session details" })
+  ).toBeVisible();
+});
+
+// Zanele's first Gamma morning holds seeded 1-on-1s at 10:00, a slot no
+// session starts in (see meetings-column.spec.ts). They are hers alone: the
+// grid gives her a column for them, the agenda a time of their own.
+test("the viewer's own 1-on-1s are listed at their time", async ({ page }) => {
+  await loginAndGoto(page, "/guests");
+  await selectUser(page, "Zanele Khumalo");
+  await page.getByRole("link", { name: "Conference Gamma" }).first().click();
+  await switchToView(page, "Agenda");
+
+  const tenOClock = page.getByRole("region", { name: "10:00" }).first();
+  await tenOClock
+    .getByRole("link", { name: /1-on-1 with Leilani Kahale/ })
+    .click();
+  const details = page.getByRole("dialog", { name: "1-on-1 details" });
+  await expect(
+    details.getByRole("heading", { name: "1-on-1 with Leilani Kahale" })
+  ).toBeVisible();
+});
+
+test.describe("while the event is running", () => {
+  // At 16:00 the marker sits after day one's last group, only a few rows down
+  // the list; a short viewport keeps it off screen until Now is pressed.
+  test.use({
+    timezoneId: "Europe/Berlin",
+    viewport: { width: 1280, height: 500 },
+  });
+
+  test("the agenda marks the current time and Now jumps to it", async ({
+    page,
+  }) => {
+    await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
+    await switchToView(page, "Agenda");
+
+    const nowLine = page.getByTestId("now-line");
+    await expect(nowLine).toBeAttached();
+    await expect(nowLine).not.toBeInViewport();
+
+    await page.getByRole("button", { name: "Now" }).click();
+    await expect(nowLine).toBeInViewport();
+
+    // 16:00 falls inside the seeded 15:30–16:30 session and after the keynote.
+    await expect(
+      page.getByRole("link", { name: /API Design: RESTful vs GraphQL/ })
+    ).toContainText("Now");
+    await expect(page.getByRole("link", { name: KEYNOTE })).not.toContainText(
+      "Now"
+    );
+  });
+});

--- a/tests/unit/agenda.test.ts
+++ b/tests/unit/agenda.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  agendaGroups,
+  nowMarkerIndex,
+  shownStart,
+  timeState,
+  type AgendaGroup,
+} from "@/utils/agenda";
+import type { Location, Session } from "@/db/repositories/interfaces";
+import type { MeetingView } from "@/utils/meeting-views";
+import { newEmptySession } from "@/app/(site)/session_utils";
+
+const at = (hour: number, minute = 0) =>
+  new Date(Date.UTC(2026, 9, 1, hour, minute));
+
+const session = (start: Date, end: Date, roomId = "a"): Session => ({
+  ...newEmptySession("e"),
+  id: `${start.toISOString()}-${roomId}`,
+  title: "A session",
+  locations: [{ id: roomId, name: roomId, color: "blue" }],
+  startTime: start,
+  endTime: end,
+});
+
+const room = (id: string, sortIndex: number): Location => ({
+  id,
+  name: id,
+  capacity: 10,
+  bookable: true,
+  sortIndex,
+  color: "blue",
+  imageUrl: "",
+  description: "",
+  hidden: false,
+});
+const rooms = [room("a", 1), room("b", 2)];
+
+const blocker = (roomId: string, end: Date, start = at(12, 30)): Session => ({
+  ...session(start, end, roomId),
+  title: "Lunch",
+  blocker: true,
+});
+
+const meeting = (start: Date, otherName: string): MeetingView => ({
+  id: otherName,
+  status: "accepted",
+  role: "requester",
+  otherName,
+  slotStart: start.toISOString(),
+  slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
+  dayLabel: "",
+  timeLabel: "",
+  meetingPoint: "Coffee bar",
+  message: "",
+  cancelNote: "",
+  clashes: [],
+});
+
+const group = (input: {
+  sessions?: Session[];
+  meetings?: MeetingView[];
+  breakMinutes?: number;
+}) =>
+  agendaGroups({
+    sessions: input.sessions ?? [],
+    meetings: input.meetings ?? [],
+    locations: rooms,
+    breakMinutes: input.breakMinutes ?? 10,
+  });
+
+describe("shownStart", () => {
+  it("is the slot start plus the break, except for a blocker", () => {
+    expect(shownStart(session(at(9), at(10)), 10)).toEqual(at(9, 10));
+    expect(shownStart(blocker("a", at(14)), 10)).toEqual(at(12, 30));
+  });
+});
+
+describe("agendaGroups", () => {
+  it("heads sessions by their shown start, in room order", () => {
+    const groups = group({
+      sessions: [session(at(9), at(10), "b"), session(at(9), at(10), "a")],
+    });
+    expect(groups.map((g) => g.start)).toEqual([at(9, 10)]);
+    expect(groups[0].sessions.map((s) => s.locations[0].id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("keeps a blocker on its slot when a session shares the slot", () => {
+    const groups = group({
+      sessions: [session(at(9), at(10), "a"), blocker("b", at(9, 30), at(9))],
+    });
+    expect(groups.map((g) => [g.start, g.sessions.length])).toEqual([
+      [at(9), 1],
+      [at(9, 10), 1],
+    ]);
+    expect(groups[0].sessions[0].blocker).toBe(true);
+  });
+
+  it("keeps sessions whose shown start meets a blocker's slot", () => {
+    const groups = group({
+      sessions: [session(at(9), at(10), "a"), blocker("b", at(10), at(9, 30))],
+      breakMinutes: 30,
+    });
+    expect(groups.map((g) => g.start)).toEqual([at(9, 30)]);
+    expect(groups[0].sessions.map((s) => s.blocker).sort()).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  it("merges same-titled blockers that start and end together", () => {
+    const groups = group({
+      sessions: [blocker("a", at(14)), blocker("b", at(14))],
+    });
+    expect(groups.map((g) => g.start)).toEqual([at(12, 30)]);
+    expect(groups[0].sessions).toHaveLength(1);
+    expect(groups[0].sessions[0].locations.map((l) => l.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("names a room once when merged blockers share it", () => {
+    const groups = group({
+      sessions: [
+        { ...blocker("a", at(14)), locations: [...rooms] },
+        blocker("b", at(14)),
+      ],
+    });
+    expect(groups[0].sessions[0].locations.map((l) => l.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("keeps same-titled blockers apart when they end at different times", () => {
+    const groups = group({
+      sessions: [blocker("a", at(14)), blocker("b", at(13))],
+    });
+    expect(groups[0].sessions).toHaveLength(2);
+  });
+
+  it("gives a 1-on-1 its own time between the session groups", () => {
+    const groups = group({
+      sessions: [session(at(9), at(10)), session(at(11), at(12))],
+      meetings: [meeting(at(10), "Leilani")],
+    });
+    expect(groups.map((g) => g.start)).toEqual([at(9, 10), at(10), at(11, 10)]);
+    expect(groups[1].sessions).toEqual([]);
+    expect(groups[1].meetings.map((m) => m.otherName)).toEqual(["Leilani"]);
+  });
+
+  it("lists 1-on-1s at an existing time under that heading", () => {
+    const groups = group({
+      sessions: [session(at(9), at(10))],
+      meetings: [meeting(at(9, 10), "Sam"), meeting(at(9, 10), "Ana")],
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].meetings.map((m) => m.otherName)).toEqual(["Sam", "Ana"]);
+  });
+});
+
+describe("timeState", () => {
+  it("is running from the start until the end", () => {
+    expect(timeState(at(9, 10), at(10), at(9, 5))).toBe("upcoming");
+    expect(timeState(at(9, 10), at(10), at(9, 10))).toBe("running");
+    expect(timeState(at(9, 10), at(10), at(9, 59))).toBe("running");
+    expect(timeState(at(9, 10), at(10), at(10))).toBe("ended");
+  });
+});
+
+const groups: AgendaGroup[] = [
+  { start: at(9), sessions: [session(at(9), at(10, 30))], meetings: [] },
+  { start: at(11), sessions: [session(at(11), at(12))], meetings: [] },
+  { start: at(14), sessions: [session(at(14), at(15))], meetings: [] },
+];
+
+describe("nowMarkerIndex", () => {
+  it("heads the list before the day's first session", () => {
+    expect(nowMarkerIndex(groups, at(8))).toBe(0);
+  });
+
+  it("sits after every group that has started, in time order", () => {
+    expect(nowMarkerIndex(groups, at(9))).toBe(1);
+    expect(nowMarkerIndex(groups, at(9, 40))).toBe(1);
+    expect(nowMarkerIndex(groups, at(12, 40))).toBe(2);
+  });
+
+  it("ends the list once the last group has started", () => {
+    expect(nowMarkerIndex(groups, at(16))).toBe(3);
+  });
+
+  it("is 0 for a day with no sessions", () => {
+    expect(nowMarkerIndex([], at(12))).toBe(0);
+  });
+});

--- a/utils/agenda.ts
+++ b/utils/agenda.ts
@@ -1,0 +1,96 @@
+import type { Location, Session } from "@/db/repositories/interfaces";
+import type { MeetingView } from "@/utils/meeting-views";
+import { getStartTimePlusBreak } from "@/utils/utils";
+
+export type AgendaGroup = {
+  start: Date;
+  sessions: Session[];
+  meetings: MeetingView[];
+};
+
+/** As the session's details show it — except a blocker, which fills its slot. */
+export function shownStart(session: Session, breakMinutes: number): Date {
+  const start = session.startTime ?? new Date(0);
+  return session.blocker
+    ? start
+    : getStartTimePlusBreak(start, breakMinutes).toJSDate();
+}
+
+/**
+ * A day's entries under their shown starts: sessions in room order, 1-on-1s
+ * on their slot, same-titled blockers with the same times merged into one.
+ */
+export function agendaGroups(input: {
+  sessions: Session[];
+  meetings: MeetingView[];
+  locations: Location[];
+  breakMinutes: number;
+}): AgendaGroup[] {
+  const { sessions, meetings, locations, breakMinutes } = input;
+  const rank = new Map(locations.map((loc) => [loc.id, loc.sortIndex]));
+  const roomRank = (session: Session) => {
+    const ranks = session.locations.flatMap((l) => rank.get(l.id) ?? []);
+    return ranks.length ? Math.min(...ranks) : Number.MAX_SAFE_INTEGER;
+  };
+  const byStart = new Map<number, AgendaGroup>();
+  const groupAt = (start: number) => {
+    const group = byStart.get(start) ?? {
+      start: new Date(start),
+      sessions: [],
+      meetings: [],
+    };
+    byStart.set(start, group);
+    return group;
+  };
+
+  for (const session of sessions) {
+    if (!session.startTime) continue;
+    const group = groupAt(shownStart(session, breakMinutes).getTime());
+    const twin = session.blocker
+      ? group.sessions.findIndex(
+          (s) =>
+            s.blocker &&
+            s.title === session.title &&
+            s.endTime?.getTime() === session.endTime?.getTime()
+        )
+      : -1;
+    if (twin >= 0) {
+      const existing = group.sessions[twin];
+      const known = new Set(existing.locations.map((l) => l.id));
+      group.sessions[twin] = {
+        ...existing,
+        locations: [
+          ...existing.locations,
+          ...session.locations.filter((l) => !known.has(l.id)),
+        ],
+      };
+    } else {
+      group.sessions.push(session);
+    }
+  }
+  for (const meeting of meetings) {
+    groupAt(new Date(meeting.slotStart).getTime()).meetings.push(meeting);
+  }
+
+  const groups = [...byStart.values()];
+  for (const group of groups) {
+    group.sessions.sort((a, b) => roomRank(a) - roomRank(b));
+  }
+  return groups.sort((a, b) => a.start.getTime() - b.start.getTime());
+}
+
+/**
+ * Where the "now" marker goes: before the first group still to start, so
+ * what has started is above it and what is to come below.
+ */
+export function nowMarkerIndex(groups: AgendaGroup[], now: Date): number {
+  const next = groups.findIndex((g) => g.start.getTime() > now.getTime());
+  return next < 0 ? groups.length : next;
+}
+
+export type TimeState = "ended" | "running" | "upcoming";
+
+export function timeState(start: Date, end: Date, now: Date): TimeState {
+  if (end.getTime() <= now.getTime()) return "ended";
+  return start.getTime() <= now.getTime() ? "running" : "upcoming";
+}


### PR DESCRIPTION
## Agenda view of the schedule (beta)

A list layout of the schedule, as an alternative to the grid on narrow screens: every session and the viewer's own 1-on-1s under the time they start, all rooms together. Shipped as a beta behind its own toolbar button so nothing changes for anyone who doesn't tap it.

### What's new

- **Agenda view**, behind a new toolbar button tagged *beta*. Each row shows the room's colour, title, room, end time, hosts, RSVP count and your host / RSVP'd marks. Tapping opens the usual session popup.
- **Your 1-on-1s** appear at their time between the sessions, with meeting point and state, opening the same popup as the grid's column. Only your own; nothing for a viewer without any.
- **Where you are in the day**: a red "Now · 10:20" line at the current time (the toolbar's Now button scrolls to it), a "Now" chip on entries in progress, finished ones dimmed.
- Headings show a session's start after the event's break, matching the session details.

### Blast radius

- Grid stays the default on every device.
- The agenda has its own branch in the view switch; the Text and RSVP'd views are byte-identical to main.
- Shared files touched: the view switch (one added branch, Now button also offered on the agenda) and the toolbar (one added button, `aria-pressed` on the view buttons). Everything else is new files, tests and docs.
- A note in the view points people back to the grid if anything looks off.

### Testing

- Unit: grouping by shown start (incl. blockers sharing a slot and colliding shown times), blocker merging, 1-on-1 placement, entry state, Now-marker placement.
- E2E (`schedule-agenda.spec.ts`): agenda at phone width with rooms and end times, time grouping and the session popup, a viewer's 1-on-1s at their time, Now marker + Now button + running chip with the dev clock.
- `make lint`, `arch`, `typecheck`, `format-check`, `docs-validate`, `test-coverage` and `build` pass.

### Docs

One changelog bullet, one release-notes highlight, a paragraph in the attendee guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)