### PR TITLE
feat: link the other attendee's name in the 1-on-1 details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **1-on-1 details link to the other attendee** (#1020): their name in the request's
+  heading now opens their profile.
+
 ## [3.7.0] - 2026-09-11
 
 ### Added

--- a/app/(site)/[eventSlug]/meeting-modal.tsx
+++ b/app/(site)/[eventSlug]/meeting-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useContext, useEffect, useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import {
@@ -17,7 +18,7 @@ import { Input } from "@/app/input";
 import { ModalCloseButton } from "@/app/components/modal-close-button";
 import { EventContext } from "@/app/(site)/context";
 import { clashLines } from "@/utils/meeting-clash-text";
-import { canCancel, meetingTitle, statusLine } from "@/utils/meeting-rules";
+import { canCancel, statusLine } from "@/utils/meeting-rules";
 import { dismissViewMeeting } from "./modal-nav";
 import { useMyMeetings } from "./use-meetings";
 
@@ -110,7 +111,13 @@ function MeetingModal({ meetingId }: { meetingId: string }) {
         ) : (
           <div className="flex flex-col gap-4">
             <h2 className="text-xl font-bold text-fg pr-8">
-              {meetingTitle(meeting)}
+              1-on-1 with{" "}
+              <Link
+                href={`/guests/${meeting.otherId}`}
+                className="text-brand-fg hover:text-brand-fg-hover hover:underline"
+              >
+                {meeting.otherName}
+              </Link>
             </h2>
 
             <dl className="flex flex-col gap-1 text-sm">

--- a/tests/e2e/meetings-request.spec.ts
+++ b/tests/e2e/meetings-request.spec.ts
@@ -361,6 +361,23 @@ test.describe("1-on-1 meetings", () => {
     const meeting = page.getByRole("dialog", { name: "1-on-1 details" });
     await expect(meeting).toBeVisible();
     await expect(meeting.getByText("Coffee bar")).toBeVisible();
+
+    // Who is asking is a click away (#1020). Back to the request the way it
+    // was reached, and by links: going back re-renders the page under the
+    // modal and detaches the button mid-click, and a goto aborts the profile
+    // page still loading behind its modal.
+    await meeting.getByRole("link", { name: asker }).click();
+    const profile = page.getByRole("dialog", { name: asker });
+    await expect(profile.getByRole("heading", { name: asker })).toBeVisible();
+    await profile.getByRole("button", { name: "Close" }).click();
+    await page.getByRole("link", { name: /^Notifications/ }).click();
+    await page
+      .getByRole("button", {
+        name: new RegExp(`${asker} asked you for a 1-on-1`),
+      })
+      .click();
+    await expect(meeting).toBeVisible();
+
     await meeting.getByRole("button", { name: "Accept" }).click();
     await expect(meeting.getByText(/Confirmed/)).toBeVisible();
 

--- a/tests/integration/meeting-views.test.ts
+++ b/tests/integration/meeting-views.test.ts
@@ -56,6 +56,7 @@ describe("meetingViewsFor", () => {
 
     expect(view.id).toBe(meeting.id);
     expect(view.role).toBe("recipient");
+    expect(view.otherId).toBe(requester.id);
     expect(view.otherName).toBe("Ada");
     expect(view.status).toBe("pending");
     expect(view.meetingPoint).toBe("Coffee bar");
@@ -70,6 +71,7 @@ describe("meetingViewsFor", () => {
     const [view] = await meetingViewsFor(requester.id, event.id, BEFORE);
 
     expect(view.role).toBe("requester");
+    expect(view.otherId).toBe(recipient.id);
     expect(view.otherName).toBe("Grace");
   });
 

--- a/tests/unit/agenda.test.ts
+++ b/tests/unit/agenda.test.ts
@@ -45,6 +45,7 @@ const meeting = (start: Date, otherName: string): MeetingView => ({
   id: otherName,
   status: "accepted",
   role: "requester",
+  otherId: otherName,
   otherName,
   slotStart: start.toISOString(),
   slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),

--- a/tests/unit/day-text-entries.test.ts
+++ b/tests/unit/day-text-entries.test.ts
@@ -25,6 +25,7 @@ function meeting(
     id,
     status: "accepted",
     role: "requester",
+    otherId: "grace",
     otherName: "Grace",
     slotStart: at(hour),
     slotEnd: at(hour + 1),

--- a/tests/unit/meeting-column.test.ts
+++ b/tests/unit/meeting-column.test.ts
@@ -22,6 +22,7 @@ function meeting(minutesIn: number, patch?: Partial<MeetingView>): MeetingView {
     id: `m-${minutesIn}`,
     status: "accepted",
     role: "requester",
+    otherId: "grace",
     otherName: "Grace",
     slotStart: at(minutesIn),
     slotEnd: at(minutesIn + SLOT),

--- a/utils/meeting-views.ts
+++ b/utils/meeting-views.ts
@@ -12,12 +12,14 @@ import type { MeetingClash } from "@/utils/meeting-clash-text";
  */
 export type MeetingViewStatus = MeetingStatus | "expired";
 
-/** One of the viewer's 1-on-1s, ready to render: no ids of anyone's else's. */
+/** One of the viewer's 1-on-1s, ready to render. */
 export type MeetingView = {
   id: string;
   status: MeetingViewStatus;
   /** Which side the viewer is on — only a recipient can answer. */
   role: "requester" | "recipient";
+  /** The other party, for linking their profile. */
+  otherId: string;
   otherName: string;
   /** ISO instants, for placing the meeting on the schedule grid. */
   slotStart: string;
@@ -103,6 +105,7 @@ export async function meetingViewsFor(
           ? "expired"
           : meeting.status,
       role: meeting.requesterId === viewerId ? "requester" : "recipient",
+      otherId,
       otherName: byGuest.get(otherId)?.guestName ?? "Someone",
       slotStart: meeting.slotStart.toISOString(),
       slotEnd: meeting.slotEnd.toISOString(),


### PR DESCRIPTION
The heading of a 1-on-1 request named the other party but gave no way to reach them. `MeetingView` now carries their id, and the modal links the name to their profile.

- Integration test: `meetingViewsFor` returns `otherId` for both sides
- E2E: the askee opens the asker's profile from the request, then returns and accepts

fixes schellingboard/schellingboard#1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
