### PR TITLE
feat: let hosts set a session's max attendee count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Hosts set a session's max attendees** (#1032): the session form starts at what the room
+  holds and the host can change it — lower for a hands-on session, higher for standing room,
+  0 for no limit
+
 ### Changed
 
 - **1-on-1 details link to the other attendee** (#1020): their name in the request's

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -30,7 +30,10 @@ import { ConfirmDeletionModal } from "../modals";
 import { UserContext } from "../context";
 import { newEmptySession } from "../session_utils";
 import { useToast } from "../toast";
-import { buildSessionInterval } from "@/app/api/session-form-utils";
+import {
+  buildSessionInterval,
+  CAPACITY_ERROR,
+} from "@/app/api/session-form-utils";
 import { revalidateEvent } from "./session-actions";
 import { detectGuestClashes, type GuestClash } from "./clash-actions";
 import { MarkdownHint } from "@/app/(site)/markdown";
@@ -121,6 +124,29 @@ export function SessionForm(props: {
     locations.find((l) => l.name === initLocation)?.id ??
       locations.find((l) => l.id === session.locations[0]?.id)?.id
   );
+  const location = locations.find((loc) => loc.id === locationId);
+  // null while the field still follows the room. An existing session whose
+  // capacity already differs from its room's is a number the host chose, so
+  // it survives a move to another room.
+  const [capacityInput, setCapacityInput] = useState<string | null>(
+    sessionID &&
+      session.capacity !==
+        (locations.find((l) => l.id === session.locations[0]?.id)?.capacity ??
+          0)
+      ? String(session.capacity)
+      : null
+  );
+  const capacity = capacityInput ?? String(location?.capacity ?? 0);
+  const capacityNumber = Number(capacity);
+  const capacityValid =
+    capacity.trim() !== "" &&
+    Number.isInteger(capacityNumber) &&
+    capacityNumber >= 0;
+  const overRoomCapacity =
+    capacityValid &&
+    !!location &&
+    location.capacity > 0 &&
+    capacityNumber > location.capacity;
   const startTimes = getAvailableStartTimes(
     day,
     sessions,
@@ -255,7 +281,6 @@ export function SessionForm(props: {
   const Submit = async () => {
     setIsSubmitting(true);
     setError(null);
-    const location = locations.find((loc) => loc.id === locationId);
     if (!location || !day || effectiveStartTime === undefined) {
       setError("Missing required fields");
       setIsSubmitting(false);
@@ -274,6 +299,7 @@ export function SessionForm(props: {
         closed,
         dayId: day.id,
         location,
+        capacity: capacityNumber,
         startTime: new Date(effectiveStartTime).toISOString(),
         duration: effectiveDuration,
         hosts,
@@ -454,6 +480,28 @@ export function SessionForm(props: {
           truncateText={true}
         />
       </div>
+      <div className="flex flex-col gap-1 w-72">
+        <label htmlFor="max-attendees" className="font-medium">
+          Max attendees
+        </label>
+        <Input
+          id="max-attendees"
+          type="number"
+          min="0"
+          value={capacity}
+          onChange={(e) => setCapacityInput(e.target.value)}
+          error={!capacityValid}
+          errorMessage={CAPACITY_ERROR}
+        />
+        <p className="text-sm text-fg-subtle">
+          Starts at what the room holds. 0 means no limit.
+        </p>
+        {overRoomCapacity && location && (
+          <p className="text-sm text-danger-fg">
+            That is more than {location.name} holds ({location.capacity}).
+          </p>
+        )}
+      </div>
       <div className="flex flex-col gap-1">
         <label className="font-medium">
           Day
@@ -530,6 +578,7 @@ export function SessionForm(props: {
           effectiveStartTime === undefined ||
           !hosts.length ||
           !locationId ||
+          !capacityValid ||
           !day ||
           !effectiveDuration ||
           isCheckingClashes ||

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -9,7 +9,11 @@ import {
 } from "@/utils/acting-guest";
 import { sessionBookingWindowError } from "@/utils/day-window";
 import { sessionDurationError } from "@/utils/slots";
-import { prepareToInsert, validateSession } from "../session-form-utils";
+import {
+  prepareToInsert,
+  sessionCapacityError,
+  validateSession,
+} from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
 export const dynamic = "force-dynamic"; // defaults to auto
@@ -87,9 +91,13 @@ export async function POST(req: NextRequest) {
       { status: 403 }
     );
   }
-  // The payload carries the client's copy of the location; capacity gates the
-  // RSVP hard limit, so take it from the stored row instead.
-  input.capacity = chosen[0].capacity;
+  const capacityError = sessionCapacityError(params.capacity);
+  if (capacityError) {
+    return Response.json({ error: capacityError }, { status: 400 });
+  }
+  // The payload's location is the client's copy, so the room's own maximum
+  // comes from the stored row; a number the host chose themselves wins.
+  input.capacity = params.capacity ?? chosen[0].capacity;
   const existingSessions = (await repos.sessions.listScheduled()).filter(
     (s) => s.eventId === input.eventId
   );

--- a/app/api/session-form-utils.ts
+++ b/app/api/session-form-utils.ts
@@ -21,8 +21,28 @@ export type SessionParams = {
    */
   startTime: string;
   duration: number;
+  /**
+   * The host's own attendee maximum, 0 meaning no limit. Absent falls back to
+   * the chosen location's capacity.
+   */
+  capacity?: number;
   proposal?: string;
 };
+
+export const CAPACITY_ERROR =
+  "Max attendees must be a non-negative whole number";
+
+/** Null when the value may be saved; absent means "whatever the room holds". */
+export function sessionCapacityError(capacity: unknown): string | null {
+  if (capacity === undefined) return null;
+  if (
+    typeof capacity !== "number" ||
+    !Number.isInteger(capacity) ||
+    capacity < 0
+  )
+    return CAPACITY_ERROR;
+  return null;
+}
 
 export type SessionInterval = {
   start: Date;
@@ -56,7 +76,7 @@ export function prepareToInsert(
     locationIds: [location.id],
     startTime: start,
     endTime: end,
-    capacity: location.capacity ?? 0,
+    capacity: params.capacity ?? location.capacity ?? 0,
     adminManaged: false,
     blocker: false,
     proposalId: params.proposal ?? undefined,

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -9,7 +9,11 @@ import {
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { sessionBookingWindowError } from "@/utils/day-window";
 import { sessionDurationError } from "@/utils/slots";
-import { prepareToInsert, validateSession } from "../session-form-utils";
+import {
+  prepareToInsert,
+  sessionCapacityError,
+  validateSession,
+} from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
 export const dynamic = "force-dynamic"; // defaults to auto
@@ -99,9 +103,13 @@ export async function POST(req: NextRequest) {
       { status: 403 }
     );
   }
-  // The payload carries the client's copy of the location; capacity gates the
-  // RSVP hard limit, so take it from the stored row instead.
-  input.capacity = chosen[0].capacity;
+  const capacityError = sessionCapacityError(params.capacity);
+  if (capacityError) {
+    return Response.json({ error: capacityError }, { status: 400 });
+  }
+  // The payload's location is the client's copy, so the room's own maximum
+  // comes from the stored row; a number the host chose themselves wins.
+  input.capacity = params.capacity ?? chosen[0].capacity;
   const existingSessions = allSessions.filter((ses) => ses.id !== params.id);
   const sessionValid = validateSession(input, existingSessions, now);
   if (sessionValid) {

--- a/app/release-notes.ts
+++ b/app/release-notes.ts
@@ -44,7 +44,9 @@ export const SHOWN_RELEASES = 3;
 export const releaseNotes: ReleaseNote[] = [
   {
     version: "Unreleased",
-    highlights: [],
+    highlights: [
+      "**Hosts choose how many people fit**: a session's max attendees starts at what the room holds, and the host can cap it lower or allow standing room.",
+    ],
   },
   {
     version: "3.7.0",

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -137,6 +137,10 @@ Two ways, whichever you find first:
 
 ![Form for adding a session to the schedule, with a Pre-fill from proposal dropdown](../screenshots/add-session.webp)
 
+**Max attendees** starts at what the room holds. Cap it lower for a hands-on
+session, or raise it past the room's own maximum for standing room — you'll be
+warned, but it's your call. **0 means no limit.**
+
 Worth knowing: **proposals with no host are up for grabs** — anyone can
 schedule one, and they appear in your "Pre-fill from proposal" dropdown
 alongside your own. And **the same proposal can be scheduled more than once**,

--- a/tests/e2e/scheduling.spec.ts
+++ b/tests/e2e/scheduling.spec.ts
@@ -121,6 +121,48 @@ test("a host can delete a session and it disappears from the grid", async ({
   await expect(page.getByRole("link", { name: title })).toHaveCount(0);
 });
 
+test("a host can cap attendance below the room's own maximum", async ({
+  page,
+}) => {
+  await login(page);
+  const title = `E2E Capped Session ${uniqueSuffix()}`;
+
+  await page.goto("/Conference-Gamma");
+  await selectUser(page, /Alice Test/i);
+  await page.getByRole("link", { name: "Add session" }).first().click();
+  await expect(
+    page.getByRole("heading", { name: /Add a session/i })
+  ).toBeVisible();
+
+  await page.getByRole("textbox").first().fill(title);
+  await dayRadios(page).last().check();
+  await listboxButton(page, /^Location/).click();
+  await page.getByRole("option", { name: /Workshop Room/ }).click();
+  await listboxButton(page, /^Start Time/).click();
+  await page.getByRole("option", { name: "17:10" }).click();
+
+  // Defaults to the room's own maximum. Going above it is allowed — standing
+  // room is the host's call — but says so.
+  const maxAttendees = page.getByLabel("Max attendees");
+  await expect(maxAttendees).toHaveValue("30");
+  await maxAttendees.fill("99");
+  await expect(page.getByText(/more than Workshop Room holds/i)).toBeVisible();
+  await maxAttendees.fill("6");
+  await expect(page.getByText(/more than Workshop Room holds/i)).toHaveCount(0);
+
+  const submit = page.getByRole("button", { name: "Submit" });
+  await expect(submit).toBeEnabled();
+  await submit.click();
+  await expect(page.getByRole("link", { name: title })).toBeVisible();
+  await dismissToast(page);
+
+  // What attendees see is the host's cap, not the room's 30.
+  await page.getByRole("link", { name: title }).click();
+  const dialog = page.getByRole("dialog", { name: "Session details" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Attendees (0 / 6):")).toBeVisible();
+});
+
 test("a session booked after midnight lands on the next calendar date", async ({
   page,
 }) => {

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -477,6 +477,72 @@ describe("POST /api/add-session", () => {
     expect(session.capacity).toBe(10);
   });
 
+  it("saves the max attendee count the host chose", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 30, eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(buildPayload(guest, location, day, { capacity: 8 }))
+    );
+    expect(res.ok).toBe(true);
+
+    const [session] = await getRepositories().sessions.listByEvent(event.id);
+    expect(session.capacity).toBe(8);
+  });
+
+  // The room may not hold them, but standing room or an overflow area is the
+  // host's call; the form warns rather than blocking.
+  it("accepts a max above the room's own", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 30, eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(buildPayload(guest, location, day, { capacity: 100 }))
+    );
+    expect(res.ok).toBe(true);
+
+    const [session] = await getRepositories().sessions.listByEvent(event.id);
+    expect(session.capacity).toBe(100);
+  });
+
+  it("saves 0 as no maximum, even where the room has one", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 30, eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(buildPayload(guest, location, day, { capacity: 0 }))
+    );
+    expect(res.ok).toBe(true);
+
+    const [session] = await getRepositories().sessions.listByEvent(event.id);
+    expect(session.capacity).toBe(0);
+  });
+
+  it.each([[-1], [2.5]])("rejects a max attendee count of %p", async (cap) => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(buildPayload(guest, location, day, { capacity: cap }))
+    );
+    expect(res.status).toBe(400);
+    // Named, so the rejection can't be mistaken for one of the other rules.
+    expect(await res.json()).toEqual({
+      error: "Max attendees must be a non-negative whole number",
+    });
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(0);
+  });
+
   it("rejects creating as a protected guest without a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -540,6 +540,44 @@ describe("POST /api/update-session", () => {
     expect(updated.capacity).toBe(10);
   });
 
+  it("saves the max attendee count the host chose", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 30, eventId: event.id });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, location, day, { capacity: 8 }), id },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.ok).toBe(true);
+
+    const updated = (await getRepositories().sessions.findById(id))!;
+    expect(updated.capacity).toBe(8);
+  });
+
+  it("rejects a negative max attendee count and leaves the session alone", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 30, eventId: event.id });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, location, day, { capacity: -1 }), id },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.status).toBe(400);
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.capacity).toBe(30);
+  });
+
   it("rejects moving the session to a location that is not part of the event", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });

--- a/tests/unit/session-validation.test.ts
+++ b/tests/unit/session-validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { validateSession } from "@/app/api/session-form-utils";
+import {
+  CAPACITY_ERROR,
+  sessionCapacityError,
+  validateSession,
+} from "@/app/api/session-form-utils";
 import type { Session, SessionCreateInput } from "@/db/repositories/interfaces";
 
 const LOC_A = "loc-a";
@@ -53,6 +57,31 @@ function makeExisting(
     eventId: "111",
   };
 }
+
+describe("sessionCapacityError", () => {
+  // Absent is not a rejection: the routes then fall back to the room's own
+  // maximum, which is what a client that never sends the field expects.
+  it("accepts an absent capacity", () => {
+    expect(sessionCapacityError(undefined)).toBeNull();
+  });
+
+  it("accepts 0, the existing 'no maximum' convention", () => {
+    expect(sessionCapacityError(0)).toBeNull();
+  });
+
+  it("accepts a positive whole number", () => {
+    expect(sessionCapacityError(12)).toBeNull();
+  });
+
+  // Each case is wrapped because `it.each` spreads a bare array over the
+  // arguments.
+  it.each([[-1], [2.5], [NaN], ["8"], [null], [{}]])(
+    "rejects %p",
+    (capacity) => {
+      expect(sessionCapacityError(capacity)).toBe(CAPACITY_ERROR);
+    }
+  );
+});
 
 describe("validateSession", () => {
   it("accepts a valid session with no existing sessions", () => {


### PR DESCRIPTION
A room's capacity is a physical default, not always the right limit for a
session: a hands-on workshop may want fewer, standing room or an outdoor
session more. Above the room's own maximum the form warns rather than
blocks — it is the host's call.

fixes schellingboard/schellingboard#1032

<!-- jip:pushed-commit=e0c96dd3ac59edb3899632813e14f4d5f8b6441e -->