### PR TITLE
fix: warn before RSVPing over a confirmed 1-on-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **1-on-1 details link to the other attendee** (#1020): their name in the request's
   heading now opens their profile.
 
+### Fixed
+
+- **RSVPing over a 1-on-1 warns you** (#1033): the clash warning only knew about sessions, so
+  a session overlapping a confirmed 1-on-1 could be RSVP'd without a word
+
 ## [3.7.0] - 2026-09-11
 
 ### Added

--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -15,7 +15,6 @@ import {
   useBreakMinutes,
   useSlotIncrement,
 } from "../context";
-import { sessionsOverlap } from "../session_utils";
 import {
   formatOptionalTime,
   formatStartTimePlusBreak,
@@ -25,6 +24,12 @@ import { isBookableSlot } from "@/utils/session-bookable";
 import { LockIcon } from "../lock-icon";
 import { viewSessionLinkFromOwner } from "./modal-nav";
 import { stripMarkdown } from "@/utils/markdown";
+import {
+  describeRsvpClash,
+  findRsvpClash,
+  type RsvpClash,
+} from "@/utils/rsvp-clash";
+import { useMyMeetings } from "./use-meetings";
 
 export function SessionBlock(props: {
   session: Session;
@@ -206,11 +211,12 @@ export function RealSessionCard(props: {
   const { user: currentUser } = useContext(UserContext);
   const { localSessions, updateRsvp, userBusySessions, event } =
     useContext(EventContext);
+  const { meetings } = useMyMeetings();
   const timezone = event?.timezone ?? "UTC";
   const searchParams = useSearchParams();
   const [isRsvping, setIsRsvping] = useState(false);
   const [userModalOpen, setUserModalOpen] = useState(false);
-  const [clashingSession, setClashingSession] = useState<Session | null>(null);
+  const [clash, setClash] = useState<RsvpClash | null>(null);
   const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
   const [rsvpError, setRsvpError] = useState<string | null>(null);
 
@@ -242,12 +248,9 @@ export function RealSessionCard(props: {
     }
 
     if (!rsvpd) {
-      const clashing = userBusySessions().find((busySession: Session) =>
-        sessionsOverlap(currentSession, busySession)
-      );
-
-      if (clashing) {
-        setClashingSession(clashing);
+      const found = findRsvpClash(currentSession, userBusySessions(), meetings);
+      if (found) {
+        setClash(found);
         setConfirmRSVPModalOpen(true);
         return;
       }
@@ -282,7 +285,7 @@ export function RealSessionCard(props: {
 
   const handleConfirmRSVP = () => {
     setConfirmRSVPModalOpen(false);
-    setClashingSession(null);
+    setClash(null);
     void doRsvp();
   };
 
@@ -374,9 +377,9 @@ export function RealSessionCard(props: {
         open={confirmRSVPModalOpen}
         close={() => setConfirmRSVPModalOpen(false)}
         message={
-          clashingSession
-            ? `This session conflicts with "${clashingSession.title}". Do you want to RSVP anyway?`
-            : "This session conflicts with another session you're attending. Do you want to RSVP anyway?"
+          clash
+            ? `This session clashes with ${describeRsvpClash(clash, currentUser)}. Do you want to RSVP anyway?`
+            : ""
         }
         confirm={handleConfirmRSVP}
         portal={true}

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -14,12 +14,17 @@ import {
 } from "@/utils/utils";
 import { UserContext, EventContext } from "../../context";
 import { CurrentUserModal, ConfirmationModal } from "../../modals";
-import { sessionsOverlap } from "../../session_utils";
 import { LockIcon } from "../../lock-icon";
 import { LocationTag } from "../session-text";
 import { viewProposalLinkFromElsewhere } from "../modal-nav";
 import { SessionComments } from "../session-comments";
 import { Markdown } from "@/app/(site)/markdown";
+import {
+  describeRsvpClash,
+  findRsvpClash,
+  type RsvpClash,
+} from "@/utils/rsvp-clash";
+import { useMyMeetings } from "../use-meetings";
 import { AttendeeCountField } from "./attendee-count-field";
 
 export function ViewSession(props: {
@@ -42,6 +47,7 @@ export function ViewSession(props: {
   } = props;
 
   const { user: currentUser } = useContext(UserContext);
+  const { meetings } = useMyMeetings();
   const {
     rsvpdForSession,
     updateRsvp,
@@ -72,7 +78,7 @@ export function ViewSession(props: {
   const searchParams = useSearchParams();
   const [isRsvping, setIsRsvping] = useState(false);
   const [userModalOpen, setUserModalOpen] = useState(false);
-  const [clashingSession, setClashingSession] = useState<Session | null>(null);
+  const [clash, setClash] = useState<RsvpClash | null>(null);
   const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
   const [rsvpError, setRsvpError] = useState<string | null>(null);
 
@@ -108,11 +114,9 @@ export function ViewSession(props: {
     }
 
     if (!rsvpd) {
-      const overlappingSession = userBusySessions().find((ses) =>
-        sessionsOverlap(session, ses)
-      );
-      if (overlappingSession) {
-        setClashingSession(overlappingSession);
+      const found = findRsvpClash(session, userBusySessions(), meetings);
+      if (found) {
+        setClash(found);
         setConfirmRSVPModalOpen(true);
         return;
       }
@@ -190,9 +194,9 @@ export function ViewSession(props: {
         zIndex="z-[100]"
         portal={true}
         message={
-          `Warning: that session clashes with ${clashingSession?.title}, which you ` +
-          `are ${clashingSession?.hosts.some((h) => h.id === (currentUser || "")) ? "hosting" : "attending"}. ` +
-          "Are you sure you want to proceed?"
+          clash
+            ? `Warning: that session clashes with ${describeRsvpClash(clash, currentUser)}. Are you sure you want to proceed?`
+            : ""
         }
       />
       <div className="flex items-start gap-2 mb-2 mt-5">

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -180,7 +180,8 @@ Unlike votes, hosts plan around it. If you change your mind, take it back with
 "Un-RSVP" — someone else may want the place.
 :::
 
-- You'll be warned if you RSVP to two sessions that overlap.
+- You'll be warned if you RSVP to two sessions that overlap, or to one that
+  overlaps a confirmed 1-on-1.
 - Capacity is either advisory or a hard limit, depending on how the organizers
   set the event up. With a hard limit the button reads "Session full".
 - A session marked **closed** warns that you can be at most five minutes late,

--- a/scripts/seed/seed-database.ts
+++ b/scripts/seed/seed-database.ts
@@ -43,8 +43,8 @@ const SLOT_INCREMENT_MINUTES = 30;
 const SCREENSHOT_GUEST = "Hana Kobayashi";
 
 // The attendee whose Gamma morning is crowded with 1-on-1s, for
-// tests/e2e/meetings-column.spec.ts. Nothing else acts as her: those meetings
-// give her a column that shifts the rooms of every schedule she looks at.
+// tests/e2e/meetings-column.spec.ts. Nothing else changes her diary: those
+// meetings give her a column that shifts the rooms of every schedule she looks at.
 const PARALLEL_GUEST = "Zanele Khumalo";
 
 // Returns a UTC Date representing the given clock time on a specific day in Berlin.
@@ -1087,6 +1087,16 @@ async function seedTestData(profile: SeedProfile) {
         message: "Free at eleven?",
       })
     ),
+    // Inside the 15:30 "API Design" session, which she has no RSVP for: the
+    // clash an RSVP there has to warn about (tests/e2e/rsvp.spec.ts).
+    {
+      other: "Rafael Souza",
+      role: "requester",
+      status: "accepted",
+      ...slotAt(15, 30),
+      meetingPoint: "Garden bench",
+      message: "Keen to hear how you run your platform team.",
+    },
   ]);
 
   // One of each state for the screenshot guest's column, in the afternoon the

--- a/tests/e2e/rsvp.spec.ts
+++ b/tests/e2e/rsvp.spec.ts
@@ -61,6 +61,33 @@ test("RSVP to a session persists across reloads and can be removed again", async
   await expect(dialog.getByText(/Bob Test/)).toHaveCount(0);
 });
 
+// Zanele's seeded 1-on-1 with Rafael falls inside "API Design" on Gamma's
+// first day (scripts/seed/seed-database.ts). Only the warning is under test,
+// so it is declined and her diary is left as it was.
+test("RSVPing over a confirmed 1-on-1 warns about it first", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Gamma");
+  await selectUser(page, "Zanele Khumalo");
+
+  await page
+    .getByRole("link", { name: /API Design: RESTful vs GraphQL/ })
+    .first()
+    .click();
+  const dialog = page.getByRole("dialog", { name: "Session details" });
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByRole("button", { name: "RSVP", exact: true }).click();
+  await expect(
+    page.getByText(/clashes with your 1-on-1 with Rafael Souza/)
+  ).toBeVisible();
+  await page.getByRole("button", { name: "No" }).click();
+  await expect(
+    dialog.getByRole("button", { name: "RSVP", exact: true })
+  ).toBeVisible();
+});
+
 test("the RSVP'd view lists nothing when the guest has no RSVPs", async ({
   page,
 }) => {

--- a/tests/unit/rsvp-clash.test.ts
+++ b/tests/unit/rsvp-clash.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+
+import { newEmptySession } from "@/app/(site)/session_utils";
+import type { MeetingView } from "@/utils/meeting-views";
+import { describeRsvpClash, findRsvpClash } from "@/utils/rsvp-clash";
+
+const at = (hour: number, minute = 0) =>
+  new Date(Date.UTC(2026, 9, 1, hour, minute));
+
+const session = (id: string, start: Date, end: Date, title = id) => ({
+  ...newEmptySession("ev"),
+  id,
+  title,
+  startTime: start,
+  endTime: end,
+});
+
+function meeting(
+  id: string,
+  start: Date,
+  patch?: Partial<MeetingView>
+): MeetingView {
+  return {
+    id,
+    status: "accepted",
+    role: "requester",
+    otherId: "grace",
+    otherName: "Grace",
+    slotStart: start.toISOString(),
+    slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
+    dayLabel: "Thu 1 Oct",
+    timeLabel: "10:00 – 10:30",
+    meetingPoint: "Coffee bar",
+    message: "",
+    cancelNote: "",
+    clashes: [],
+    ...patch,
+  };
+}
+
+const candidate = session("s", at(10), at(11), "Design Systems");
+
+describe("findRsvpClash", () => {
+  it("names an accepted 1-on-1 in the session's slot", () => {
+    const m = meeting("m", at(10, 30));
+    expect(findRsvpClash(candidate, [], [m])).toEqual({
+      kind: "meeting",
+      meeting: m,
+    });
+  });
+
+  it("ignores 1-on-1s that are not confirmed or do not overlap", () => {
+    expect(
+      findRsvpClash(
+        candidate,
+        [],
+        [
+          meeting("pending", at(10), { status: "pending" }),
+          meeting("declined", at(10), { status: "declined" }),
+          meeting("before", at(9, 30)),
+          meeting("after", at(11)),
+        ]
+      )
+    ).toBeNull();
+  });
+
+  it("reports a clashing session ahead of a 1-on-1", () => {
+    const busy = session("b", at(10, 30), at(12));
+    expect(findRsvpClash(candidate, [busy], [meeting("m", at(10))])).toEqual({
+      kind: "session",
+      session: busy,
+    });
+  });
+
+  it("copes with the 1-on-1s not having loaded yet", () => {
+    expect(findRsvpClash(candidate, [], null)).toBeNull();
+  });
+});
+
+describe("describeRsvpClash", () => {
+  it("says who the 1-on-1 is with", () => {
+    expect(
+      describeRsvpClash(
+        { kind: "meeting", meeting: meeting("m", at(10)) },
+        "me"
+      )
+    ).toBe("your 1-on-1 with Grace");
+  });
+
+  it("says whether the viewer hosts or attends the session", () => {
+    const hosted = {
+      ...session("h", at(10), at(11), "Hosted"),
+      hosts: [{ id: "me", name: "Me" }],
+    };
+    expect(describeRsvpClash({ kind: "session", session: hosted }, "me")).toBe(
+      '"Hosted", which you are hosting'
+    );
+    expect(
+      describeRsvpClash({ kind: "session", session: candidate }, "me")
+    ).toBe('"Design Systems", which you are attending');
+  });
+});

--- a/utils/rsvp-clash.ts
+++ b/utils/rsvp-clash.ts
@@ -1,0 +1,40 @@
+import type { Session } from "@/db/repositories/interfaces";
+import { sessionsOverlap } from "@/app/(site)/session_utils";
+import type { MeetingView } from "./meeting-views";
+
+export type RsvpClash =
+  | { kind: "session"; session: Session }
+  | { kind: "meeting"; meeting: MeetingView };
+
+// `meetings` is null until the viewer's 1-on-1s have loaded; until then only
+// sessions can be reported.
+export function findRsvpClash(
+  session: Session,
+  busySessions: Session[],
+  meetings: MeetingView[] | null
+): RsvpClash | null {
+  const busy = busySessions.find((other) => sessionsOverlap(session, other));
+  if (busy) return { kind: "session", session: busy };
+
+  const { startTime, endTime } = session;
+  if (!startTime || !endTime) return null;
+  const meeting = meetings?.find(
+    (m) =>
+      m.status === "accepted" &&
+      new Date(m.slotStart) < endTime &&
+      new Date(m.slotEnd) > startTime
+  );
+  return meeting ? { kind: "meeting", meeting } : null;
+}
+
+export function describeRsvpClash(
+  clash: RsvpClash,
+  currentUser: string | null
+): string {
+  if (clash.kind === "meeting") {
+    return `your 1-on-1 with ${clash.meeting.otherName}`;
+  }
+  const { session } = clash;
+  const hosting = session.hosts.some((h) => h.id === currentUser);
+  return `"${session.title}", which you are ${hosting ? "hosting" : "attending"}`;
+}


### PR DESCRIPTION
The RSVP clash check only looked at sessions the viewer hosts or has
RSVP'd to, so a session overlapping an accepted 1-on-1 was RSVP'd without
a word — while booking a 1-on-1 over a session already warned. Both RSVP
paths now share findRsvpClash, which also checks the viewer's loaded
meetings and names the other party in the warning.

Seeds Zanele an accepted 1-on-1 inside Gamma's "API Design" session for
the E2E test.

fixes schellingboard/schellingboard#1033

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=3a6c3ca7af0a88d0ebb369fa07d85ba48c7fd3f4 -->